### PR TITLE
Rename ErrorInfo to GleanDataError

### DIFF
--- a/overlays/speakeasy-modifications-overlay.yaml
+++ b/overlays/speakeasy-modifications-overlay.yaml
@@ -1338,3 +1338,6 @@ actions:
     update:
       x-speakeasy-name-override: reportActivity
       x-speakeasy-group: client.activities
+  - target: $["components"]["schemas"]["ErrorInfo"]
+    update:
+      x-speakeasy-name-override: GleanDataError


### PR DESCRIPTION
Updates the `ErrorInfo` schema to be renamed `GleanDataError` as it makes for a more idiomatic error class name for SDK users.