### PR TITLE
Updates workflow.yaml to include Go code samples

### DIFF
--- a/.speakeasy/workflow.yaml
+++ b/.speakeasy/workflow.yaml
@@ -15,8 +15,9 @@ sources:
         inputs:
             - location: generated_specs/client_rest.yaml
         overlays:
-            - location: registry.speakeasyapi.dev/glean-el2/sdk/glean-api-specs-typescript-code-samples
             - location: registry.speakeasyapi.dev/glean-el2/sdk/glean-api-specs-python-code-samples
+            - location: registry.speakeasyapi.dev/glean-el2/sdk/glean-api-specs-typescript-code-samples
+            - location: registry.speakeasyapi.dev/glean-el2/sdk/glean-api-specs-go-code-samples
             - location: registry.speakeasyapi.dev/glean-el2/sdk/glean-api-specs-java-code-samples
         output: merged_code_samples_specs/glean-client-merged-code-samples-spec.yaml
         registry:
@@ -25,9 +26,10 @@ sources:
         inputs:
             - location: generated_specs/indexing.yaml
         overlays:
-            - location: registry.speakeasyapi.dev/glean-el2/sdk/glean-api-specs-typescript-code-samples
             - location: registry.speakeasyapi.dev/glean-el2/sdk/glean-api-specs-python-code-samples
+            - location: registry.speakeasyapi.dev/glean-el2/sdk/glean-api-specs-typescript-code-samples
             - location: registry.speakeasyapi.dev/glean-el2/sdk/glean-api-specs-java-code-samples
+            - location: registry.speakeasyapi.dev/glean-el2/sdk/glean-api-specs-go-code-samples
         output: merged_code_samples_specs/glean-index-merged-code-samples-spec.yaml
         registry:
             location: registry.speakeasyapi.dev/glean-el2/sdk/glean-index-merged-code-samples-spec


### PR DESCRIPTION
## Summary

The current code samples don't include Go. This PR adds support for it.

### Code changes:
* The workflow.yaml file is updated to include Go code samples in addition to existing TypeScript and Python samples, enhancing the support for multiple programming languages. This is shown by the addition of lines to include the Go code samples in the overlays section.
