### PR TITLE
Add the x-speakeasy-usage-example: true to feature chat.start()

### DIFF
--- a/overlays/speakeasy-modifications-overlay.yaml
+++ b/overlays/speakeasy-modifications-overlay.yaml
@@ -32,6 +32,7 @@ actions:
     update:
       x-speakeasy-group: client.chat
       x-speakeasy-name-override: start
+      x-speakeasy-usage-example: true
     x-speakeasy-metadata:
       after: sdk.chat.start()
       before: sdk.Chat.chat()


### PR DESCRIPTION
This is a PR to add the x-speakeasy-usage-example (https://www.speakeasy.com/docs/sdk-docs#values) extension to ensure that the /chat (.start()) function ends up as the primary example in the SDK code snippets that get generated in the root level SDK READMEs.