### PR TITLE
internal: Removes speakeasy metadata from overlay

### DIFF
--- a/overlays/agent-modifications-overlay.yaml
+++ b/overlays/agent-modifications-overlay.yaml
@@ -3,6 +3,7 @@ x-speakeasy-jsonpath: rfc9535
 info:
   title: Speakeasy Modifications
   version: 0.0.5
+
 actions:
   - target: $["paths"]["/rest/api/v1/runagent"]["post"]
     update:

--- a/overlays/client-modifications-overlay.yaml
+++ b/overlays/client-modifications-overlay.yaml
@@ -3,66 +3,35 @@ x-speakeasy-jsonpath: rfc9535
 info:
   title: Speakeasy Modifications
   version: 0.0.5
-  x-speakeasy-metadata:
-    after: ""
-    before: ""
-    type: speakeasy-modifications
+
 actions:
   # Activity
   - target: $["paths"]["/rest/api/v1/activity"]["post"]
     update:
       x-speakeasy-name-override: report
       x-speakeasy-group: client.activity
-    x-speakeasy-metadata:
-      after: sdk.activity.report()
-      before: sdk.Activity.activity()
-      created_at: 1743113936038
-      reviewed_at: 1743114533812
-      type: method-name
 
   - target: $["paths"]["/rest/api/v1/feedback"]["post"]
     update:
       x-speakeasy-group: client.activity
-    x-speakeasy-metadata:
-      created_at: 1743113936038
-      reviewed_at: 1743114533812
-      type: method-name
 
   # Announcements
   - target: $["paths"]["/rest/api/v1/deleteannouncement"]["post"]
     update:
       x-speakeasy-name-override: delete
       x-speakeasy-group: client.announcements
-    x-speakeasy-metadata:
-      after: sdk.announcements.delete()
-      before: sdk.Announcements.deleteannouncement()
-      created_at: 1743113936039
-      reviewed_at: 1743114533812
-      type: method-name
 
 
   - target: $["paths"]["/rest/api/v1/createannouncement"]["post"]
     update:
       x-speakeasy-name-override: create
       x-speakeasy-group: client.announcements
-    x-speakeasy-metadata:
-      after: sdk.announcements.create()
-      before: sdk.Announcements.createannouncement()
-      created_at: 1743113936039
-      reviewed_at: 1743114533812
-      type: method-name
 
 
   - target: $["paths"]["/rest/api/v1/updateannouncement"]["post"]
     update:
       x-speakeasy-name-override: update
       x-speakeasy-group: client.announcements
-    x-speakeasy-metadata:
-      after: sdk.announcements.update()
-      before: sdk.Announcements.updateannouncement()
-      created_at: 1743113936039
-      reviewed_at: 1743114533813
-      type: method-name
 
 
   # Answers
@@ -70,60 +39,30 @@ actions:
     update:
       x-speakeasy-name-override: create
       x-speakeasy-group: client.answers
-    x-speakeasy-metadata:
-      after: sdk.answers.create()
-      before: sdk.Answers.createanswer()
-      created_at: 1743113936038
-      reviewed_at: 1743114533812
-      type: method-name
 
 
   - target: $["paths"]["/rest/api/v1/editanswer"]["post"]
     update:
       x-speakeasy-name-override: update
       x-speakeasy-group: client.answers
-    x-speakeasy-metadata:
-      after: sdk.answers.update()
-      before: sdk.Answers.editanswer()
-      created_at: 1743113936039
-      reviewed_at: 1743114533812
-      type: method-name
 
 
   - target: $["paths"]["/rest/api/v1/listanswers"]["post"]
     update:
       x-speakeasy-name-override: list
       x-speakeasy-group: client.answers
-    x-speakeasy-metadata:
-      after: sdk.answers.list()
-      before: sdk.Answers.listanswers()
-      created_at: 1743113936039
-      reviewed_at: 1743114533812
-      type: method-name
 
 
   - target: $["paths"]["/rest/api/v1/getanswer"]["post"]
     update:
       x-speakeasy-name-override: retrieve
       x-speakeasy-group: client.answers
-    x-speakeasy-metadata:
-      after: sdk.answers.retrieve()
-      before: sdk.Answers.getanswer()
-      created_at: 1743113936039
-      reviewed_at: 1743114533812
-      type: method-name
 
 
   - target: $["paths"]["/rest/api/v1/deleteanswer"]["post"]
     update:
       x-speakeasy-name-override: delete
       x-speakeasy-group: client.answers
-    x-speakeasy-metadata:
-      after: sdk.answers.delete()
-      before: sdk.Answers.deleteanswer()
-      created_at: 1743113936039
-      reviewed_at: 1743114533813
-      type: method-name
 
 
   # Authentication
@@ -131,12 +70,6 @@ actions:
     update:
       x-speakeasy-name-override: createToken
       x-speakeasy-group: client.authentication
-    x-speakeasy-metadata:
-      after: sdk.authentication.createToken()
-      before: sdk.Authentication.createauthtoken()
-      created_at: 1743113936039
-      reviewed_at: 1743114533812
-      type: method-name
 
 
   # Chat
@@ -145,12 +78,6 @@ actions:
       x-speakeasy-group: client.chat
       x-speakeasy-name-override: create
       x-speakeasy-usage-example: true
-    x-speakeasy-metadata:
-      after: sdk.chat.create()
-      before: sdk.Chat.chat()
-      created_at: 1743113936038
-      reviewed_at: 1743114533812
-      type: method-name
 
 
   - target: $["paths"]["/rest/api/v1/chat#stream"]["post"]
@@ -158,108 +85,54 @@ actions:
       x-speakeasy-group: client.chat
       x-speakeasy-name-override: createStream
       x-speakeasy-usage-example: true
-    x-speakeasy-metadata:
-      after: sdk.chat.createStream()
-      before: sdk.Chat.chat()
-      created_at: 1743113936038
-      reviewed_at: 1743114533812
-      type: method-name
 
 
   - target: $["paths"]["/rest/api/v1/getchat"]["post"]
     update:
       x-speakeasy-name-override: retrieve
       x-speakeasy-group: client.chat
-    x-speakeasy-metadata:
-      after: sdk.chat.retrieve()
-      before: sdk.Chat.getchat()
-      created_at: 1743113936038
-      reviewed_at: 1743114533812
-      type: method-name
 
 
   - target: $["paths"]["/rest/api/v1/deletechatfiles"]["post"]
     update:
       x-speakeasy-name-override: deleteFiles
       x-speakeasy-group: client.chat
-    x-speakeasy-metadata:
-      after: sdk.chat.deleteFiles()
-      before: sdk.Chat.deletechatfiles()
-      created_at: 1743113936039
-      reviewed_at: 1743114533812
-      type: method-name
 
 
   - target: $["paths"]["/rest/api/v1/uploadchatfiles"]["post"]
     update:
       x-speakeasy-name-override: uploadFiles
       x-speakeasy-group: client.chat
-    x-speakeasy-metadata:
-      after: sdk.chat.uploadFiles()
-      before: sdk.Chat.uploadchatfiles()
-      created_at: 1743113936039
-      reviewed_at: 1743114533812
-      type: method-name
 
 
   - target: $["paths"]["/rest/api/v1/deleteallchats"]["post"]
     update:
       x-speakeasy-name-override: deleteAll
       x-speakeasy-group: client.chat
-    x-speakeasy-metadata:
-      after: sdk.chat.deleteAll()
-      before: sdk.Chat.deleteallchats()
-      created_at: 1743113936039
-      reviewed_at: 1743114533812
-      type: method-name
 
 
   - target: $["paths"]["/rest/api/v1/getchatfiles"]["post"]
     update:
       x-speakeasy-name-override: retrieveFiles
       x-speakeasy-group: client.chat
-    x-speakeasy-metadata:
-      after: sdk.chat.retrieveFiles()
-      before: sdk.Chat.getchatfiles()
-      created_at: 1743113936039
-      reviewed_at: 1743114533812
-      type: method-name
 
 
   - target: $["paths"]["/rest/api/v1/deletechats"]["post"]
     update:
       x-speakeasy-name-override: delete
       x-speakeasy-group: client.chat
-    x-speakeasy-metadata:
-      after: sdk.chat.delete()
-      before: sdk.Chat.deletechats()
-      created_at: 1743113936039
-      reviewed_at: 1743114533812
-      type: method-name
 
 
   - target: $["paths"]["/rest/api/v1/getchatapplication"]["post"]
     update:
       x-speakeasy-name-override: retrieveApplication
       x-speakeasy-group: client.chat
-    x-speakeasy-metadata:
-      after: sdk.chat.retrieveApplication()
-      before: sdk.Chat.getchatapplication()
-      created_at: 1743113936039
-      reviewed_at: 1743114533812
-      type: method-name
 
 
   - target: $["paths"]["/rest/api/v1/listchats"]["post"]
     update:
       x-speakeasy-name-override: list
       x-speakeasy-group: client.chat
-    x-speakeasy-metadata:
-      after: sdk.chat.list()
-      before: sdk.Chat.listchats()
-      created_at: 1743113936039
-      reviewed_at: 1743114533812
-      type: method-name
 
 
   # Collections
@@ -267,96 +140,48 @@ actions:
     update:
       x-speakeasy-name-override: deleteItem
       x-speakeasy-group: client.collections
-    x-speakeasy-metadata:
-      after: sdk.collections.deleteItem()
-      before: sdk.Collections.deletecollectionitem()
-      created_at: 1743113936038
-      reviewed_at: 1743114533812
-      type: method-name
 
 
   - target: $["paths"]["/rest/api/v1/createcollection"]["post"]
     update:
       x-speakeasy-group: client.collections
       x-speakeasy-name-override: create
-    x-speakeasy-metadata:
-      after: sdk.collections.create()
-      before: sdk.Collections.createcollection()
-      created_at: 1743113936038
-      reviewed_at: 1743114533812
-      type: method-name
 
 
   - target: $["paths"]["/rest/api/v1/editcollectionitem"]["post"]
     update:
       x-speakeasy-name-override: updateItem
       x-speakeasy-group: client.collections
-    x-speakeasy-metadata:
-      after: sdk.collections.updateItem()
-      before: sdk.Collections.editcollectionitem()
-      created_at: 1743113936039
-      reviewed_at: 1743114533812
-      type: method-name
 
 
   - target: $["paths"]["/rest/api/v1/getcollection"]["post"]
     update:
       x-speakeasy-name-override: retrieve
       x-speakeasy-group: client.collections
-    x-speakeasy-metadata:
-      after: sdk.collections.retrieve()
-      before: sdk.Collections.getcollection()
-      created_at: 1743113936039
-      reviewed_at: 1743114533812
-      type: method-name
 
 
   - target: $["paths"]["/rest/api/v1/listcollections"]["post"]
     update:
       x-speakeasy-name-override: list
       x-speakeasy-group: client.collections
-    x-speakeasy-metadata:
-      after: sdk.collections.list()
-      before: sdk.Collections.listcollections()
-      created_at: 1743113936039
-      reviewed_at: 1743114533812
-      type: method-name
 
 
   - target: $["paths"]["/rest/api/v1/addcollectionitems"]["post"]
     update:
       x-speakeasy-name-override: addItems
       x-speakeasy-group: client.collections
-    x-speakeasy-metadata:
-      after: sdk.collections.addItems()
-      before: sdk.Collections.addcollectionitems()
-      created_at: 1743113936039
-      reviewed_at: 1743114533812
-      type: method-name
 
 
   - target: $["paths"]["/rest/api/v1/editcollection"]["post"]
     update:
       x-speakeasy-name-override: update
       x-speakeasy-group: client.collections
-    x-speakeasy-metadata:
-      after: sdk.collections.update()
-      before: sdk.Collections.editcollection()
-      created_at: 1743113936039
-      reviewed_at: 1743114533812
-      type: method-name
 
 
   - target: $["paths"]["/rest/api/v1/deletecollection"]["post"]
     update:
       x-speakeasy-name-override: delete
       x-speakeasy-group: client.collections
-    x-speakeasy-metadata:
-      after: sdk.collections.delete()
-      before: sdk.Collections.deletecollection()
-      created_at: 1743113936039
-      reviewed_at: 1743114533813
-      type: method-name
 
 
   # Documents
@@ -364,36 +189,18 @@ actions:
     update:
       x-speakeasy-name-override: retrievePermissions
       x-speakeasy-group: client.documents
-    x-speakeasy-metadata:
-      after: sdk.documents.retrievePermissions()
-      before: sdk.Documents.getdocpermissions()
-      created_at: 1743113936039
-      reviewed_at: 1743114533812
-      type: method-name
 
 
   - target: $["paths"]["/rest/api/v1/getdocumentsbyfacets"]["post"]
     update:
       x-speakeasy-name-override: retrieveByFacets
       x-speakeasy-group: client.documents
-    x-speakeasy-metadata:
-      after: sdk.documents.retrieveByFacets()
-      before: sdk.Documents.getdocumentsbyfacets()
-      created_at: 1743113936039
-      reviewed_at: 1743114533812
-      type: method-name
 
 
   - target: $["paths"]["/rest/api/v1/getdocuments"]["post"]
     update:
       x-speakeasy-name-override: retrieve
       x-speakeasy-group: client.documents
-    x-speakeasy-metadata:
-      after: sdk.documents.retrieve()
-      before: sdk.Documents.getdocuments()
-      created_at: 1743113936039
-      reviewed_at: 1743114533812
-      type: method-name
 
 
   # Entities
@@ -401,24 +208,12 @@ actions:
     update:
       x-speakeasy-group: client.entities
       x-speakeasy-name-override: list
-    x-speakeasy-metadata:
-      after: sdk.entities.list()
-      before: sdk.Entities.listentities()
-      created_at: 1743113936038
-      reviewed_at: 1743114533812
-      type: method-name
 
 
   - target: $["paths"]["/rest/api/v1/people"]["post"]
     update:
       x-speakeasy-name-override: readPeople
       x-speakeasy-group: client.entities
-    x-speakeasy-metadata:
-      after: sdk.entities.readPeople()
-      before: sdk.Entities.people()
-      created_at: 1743113936039
-      reviewed_at: 1743114533812
-      type: method-name
 
 
   # Insights
@@ -426,12 +221,6 @@ actions:
     update:
       x-speakeasy-name-override: retrieve
       x-speakeasy-group: client.insights
-    x-speakeasy-metadata:
-      after: sdk.insights.retrieve()
-      before: sdk.Insights.insights()
-      created_at: 1743113936039
-      reviewed_at: 1743114533812
-      type: method-name
 
 
   # Messages
@@ -439,12 +228,6 @@ actions:
     update:
       x-speakeasy-name-override: retrieve
       x-speakeasy-group: client.messages
-    x-speakeasy-metadata:
-      after: sdk.messages.retrieve()
-      before: sdk.Messages.messages()
-      created_at: 1743113936039
-      reviewed_at: 1743114533812
-      type: method-name
 
 
   # Pins
@@ -452,60 +235,30 @@ actions:
     update:
       x-speakeasy-name-override: list
       x-speakeasy-group: client.pins
-    x-speakeasy-metadata:
-      after: sdk.pins.list()
-      before: sdk.Pins.listpins()
-      created_at: 1743113936039
-      reviewed_at: 1743114533812
-      type: method-name
 
 
   - target: $["paths"]["/rest/api/v1/pin"]["post"]
     update:
       x-speakeasy-name-override: create
       x-speakeasy-group: client.pins
-    x-speakeasy-metadata:
-      after: sdk.pins.create()
-      before: sdk.Pins.pin()
-      created_at: 1743113936039
-      reviewed_at: 1743114533812
-      type: method-name
 
 
   - target: $["paths"]["/rest/api/v1/editpin"]["post"]
     update:
       x-speakeasy-name-override: update
       x-speakeasy-group: client.pins
-    x-speakeasy-metadata:
-      after: sdk.pins.update()
-      before: sdk.Pins.editpin()
-      created_at: 1743113936039
-      reviewed_at: 1743114533812
-      type: method-name
 
 
   - target: $["paths"]["/rest/api/v1/getpin"]["post"]
     update:
       x-speakeasy-name-override: retrieve
       x-speakeasy-group: client.pins
-    x-speakeasy-metadata:
-      after: sdk.pins.retrieve()
-      before: sdk.Pins.getpin()
-      created_at: 1743113936039
-      reviewed_at: 1743114533812
-      type: method-name
 
 
   - target: $["paths"]["/rest/api/v1/unpin"]["post"]
     update:
       x-speakeasy-name-override: remove
       x-speakeasy-group: client.pins
-    x-speakeasy-metadata:
-      after: sdk.pins.remove()
-      before: sdk.Pins.unpin()
-      created_at: 1743113936039
-      reviewed_at: 1743114533813
-      type: method-name
 
 
   # Search
@@ -513,12 +266,6 @@ actions:
     update:
       x-speakeasy-name-override: retrieveFeed
       x-speakeasy-group: client.search
-    x-speakeasy-metadata:
-      after: sdk.search.retrieveFeed()
-      before: sdk.Search.feed()
-      created_at: 1743113936038
-      reviewed_at: 1743114533812
-      type: method-name
 
 
   - target: $["paths"]["/rest/api/v1/recommendations"]["post"]
@@ -531,95 +278,47 @@ actions:
     update:
       x-speakeasy-name-override: query
       x-speakeasy-group: client.admin.search
-    x-speakeasy-metadata:
-      after: sdk.admin.search.query()
-      before: sdk.Admin.search()
-      created_at: 1743113936039
-      reviewed_at: 1743114533812
-      type: method-name
 
 
   - target: $["paths"]["/rest/api/v1/search"]["post"]
     update:
       x-speakeasy-name-override: query
       x-speakeasy-group: client.search
-    x-speakeasy-metadata:
-      after: sdk.search.query()
-      before: sdk.Search.search()
-      created_at: 1743113936039
-      reviewed_at: 1743114533812
-      type: method-name
 
   - target: $["paths"]["/rest/api/v1/search/autocomplete"]["post"]
     update:
       x-speakeasy-group: client.search
       x-speakeasy-name-override: autocomplete
-    x-speakeasy-metadata:
-      type: method-name
-      before: sdk.search.search.autocomplete()
-      after: sdk.search.autocomplete.retrieve()
-      created_at: 1746289796032
-      reviewed_at: 1746289796032
 
   # Shortcuts
   - target: $["paths"]["/rest/api/v1/listshortcuts"]["post"]
     update:
       x-speakeasy-name-override: list
       x-speakeasy-group: client.shortcuts
-    x-speakeasy-metadata:
-      after: sdk.shortcuts.list()
-      before: sdk.Shortcuts.listshortcuts()
-      created_at: 1743113936039
-      reviewed_at: 1743114533812
-      type: method-name
 
 
   - target: $["paths"]["/rest/api/v1/getshortcut"]["post"]
     update:
       x-speakeasy-name-override: retrieve
       x-speakeasy-group: client.shortcuts
-    x-speakeasy-metadata:
-      after: sdk.shortcuts.retrieve()
-      before: sdk.Shortcuts.getshortcut()
-      created_at: 1743113936039
-      reviewed_at: 1743114533812
-      type: method-name
 
 
   - target: $["paths"]["/rest/api/v1/updateshortcut"]["post"]
     update:
       x-speakeasy-name-override: update
       x-speakeasy-group: client.shortcuts
-    x-speakeasy-metadata:
-      after: sdk.shortcuts.update()
-      before: sdk.Shortcuts.updateshortcut()
-      created_at: 1743113936039
-      reviewed_at: 1743114533812
-      type: method-name
 
 
   - target: $["paths"]["/rest/api/v1/createshortcut"]["post"]
     update:
       x-speakeasy-name-override: create
       x-speakeasy-group: client.shortcuts
-    x-speakeasy-metadata:
-      after: sdk.shortcuts.create()
-      before: sdk.Shortcuts.createshortcut()
-      created_at: 1743113936039
-      reviewed_at: 1743114533812
-      type: method-name
 
 
   - target: $["paths"]["/rest/api/v1/deleteshortcut"]["post"]
     update:
       x-speakeasy-name-override: delete
       x-speakeasy-group: client.shortcuts
-    x-speakeasy-metadata:
-      after: sdk.shortcuts.delete()
-      before: sdk.Shortcuts.deleteshortcut()
-      created_at: 1743113936039
-      reviewed_at: 1743114533812
-      type: method-name
 
 
   # Summarize
@@ -627,12 +326,6 @@ actions:
     update:
       x-speakeasy-name-override: summarize
       x-speakeasy-group: client.documents
-    x-speakeasy-metadata:
-      after: sdk.documents.summarize()
-      before: sdk.Summarize.summarize()
-      created_at: 1743113936039
-      reviewed_at: 1743114533812
-      type: method-name
 
 
   # Verification
@@ -640,36 +333,18 @@ actions:
     update:
       x-speakeasy-name-override: list
       x-speakeasy-group: client.verification
-    x-speakeasy-metadata:
-      after: sdk.verification.list()
-      before: sdk.Verification.listverifications()
-      created_at: 1743113936039
-      reviewed_at: 1743114533812
-      type: method-name
 
 
   - target: $["paths"]["/rest/api/v1/addverificationreminder"]["post"]
     update:
       x-speakeasy-name-override: addReminder
       x-speakeasy-group: client.verification
-    x-speakeasy-metadata:
-      after: sdk.verification.addReminder()
-      before: sdk.Verification.addverificationreminder()
-      created_at: 1743113936039
-      reviewed_at: 1743114533812
-      type: method-name
 
 
   - target: $["paths"]["/rest/api/v1/verify"]["post"]
     update:
       x-speakeasy-name-override: verify
       x-speakeasy-group: client.verification
-    x-speakeasy-metadata:
-      after: sdk.verification.verify()
-      before: sdk.Verification.verify()
-      created_at: 1743113936039
-      reviewed_at: 1743114533812
-      type: method-name
 
   - target: $["components"]["schemas"]["ErrorInfo"]
     update:

--- a/overlays/indexing-modifications-overlay.yaml
+++ b/overlays/indexing-modifications-overlay.yaml
@@ -3,22 +3,13 @@ x-speakeasy-jsonpath: rfc9535
 info:
   title: Speakeasy Modifications
   version: 0.0.5
-  x-speakeasy-metadata:
-    after: ""
-    before: ""
-    type: speakeasy-modifications
+
 actions:
   # Authentication
   - target: $["paths"]["/api/index/v1/rotatetoken"]["post"]
     update:
       x-speakeasy-name-override: rotateToken
       x-speakeasy-group: indexing.authentication
-    x-speakeasy-metadata:
-      after: sdk.authentication.rotateToken()
-      before: sdk.Authentication.post_/api/index/v1/rotatetoken()
-      created_at: 1743113936039
-      reviewed_at: 1743114533812
-      type: method-name
 
 
   # Datasources
@@ -26,24 +17,12 @@ actions:
     update:
       x-speakeasy-name-override: retrieveConfig
       x-speakeasy-group: indexing.datasources
-    x-speakeasy-metadata:
-      after: sdk.datasources.retrieveConfig()
-      before: sdk.Datasources.post_/api/index/v1/getdatasourceconfig()
-      created_at: 1743113936039
-      reviewed_at: 1743114533812
-      type: method-name
 
 
   - target: $["paths"]["/api/index/v1/adddatasource"]["post"]
     update:
       x-speakeasy-name-override: add
       x-speakeasy-group: indexing.datasources
-    x-speakeasy-metadata:
-      after: sdk.datasources.add()
-      before: sdk.Datasources.post_/api/index/v1/adddatasource()
-      created_at: 1743113936039
-      reviewed_at: 1743114533813
-      type: method-name
 
 
   # Documents
@@ -51,60 +30,30 @@ actions:
     update:
       x-speakeasy-name-override: delete
       x-speakeasy-group: indexing.documents
-    x-speakeasy-metadata:
-      after: sdk.documents.delete()
-      before: sdk.Documents.post_/api/index/v1/deletedocument()
-      created_at: 1743113936039
-      reviewed_at: 1743114533812
-      type: method-name
 
 
   - target: $["paths"]["/api/index/v1/bulkindexdocuments"]["post"]
     update:
       x-speakeasy-name-override: bulkIndex
       x-speakeasy-group: indexing.documents
-    x-speakeasy-metadata:
-      after: sdk.documents.bulkIndex()
-      before: sdk.Documents.post_/api/index/v1/bulkindexdocuments()
-      created_at: 1743113936039
-      reviewed_at: 1743114533812
-      type: method-name
 
 
   - target: $["paths"]["/api/index/v1/processalldocuments"]["post"]
     update:
       x-speakeasy-name-override: processAll
       x-speakeasy-group: indexing.documents
-    x-speakeasy-metadata:
-      after: sdk.documents.processAll()
-      before: sdk.Documents.post_/api/index/v1/processalldocuments()
-      created_at: 1743113936039
-      reviewed_at: 1743114533812
-      type: method-name
 
 
   - target: $["paths"]["/api/index/v1/indexdocument"]["post"]
     update:
       x-speakeasy-name-override: addOrUpdate
       x-speakeasy-group: indexing.documents
-    x-speakeasy-metadata:
-      after: sdk.documents.addOrUpdate()
-      before: sdk.Documents.post_/api/index/v1/indexdocument()
-      created_at: 1743113936039
-      reviewed_at: 1743114533812
-      type: method-name
 
 
   - target: $["paths"]["/api/index/v1/indexdocuments"]["post"]
     update:
       x-speakeasy-name-override: index
       x-speakeasy-group: indexing.documents
-    x-speakeasy-metadata:
-      after: sdk.documents.index()
-      before: sdk.Documents.post_/api/index/v1/indexdocuments()
-      created_at: 1743113936039
-      reviewed_at: 1743114533813
-      type: method-name
 
 
   # People
@@ -112,84 +61,42 @@ actions:
     update:
       x-speakeasy-name-override: bulkIndexTeams
       x-speakeasy-group: indexing.people
-    x-speakeasy-metadata:
-      after: sdk.people.bulkIndexTeams()
-      before: sdk.People.post_/api/index/v1/bulkindexteams()
-      created_at: 1743113936039
-      reviewed_at: 1743114533813
-      type: method-name
 
 
   - target: $["paths"]["/api/index/v1/indexemployeelist"]["post"]
     update:
       x-speakeasy-name-override: bulkIndex
       x-speakeasy-group: indexing.people
-    x-speakeasy-metadata:
-      after: sdk.people.bulkIndex()
-      before: sdk.People.post_/api/index/v1/indexemployeelist()
-      created_at: 1743113936039
-      reviewed_at: 1743114533812
-      type: method-name
 
 
   - target: $["paths"]["/api/index/v1/indexemployee"]["post"]
     update:
       x-speakeasy-name-override: index
       x-speakeasy-group: indexing.people
-    x-speakeasy-metadata:
-      after: sdk.people.index()
-      before: sdk.People.post_/api/index/v1/indexemployee()
-      created_at: 1743113936039
-      reviewed_at: 1743114533812
-      type: method-name
 
 
   - target: $["paths"]["/api/index/v1/deleteemployee"]["post"]
     update:
       x-speakeasy-name-override: delete
       x-speakeasy-group: indexing.people
-    x-speakeasy-metadata:
-      after: sdk.people.delete()
-      before: sdk.People.post_/api/index/v1/deleteemployee()
-      created_at: 1743113936038
-      reviewed_at: 1743114533812
-      type: method-name
 
 
   - target: $["paths"]["/api/index/v1/indexteam"]["post"]
     update:
       x-speakeasy-name-override: indexTeam
       x-speakeasy-group: indexing.people
-    x-speakeasy-metadata:
-      after: sdk.people.indexTeam()
-      before: sdk.People.post_/api/index/v1/indexteam()
-      created_at: 1743113936039
-      reviewed_at: 1743114533812
-      type: method-name
 
 
   - target: $["paths"]["/api/index/v1/processallemployeesandteams"]["post"]
     update:
       x-speakeasy-name-override: processAllEmployeesAndTeams
       x-speakeasy-group: indexing.people
-    x-speakeasy-metadata:
-      after: sdk.people.processAllEmployeesAndTeams()
-      before: sdk.People.post_/api/index/v1/processallemployeesandteams()
-      created_at: 1743113936039
-      reviewed_at: 1743114533812
-      type: method-name
 
 
   - target: $["paths"]["/api/index/v1/deleteteam"]["post"]
     update:
       x-speakeasy-name-override: deleteTeam
       x-speakeasy-group: indexing.people
-    x-speakeasy-metadata:
-      after: sdk.people.deleteTeam()
-      before: sdk.People.post_/api/index/v1/deleteteam()
-      created_at: 1743113936039
-      reviewed_at: 1743114533812
-      type: method-name
 
 
   # Permissions
@@ -197,144 +104,72 @@ actions:
     update:
       x-speakeasy-name-override: processMemberships
       x-speakeasy-group: indexing.permissions
-    x-speakeasy-metadata:
-      after: sdk.permissions.processMemberships()
-      before: sdk.Permissions.post_/api/index/v1/processallmemberships()
-      created_at: 1743113936039
-      reviewed_at: 1743114533813
-      type: method-name
 
 
   - target: $["paths"]["/api/index/v1/bulkindexusers"]["post"]
     update:
       x-speakeasy-name-override: bulkIndexUsers
       x-speakeasy-group: indexing.permissions
-    x-speakeasy-metadata:
-      after: sdk.permissions.bulkIndexUsers()
-      before: sdk.Permissions.post_/api/index/v1/bulkindexusers()
-      created_at: 1743113936039
-      reviewed_at: 1743114533813
-      type: method-name
 
 
   - target: $["paths"]["/api/index/v1/updatepermissions"]["post"]
     update:
       x-speakeasy-name-override: updatePermissions
       x-speakeasy-group: indexing.permissions
-    x-speakeasy-metadata:
-      after: sdk.documents.updatePermissions()
-      before: sdk.Documents.post_/api/index/v1/updatepermissions()
-      created_at: 1743113936039
-      reviewed_at: 1743114533813
-      type: method-name
 
 
   - target: $["paths"]["/api/index/v1/bulkindexgroups"]["post"]
     update:
       x-speakeasy-name-override: bulkIndexGroups
       x-speakeasy-group: indexing.permissions
-    x-speakeasy-metadata:
-      after: sdk.permissions.bulkIndexGroups()
-      before: sdk.Permissions.post_/api/index/v1/bulkindexgroups()
-      created_at: 1743113936039
-      reviewed_at: 1743114533812
-      type: method-name
 
 
   - target: $["paths"]["/api/index/v1/bulkindexmemberships"]["post"]
     update:
       x-speakeasy-name-override: bulkIndexMemberships
       x-speakeasy-group: indexing.permissions
-    x-speakeasy-metadata:
-      after: sdk.permissions.bulkIndexMemberships()
-      before: sdk.Permissions.post_/api/index/v1/bulkindexmemberships()
-      created_at: 1743113936039
-      reviewed_at: 1743114533812
-      type: method-name
 
 
   - target: $["paths"]["/api/index/v1/betausers"]["post"]
     update:
       x-speakeasy-name-override: authorizeBetaUsers
       x-speakeasy-group: indexing.permissions
-    x-speakeasy-metadata:
-      after: sdk.permissions.authorizeBetaUsers()
-      before: sdk.Permissions.post_/api/index/v1/betausers()
-      created_at: 1743113936039
-      reviewed_at: 1743114533812
-      type: method-name
 
 
   - target: $["paths"]["/api/index/v1/indexgroup"]["post"]
     update:
       x-speakeasy-name-override: indexGroup
       x-speakeasy-group: indexing.permissions
-    x-speakeasy-metadata:
-      after: sdk.permissions.indexGroup()
-      before: sdk.Permissions.post_/api/index/v1/indexgroup()
-      created_at: 1743113936039
-      reviewed_at: 1743114533812
-      type: method-name
 
 
   - target: $["paths"]["/api/index/v1/indexuser"]["post"]
     update:
       x-speakeasy-name-override: indexUser
       x-speakeasy-group: indexing.permissions
-    x-speakeasy-metadata:
-      after: sdk.permissions.indexUser()
-      before: sdk.Permissions.post_/api/index/v1/indexuser()
-      created_at: 1743113936039
-      reviewed_at: 1743114533812
-      type: method-name
 
 
   - target: $["paths"]["/api/index/v1/indexmembership"]["post"]
     update:
       x-speakeasy-name-override: indexMembership
       x-speakeasy-group: indexing.permissions
-    x-speakeasy-metadata:
-      after: sdk.permissions.indexMembership()
-      before: sdk.Permissions.post_/api/index/v1/indexmembership()
-      created_at: 1743113936039
-      reviewed_at: 1743114533812
-      type: method-name
 
 
   - target: $["paths"]["/api/index/v1/deletegroup"]["post"]
     update:
       x-speakeasy-name-override: deleteGroup
       x-speakeasy-group: indexing.permissions
-    x-speakeasy-metadata:
-      after: sdk.permissions.deleteGroup()
-      before: sdk.Permissions.post_/api/index/v1/deletegroup()
-      created_at: 1743113936039
-      reviewed_at: 1743114533812
-      type: method-name
 
 
   - target: $["paths"]["/api/index/v1/deleteuser"]["post"]
     update:
       x-speakeasy-name-override: deleteUser
       x-speakeasy-group: indexing.permissions
-    x-speakeasy-metadata:
-      after: sdk.permissions.deleteUser()
-      before: sdk.Permissions.post_/api/index/v1/deleteuser()
-      created_at: 1743113936039
-      reviewed_at: 1743114533812
-      type: method-name
 
 
   - target: $["paths"]["/api/index/v1/deletemembership"]["post"]
     update:
       x-speakeasy-name-override: deleteMembership
       x-speakeasy-group: indexing.permissions
-    x-speakeasy-metadata:
-      after: sdk.permissions.deleteMembership()
-      before: sdk.Permissions.post_/api/index/v1/deletemembership()
-      created_at: 1743113936039
-      reviewed_at: 1743114533813
-      type: method-name
 
 
   # Shortcuts
@@ -342,24 +177,12 @@ actions:
     update:
       x-speakeasy-name-override: bulkIndex
       x-speakeasy-group: indexing.shortcuts
-    x-speakeasy-metadata:
-      after: sdk.shortcuts.bulkIndex()
-      before: sdk.Shortcuts.post_/api/index/v1/bulkindexshortcuts()
-      created_at: 1743113936039
-      reviewed_at: 1743114533812
-      type: method-name
 
 
   - target: $["paths"]["/api/index/v1/uploadshortcuts"]["post"]
     update:
       x-speakeasy-name-override: upload
       x-speakeasy-group: indexing.shortcuts
-    x-speakeasy-metadata:
-      after: sdk.shortcuts.upload()
-      before: sdk.Shortcuts.post_/api/index/v1/uploadshortcuts()
-      created_at: 1743113936039
-      reviewed_at: 1743114533812
-      type: method-name
 
 
   # Troubleshooting
@@ -367,93 +190,45 @@ actions:
     update:
       x-speakeasy-group: indexing.documents
       x-speakeasy-name-override: checkAccess
-    x-speakeasy-metadata:
-      after: sdk.documents.checkAccess()
-      before: sdk.Troubleshooting.post_/api/index/v1/checkdocumentaccess()
-      created_at: 1743113936038
-      reviewed_at: 1743114533812
-      type: method-name
 
 
   - target: $["paths"]["/api/index/v1/getdocumentcount"]["post"]
     update:
       x-speakeasy-group: indexing.documents
       x-speakeasy-name-override: count
-    x-speakeasy-metadata:
-      after: sdk.documents.count()
-      before: sdk.Troubleshooting.post_/api/index/v1/getdocumentcount()
-      created_at: 1743113936038
-      reviewed_at: 1743114533812
-      type: method-name
 
 
   - target: $["paths"]["/api/index/v1/debug/{datasource}/documents"]["post"]
     update:
       x-speakeasy-group: indexing.documents
       x-speakeasy-name-override: debugMany
-    x-speakeasy-metadata:
-      after: sdk.documents.debug()
-      before: sdk.Troubleshooting.post_/api/index/v1/debug/{datasource}/documents()
-      created_at: 1743113936039
-      reviewed_at: 1743114533812
-      type: method-name
 
 
   - target: $["paths"]["/api/index/v1/getdocumentstatus"]["post"]
     update:
       x-speakeasy-group: indexing.documents
       x-speakeasy-name-override: status
-    x-speakeasy-metadata:
-      after: sdk.troubleshooting.documents.status()
-      before: sdk.Troubleshooting.post_/api/index/v1/getdocumentstatus()
-      created_at: 1743113936039
-      reviewed_at: 1743114533812
-      type: method-name
 
 
   - target: $["paths"]["/api/index/v1/getusercount"]["post"]
     update:
       x-speakeasy-name-override: count
       x-speakeasy-group: indexing.people
-    x-speakeasy-metadata:
-      after: sdk.people.count()
-      before: sdk.Troubleshooting.post_/api/index/v1/getusercount()
-      created_at: 1743113936039
-      reviewed_at: 1743114533812
-      type: method-name
 
 
   - target: $["paths"]["/api/index/v1/debug/{datasource}/status"]["post"]
     update:
       x-speakeasy-name-override: status
       x-speakeasy-group: indexing.datasource
-    x-speakeasy-metadata:
-      after: sdk.datasource.status()
-      before: sdk.Troubleshooting.post_/api/index/v1/debug/{datasource}/status()
-      created_at: 1743113936039
-      reviewed_at: 1743114533812
-      type: method-name
 
 
   - target: $["paths"]["/api/index/v1/debug/{datasource}/document"]["post"]
     update:
       x-speakeasy-group: indexing.documents
       x-speakeasy-name-override: debug
-    x-speakeasy-metadata:
-      after: sdk.documents.debug()
-      before: sdk.Troubleshooting.post_/api/index/v1/debug/{datasource}/document()
-      created_at: 1743113936039
-      reviewed_at: 1743114533812
-      type: method-name
 
 
   - target: $["paths"]["/api/index/v1/debug/{datasource}/user"]["post"]
     update:
       x-speakeasy-name-override: debug
       x-speakeasy-group: indexing.people
-    x-speakeasy-metadata:
-      after: sdk.people.debug()
-      before: sdk.Troubleshooting.post_/api/index/v1/debug/{datasource}/user()
-      created_at: 1743113936039
-      reviewed_at: 1743114533813
-      type: method-name


### PR DESCRIPTION
## Summary

Removes all speakeasy metadata from overlays (they're only needed for Studio edits).

### Code changes:
* Removed `x-speakeasy-metadata` entries from multiple endpoints in the YAML configuration, simplifying the overlay by eliminating unnecessary metadata attributes related to SDK methods while retaining critical action modifications.
