### PR TITLE
chore: Updating workflows to include admin_rest.yaml

### DIFF
--- a/.speakeasy/workflow.yaml
+++ b/.speakeasy/workflow.yaml
@@ -5,6 +5,7 @@ sources:
         inputs:
             - location: generated_specs/client_rest.yaml
             - location: generated_specs/indexing.yaml
+            - location: generated_specs/admin_rest.yaml
         overlays:
             - location: overlays/chat-endpoint-fixes-overlay.yaml
             - location: overlays/info-name-overlay.yaml
@@ -12,12 +13,14 @@ sources:
             - location: overlays/client-modifications-overlay.yaml
             - location: overlays/indexing-modifications-overlay.yaml
             - location: overlays/agent-modifications-overlay.yaml
+            - location: overlays/admin-modifications-overlay.yaml
         output: overlayed_specs/glean-merged-spec.yaml
         registry:
             location: registry.speakeasyapi.dev/glean-el2/sdk/glean-api-specs
     glean-client-merged-code-samples-spec:
         inputs:
             - location: generated_specs/client_rest.yaml
+            - location: generated_specs/admin_rest.yaml
         overlays:
             - location: registry.speakeasyapi.dev/glean-el2/sdk/glean-api-specs-python-code-samples
             - location: registry.speakeasyapi.dev/glean-el2/sdk/glean-api-specs-typescript-code-samples

--- a/docs/index.html
+++ b/docs/index.html
@@ -37,7 +37,7 @@
   
   <script>
     function listSpecs() {
-      const sourceFiles = ['client_rest.yaml', 'indexing.yaml'];
+      const sourceFiles = ['client_rest.yaml', 'indexing.yaml', 'admin_rest.yaml'];
       const mergedFiles = ['glean-client-merged-code-samples-spec.yaml', 'glean-index-merged-code-samples-spec.yaml'];
       
       const sourceList = document.getElementById('source-specs');

--- a/overlays/admin-modifications-overlay.yaml
+++ b/overlays/admin-modifications-overlay.yaml
@@ -1,0 +1,38 @@
+overlay: 1.0.0
+x-speakeasy-jsonpath: rfc9535
+info:
+  title: Speakeasy Modifications
+  version: 0.0.5
+
+actions:
+  # Governance Admin endpoints
+  - target: $["paths"]["/rest/api/v1/governance/data/policies/{id}"]["get"]
+    update:
+      x-speakeasy-group: client
+  - target: $["paths"]["/rest/api/v1/governance/data/policies/{id}"]["post"]
+    update:
+      x-speakeasy-group: client
+  - target: $["paths"]["/rest/api/v1/governance/data/policies"]["get"]
+    update:
+      x-speakeasy-group: client
+  - target: $["paths"]["/rest/api/v1/governance/data/policies"]["post"]
+    update:
+      x-speakeasy-group: client
+  - target: $["paths"]["/rest/api/v1/governance/data/policies/{id}/download"]["get"]
+    update:
+      x-speakeasy-group: client
+  - target: $["paths"]["/rest/api/v1/governance/data/reports"]["post"]
+    update:
+      x-speakeasy-group: client
+  - target: $["paths"]["/rest/api/v1/governance/data/reports/{id}/download"]["get"]
+    update:
+      x-speakeasy-group: client
+  - target: $["paths"]["/rest/api/v1/governance/data/reports/{id}/status"]["get"]
+    update:
+      x-speakeasy-group: client
+  - target: $["paths"]["/rest/api/v1/governance/documents/visibilityoverrides"]["get"]
+    update:
+      x-speakeasy-group: client
+  - target: $["paths"]["/rest/api/v1/governance/documents/visibilityoverrides"]["post"]
+    update:
+      x-speakeasy-group: client


### PR DESCRIPTION
# Summary

This pull request introduces support for a new `admin_rest.yaml` specification and its corresponding overlay, enabling governance admin endpoints in the API. The most important changes include updates to the workflow configuration, documentation, and the addition of a new overlay file for admin modifications.

### Workflow and Specification Updates:
* [`.speakeasy/workflow.yaml`](diffhunk://#diff-07a627252d51850cb5031c8550183e6cf8dd9535eef9ac6a29f28d6c55a4f01dR8-R23): Added `admin_rest.yaml` to the list of input specifications and included a new overlay, `admin-modifications-overlay.yaml`, to handle admin-specific modifications.

### Documentation Updates:
* [`docs/index.html`](diffhunk://#diff-b04b38d4e36f7a7171aeb211bf933eaf36d41d9866ebbc3639f673f84dc350aeL40-R40): Updated the list of source files to include `admin_rest.yaml` in the merged code samples specs.

### New Overlay for Admin Endpoints:
* [`overlays/admin-modifications-overlay.yaml`](diffhunk://#diff-1510deccefb171a2fd1215946df3b272def6207ef2ed574b2417acde478e7073R1-R38): Added a new overlay file to define governance admin endpoint modifications, grouping them under `x-speakeasy-group: client`.