### PR TITLE
fix: Adding admin_rest.yaml to transformation

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -10,7 +10,8 @@ const OUTPUT_DIR = 'generated_specs';
 // Specification files
 const SPEC_FILES = [
   'client_rest.yaml',
-  'indexing.yaml'
+  'indexing.yaml',
+  'admin_rest.yaml'
 ];
 
 async function ensureDirectoryExists(directory) {


### PR DESCRIPTION
# Summary

This pull request updates the list of specification files in `src/index.js` by adding a new file to the array.

* [`src/index.js`](diffhunk://#diff-bfe9874d239014961b1ae4e89875a6155667db834a410aaaa2ebe3cf89820556L13-R14): Added `'admin_rest.yaml'` to the `SPEC_FILES` array to include the admin REST specification in the generated specs.