### PR TITLE
fix: Fixes invalid cookieAuth property in admin_rest.yaml

### DIFF
--- a/.github/workflows/transform.yml
+++ b/.github/workflows/transform.yml
@@ -34,6 +34,18 @@ jobs:
         env:
           SPEAKEASY_API_KEY: ${{ secrets.SPEAKEASY_API_KEY }}
       
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Run post-transformation smoke tests
+        run: npx vitest run tests/post_transform_smoke.test.js
+
       - name: Commit changes
         uses: ./.github/actions/git-commit
         with:

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,17 @@
+{
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+      {
+        "type": "node",
+        "request": "launch",
+        "name": "Debug Current Test File",
+        "autoAttachChildProcesses": true,
+        "skipFiles": ["<node_internals>/**", "**/node_modules/**"],
+        "program": "${workspaceRoot}/node_modules/vitest/vitest.mjs",
+        "args": ["run", "${relativeFile}"],
+        "smartStep": true,
+        "console": "integratedTerminal"
+      }
+    ]
+  }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,7 +8,7 @@
         "name": "Debug Current Test File",
         "autoAttachChildProcesses": true,
         "skipFiles": ["<node_internals>/**", "**/node_modules/**"],
-        "program": "${workspaceRoot}/node_modules/vitest/vitest.mjs",
+        "program": "${workspaceFolder}/node_modules/vitest/vitest.mjs",
         "args": ["run", "${relativeFile}"],
         "smartStep": true,
         "console": "integratedTerminal"

--- a/tests/post_transform_smoke.test.js
+++ b/tests/post_transform_smoke.test.js
@@ -1,0 +1,65 @@
+import { describe, test, expect } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import yaml from 'js-yaml';
+
+const SPEC_PATH = path.join(process.cwd(), 'overlayed_specs', 'glean-merged-spec.yaml');
+
+const loadSpec = () => yaml.load(fs.readFileSync(SPEC_PATH, 'utf8'));
+
+describe('Post-transformation smoke tests', () => {
+  let spec;
+
+  beforeEach(() => {
+    spec = loadSpec();
+  });
+
+  test('spec parses successfully', () => {
+    expect(spec && typeof spec === 'object').toBe(true);
+  });
+
+  test('server URL uses {instance}', () => {
+    expect(spec.servers?.length).toBeGreaterThan(0);
+
+    const url = spec.servers[0].url;
+
+    expect(url.includes('{instance}')).toBe(true);
+    expect(url.includes('{domain}')).toBe(false);
+  });
+
+  test('security scheme is APIToken only', () => {
+    const schemes = spec.components?.securitySchemes ?? {};
+
+    expect('APIToken' in schemes).toBe(true);
+    expect('BearerAuth' in schemes).toBe(false);
+    expect('actAsBearerToken' in schemes).toBe(false);
+    expect('cookieAuth' in schemes).toBe(false);
+  });
+
+  test('contains IndexingShortcut component', () => {
+    const schemas = spec.components?.schemas ?? {};
+
+    expect('IndexingShortcut' in schemas).toBe(true);
+  });
+
+  test('duplicate operationId fix applied', () => {
+    const policiesGet = spec.paths?.['/rest/api/v1/governance/data/policies']?.get ?? {};
+
+    expect(policiesGet.operationId).toBe('getpolicies');
+  });
+
+  test('overlay applied title', () => {
+    expect(spec.info?.title).toBe('Glean API');
+  });
+
+  test('all paths use expected base prefixes', () => {
+    const paths = Object.keys(spec.paths ?? {});
+
+    expect(paths.length).toBeGreaterThan(0);
+
+    const allowedPrefixes = ['/rest/api/v1', '/api/index/v1'];
+    const hasUnexpected = paths.some((p) => !allowedPrefixes.some((prefix) => p.startsWith(prefix)));
+
+    expect(hasUnexpected).toBe(false);
+  });
+}); 

--- a/tests/transformer.test.js
+++ b/tests/transformer.test.js
@@ -156,6 +156,8 @@ describe('OpenAPI YAML Transformer', () => {
     
     expect(transformedSpec.security[0]).toHaveProperty('APIToken');
     expect(transformedSpec.security[0]).not.toHaveProperty('actAsBearerToken');
+    const hasCookie = transformedSpec.security.some(s => 'cookieAuth' in s);
+    expect(hasCookie).toBe(false, 'cookieAuth should not be present in security');
   });
 
   ['client_rest.yaml', 'indexing.yaml']


### PR DESCRIPTION
## Summary

This pull request introduces updates to the OpenAPI transformation process, adds smoke tests to validate the transformation, and enhances developer tooling for debugging and testing. The most significant changes include refactoring the `transformActAsBearerTokenToAPIToken` function, adding post-transformation smoke tests, and configuring a debugging setup for test files.

### OpenAPI Transformation Updates:
* Refactored the `transformActAsBearerTokenToAPIToken` function in `src/transformer.js` to improve clarity and robustness. The function now uses a helper method `cleanSecurityObject` to handle security scheme transformations and removes the `cookieAuth` scheme from specifications.

### Testing Enhancements:
* Added a new `tests/post_transform_smoke.test.js` file with comprehensive smoke tests to validate the transformed OpenAPI specification. These tests ensure proper parsing, correct security scheme transformations, and adherence to expected structure and conventions.
* Updated `tests/transformer.test.js` to include a new assertion that verifies the absence of `cookieAuth` in the transformed security schemes.

### Developer Tooling:
* Configured a new debugging setup in `.vscode/launch.json` to allow developers to debug individual test files using Vitest. This setup includes features like skipping internal and `node_modules` files, auto-attaching child processes, and running tests in the integrated terminal.

### Workflow Updates:
* Updated the GitHub Actions workflow in `.github/workflows/transform.yml` to include Node.js setup, dependency installation, and execution of the new post-transformation smoke tests.