### PR TITLE
internal: Adds CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @gleanwork/gleanwork-reviewers


### PR DESCRIPTION
## Summary

This pull request includes a small change to the `CODEOWNERS` file. The change adds the `@gleanwork/gleanwork-reviewers` team as code owners for all files.