### PR TITLE
refactor(openapi): remove duplicate operationId fix for admin policies

### DIFF
--- a/src/transformer.js
+++ b/src/transformer.js
@@ -215,25 +215,6 @@ export function transformServerVariables(spec) {
 }
 
 /**
- * Fixes duplicate operationId in admin_rest.yaml for the GET operation on /governance/data/policies
- * @param {Object} spec The OpenAPI spec object
- * @param {string} filename The name of the file being processed
- * @param {string} basePath The computed base path from server URL
- * @returns {Object} Transformed spec object
- */
-export function transformAdminPoliciesOperationId(spec, basePath) {
-  const targetPath = `${basePath}/governance/data/policies`;
-
-  if (
-    spec.paths?.[targetPath]?.get?.operationId === 'getpolicy'
-  ) {
-    spec.paths[targetPath].get.operationId = 'getpolicies';
-  }
-
-  return spec;
-}
-
-/**
  * Transforms OpenAPI YAML by adjusting server URLs and paths
  * @param {string} content The OpenAPI YAML content
  * @param {string} filename The name of the file being processed
@@ -292,7 +273,6 @@ export function transform(content, filename) {
   
   // Apply admin duplicate operationId fix
   if (filename === 'admin_rest.yaml') {
-    transformAdminPoliciesOperationId(spec, basePath);
     transformActAsBearerTokenToAPIToken(spec);
   }
   

--- a/tests/post_transform_smoke.test.js
+++ b/tests/post_transform_smoke.test.js
@@ -42,12 +42,6 @@ describe('Post-transformation smoke tests', () => {
     expect('IndexingShortcut' in schemas).toBe(true);
   });
 
-  test('duplicate operationId fix applied', () => {
-    const policiesGet = spec.paths?.['/rest/api/v1/governance/data/policies']?.get ?? {};
-
-    expect(policiesGet.operationId).toBe('getpolicies');
-  });
-
   test('overlay applied title', () => {
     expect(spec.info?.title).toBe('Glean API');
   });

--- a/tests/transformer.test.js
+++ b/tests/transformer.test.js
@@ -206,16 +206,4 @@ describe('OpenAPI YAML Transformer', () => {
     expect(transformedSpec.servers[0].variables.instance.description)
       .toContain('instance name');
   });
-
-  test('transformAdminPoliciesOperationId changes duplicate operationId in admin_rest.yaml', () => {
-    const adminYaml = readFixture('admin_rest.yaml');
-    const transformedContent = transform(adminYaml, 'admin_rest.yaml');
-    const transformedSpec = yaml.load(transformedContent);
-
-    const originalSpec = yaml.load(adminYaml);
-    const basePath = extractBasePath(originalSpec.servers[0].url);
-    const pathKey = `${basePath}/governance/data/policies`;
-
-    expect(transformedSpec.paths[pathKey].get.operationId).toBe('getpolicies');
-  });
 });


### PR DESCRIPTION
The issue with duplicate operationId for GET /governance/data/policies in admin_rest.yaml has been fixed upstream, making our transformation code unnecessary.