### PR TITLE
fix: Adds Tools tag to tools APIs (fixes invalid sidebar category in docs)

### DIFF
--- a/overlays/client-modifications-overlay.yaml
+++ b/overlays/client-modifications-overlay.yaml
@@ -331,11 +331,15 @@ actions:
   # Tools
   - target: $["paths"]["/rest/api/v1/tools/list"]["get"]
     update:
+      tags:
+        - Tools
       x-speakeasy-name-override: list
       x-speakeasy-group: client.tools
 
   - target: $["paths"]["/rest/api/v1/tools/call"]["post"]
     update:
+      tags:
+        - Tools
       x-speakeasy-name-override: run
       x-speakeasy-group: client.tools
 


### PR DESCRIPTION
This pull request includes a small update to the `overlays/client-modifications-overlay.yaml` file. The change adds a `tags` field with the value `Tools` to the `get` and `post` operations under the `/rest/api/v1/tools` endpoints.