### PR TITLE
fix: Enables generation of code sample files from post-overlayed specs

### DIFF
--- a/.github/workflows/transform.yml
+++ b/.github/workflows/transform.yml
@@ -33,6 +33,20 @@ jobs:
         run: speakeasy run -s glean-api-specs
         env:
           SPEAKEASY_API_KEY: ${{ secrets.SPEAKEASY_API_KEY }}
+
+      # We intentionally skip uploading the spec to the Speakeasy registry since 
+      # we're only using them for code sample generation.
+      - name: Generate Client API specs for code sample generation
+        run: speakeasy run -s glean-client-api-specs --skip-upload-spec
+        env:
+          SPEAKEASY_API_KEY: ${{ secrets.SPEAKEASY_API_KEY }}
+
+      # We intentionally skip uploading the spec to the Speakeasy registry since 
+      # we're only using them for code sample generation.
+      - name: Generate Indexing API specs for code sample generation
+        run: speakeasy run -s glean-indexing-api-specs --skip-upload-spec
+        env:
+          SPEAKEASY_API_KEY: ${{ secrets.SPEAKEASY_API_KEY }}
       
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.speakeasy/workflow.yaml
+++ b/.speakeasy/workflow.yaml
@@ -17,10 +17,22 @@ sources:
         output: overlayed_specs/glean-merged-spec.yaml
         registry:
             location: registry.speakeasyapi.dev/glean-el2/sdk/glean-api-specs
-    glean-client-merged-code-samples-spec:
+            
+    glean-client-api-specs:
         inputs:
             - location: generated_specs/client_rest.yaml
             - location: generated_specs/admin_rest.yaml
+        overlays:
+            - location: overlays/chat-endpoint-fixes-overlay.yaml
+            - location: overlays/info-name-overlay.yaml
+            - location: overlays/strip-headers-overlay.yaml
+            - location: overlays/client-modifications-overlay.yaml
+            - location: overlays/agent-modifications-overlay.yaml
+            - location: overlays/admin-modifications-overlay.yaml
+        output: overlayed_specs/glean-client-api-specs.yaml
+    glean-client-merged-code-samples-spec:
+        inputs:
+            - location: overlayed_specs/glean-client-api-specs.yaml
         overlays:
             - location: registry.speakeasyapi.dev/glean-el2/sdk/glean-api-specs-python-code-samples
             - location: registry.speakeasyapi.dev/glean-el2/sdk/glean-api-specs-typescript-code-samples
@@ -29,9 +41,19 @@ sources:
         output: merged_code_samples_specs/glean-client-merged-code-samples-spec.yaml
         registry:
             location: registry.speakeasyapi.dev/glean-el2/sdk/glean-client-merged-code-samples-spec
-    glean-index-merged-code-samples-spec:
+
+    glean-indexing-api-specs:
         inputs:
             - location: generated_specs/indexing.yaml
+        overlays:
+            - location: overlays/chat-endpoint-fixes-overlay.yaml
+            - location: overlays/info-name-overlay.yaml
+            - location: overlays/strip-headers-overlay.yaml
+            - location: overlays/indexing-modifications-overlay.yaml
+        output: overlayed_specs/glean-indexing-api-specs.yaml
+    glean-index-merged-code-samples-spec:
+        inputs:
+            - location: overlayed_specs/glean-indexing-api-specs.yaml
         overlays:
             - location: registry.speakeasyapi.dev/glean-el2/sdk/glean-api-specs-python-code-samples
             - location: registry.speakeasyapi.dev/glean-el2/sdk/glean-api-specs-typescript-code-samples
@@ -40,4 +62,5 @@ sources:
         output: merged_code_samples_specs/glean-index-merged-code-samples-spec.yaml
         registry:
             location: registry.speakeasyapi.dev/glean-el2/sdk/glean-index-merged-code-samples-spec
+    
 targets: {}


### PR DESCRIPTION
This pull request introduces changes to streamline the generation of API specifications and overlays for code sample generation while skipping unnecessary uploads to the Speakeasy registry. The updates affect both the GitHub Actions workflow and the Speakeasy workflow configuration.

### Updates to GitHub Actions Workflow:
* Added steps to generate client and indexing API specifications specifically for code sample generation without uploading them to the Speakeasy registry. (`.github/workflows/transform.yml`)

### Updates to Speakeasy Workflow Configuration:
* Introduced new entries for `glean-client-api-specs` and `glean-indexing-api-specs` in the `sources` section to define inputs, overlays, and output locations for generating overlayed API specs. (`.speakeasy/workflow.yaml`) [[1]](diffhunk://#diff-07a627252d51850cb5031c8550183e6cf8dd9535eef9ac6a29f28d6c55a4f01dL20-R35) [[2]](diffhunk://#diff-07a627252d51850cb5031c8550183e6cf8dd9535eef9ac6a29f28d6c55a4f01dL32-R56)
* Updated the workflow to ensure the new overlayed specs are used as inputs for generating merged code sample specifications. (`.speakeasy/workflow.yaml`)