### PR TITLE
fix: Removes chat overlay from indexing transformations

### DIFF
--- a/.speakeasy/workflow.yaml
+++ b/.speakeasy/workflow.yaml
@@ -46,7 +46,6 @@ sources:
         inputs:
             - location: generated_specs/indexing.yaml
         overlays:
-            - location: overlays/chat-endpoint-fixes-overlay.yaml
             - location: overlays/info-name-overlay.yaml
             - location: overlays/strip-headers-overlay.yaml
             - location: overlays/indexing-modifications-overlay.yaml


### PR DESCRIPTION
This pull request makes a small update to the `.speakeasy/workflow.yaml` file by removing an unused overlay file from the workflow configuration.

* [`.speakeasy/workflow.yaml`](diffhunk://#diff-07a627252d51850cb5031c8550183e6cf8dd9535eef9ac6a29f28d6c55a4f01dL49): Removed the `overlays/chat-endpoint-fixes-overlay.yaml` entry from the `overlays` list in the `sources` section.