### PR TITLE
chore: Require imports for vitest globals

### DIFF
--- a/tests/post_transform_smoke.test.js
+++ b/tests/post_transform_smoke.test.js
@@ -1,4 +1,4 @@
-import { describe, test, expect } from 'vitest';
+import { beforeEach, describe, test, expect } from 'vitest';
 import * as fs from 'fs';
 import * as path from 'path';
 import yaml from 'js-yaml';

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -4,6 +4,6 @@ export default defineConfig({
   test: {
     environment: 'node',
     include: ['tests/**/*.test.js'],
-    globals: true,
+    globals: false,
   },
 }); 


### PR DESCRIPTION
We mostly already did this, but there was one example where we didn't. I just updated the setting and fixed that one case.