### PR TITLE
chore(config): add Speakeasy files to prettier ignore

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -10,6 +10,9 @@ pnpm-lock.yaml
 /overlayed_specs/
 /merged_code_samples_specs/
 
+# Speakeasy managed files
+/.speakeasy/
+
 # Build artifacts
 dist/
 build/


### PR DESCRIPTION
Exclude /.speakeasy/ directory from Prettier formatting since `speakeasy run` mutates the files somewhat at will.