### PR TITLE
chore: Remove legacy `specs/merged/` dir from GH Pages

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -43,11 +43,6 @@ jobs:
           # Copy source specs
           cp -R source_specs/*.yaml docs/specs/source/
 
-          # NOTE: Copying this into `docs/specs/merged` (to avoid race
-          # condition with gleanwork/glean-developer-site PR to change to use
-          # `docs/specs/final` instead)
-          cp -R merged_code_samples_specs/*.yaml docs/specs/merged/ 
-
           # Copy final processed specs
           cp -R final_specs/*.yaml docs/specs/final/
 


### PR DESCRIPTION
Requires the following to land (and deploy) before merging:

- #38 
- https://github.com/gleanwork/glean-developer-site/pull/60