### PR TITLE
feat(ci): Allow speakeasy-setup action to avoid rate limiting

### DIFF
--- a/.github/actions/speakeasy-setup/action.yml
+++ b/.github/actions/speakeasy-setup/action.yml
@@ -1,9 +1,16 @@
 name: 'Setup Speakeasy CLI'
 description: 'Install Speakeasy CLI via Homebrew'
 
+inputs:
+  github-token:
+    description: 'GitHub token for API access'
+    required: true
+
 runs:
   using: 'composite'
   steps:
     - name: Install Speakeasy CLI
       run: curl -fsSL https://go.speakeasy.com/cli-install.sh | sh
       shell: bash
+      env:
+        GITHUB_TOKEN: ${{ inputs.github-token }}

--- a/.github/workflows/generate-code-samples.yml
+++ b/.github/workflows/generate-code-samples.yml
@@ -26,6 +26,8 @@ jobs:
 
       - name: Setup Speakeasy CLI
         uses: ./.github/actions/speakeasy-setup
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Generate client code samples
         run: speakeasy run -s glean-client-merged-code-samples-spec

--- a/.github/workflows/transform.yml
+++ b/.github/workflows/transform.yml
@@ -36,6 +36,8 @@ jobs:
 
       - name: Setup Speakeasy CLI
         uses: ./.github/actions/speakeasy-setup
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Generate OpenAPI specs
         run: speakeasy run -s glean-api-specs


### PR DESCRIPTION
Currently the `curl https://go.speakeasy.com/cli-install.sh | sh` flow errors quite often due to rate limit issues. This change exposes `$GITHUB_TOKEN` to the script so that it _can_ leverage it to make authenticated requests (which have a much higher rate limit).

At the moment, this doesn't *really* do anything but once https://github.com/speakeasy-api/speakeasy/pull/1447 is reviewed and merged it will fix some of our sporadic workflow failures.