### PR TITLE
feat(ci): Add workflow to trigger client SDK generation

### DIFF
--- a/.github/workflows/trigger-client-generation.yml
+++ b/.github/workflows/trigger-client-generation.yml
@@ -1,0 +1,108 @@
+name: Trigger Client SDK Generation
+
+on:
+  workflow_dispatch:
+    inputs:
+      reason:
+        description: 'Reason for triggering client generation'
+        required: false
+        default: 'Manual trigger'
+        type: string
+
+  workflow_run:
+    workflows: ['Transform OpenAPI Specs']
+    types:
+      - completed
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  trigger-clients:
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
+
+    steps:
+      - name: Log trigger reason
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "Manually triggered: ${{ github.event.inputs.reason }}"
+          else
+            echo "Automatically triggered after successful Transform OpenAPI Specs workflow"
+          fi
+
+      - name: Trigger Python Client SDK Generation
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.CLIENT_GENERATION_TOKEN }}
+          script: |
+            const result = await github.rest.actions.createWorkflowDispatch({
+              owner: 'gleanwork',
+              repo: 'api-client-python',
+              workflow_id: 'sdk_generation.yaml',
+              ref: 'main',
+              inputs: {
+                trigger_source: 'open-api-repo'
+              }
+            });
+            console.log('Python client generation triggered:', result.status);
+
+      - name: Trigger TypeScript Client SDK Generation
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.CLIENT_GENERATION_TOKEN }}
+          script: |
+            const result = await github.rest.actions.createWorkflowDispatch({
+              owner: 'gleanwork',
+              repo: 'api-client-typescript',
+              workflow_id: 'sdk_generation.yaml',
+              ref: 'main',
+              inputs: {
+                trigger_source: 'open-api-repo'
+              }
+            });
+            console.log('TypeScript client generation triggered:', result.status);
+
+      - name: Trigger Go Client SDK Generation
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.CLIENT_GENERATION_TOKEN }}
+          script: |
+            const result = await github.rest.actions.createWorkflowDispatch({
+              owner: 'gleanwork',
+              repo: 'api-client-go',
+              workflow_id: 'sdk_generation.yaml',
+              ref: 'main',
+              inputs: {
+                trigger_source: 'open-api-repo'
+              }
+            });
+            console.log('Go client generation triggered:', result.status);
+
+      - name: Trigger Java Client SDK Generation
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.CLIENT_GENERATION_TOKEN }}
+          script: |
+            const result = await github.rest.actions.createWorkflowDispatch({
+              owner: 'gleanwork',
+              repo: 'api-client-java',
+              workflow_id: 'sdk_generation.yaml',
+              ref: 'main',
+              inputs: {
+                trigger_source: 'open-api-repo'
+              }
+            });
+            console.log('Java client generation triggered:', result.status);
+
+      - name: Summary
+        run: |
+          echo "✅ All client SDK generation workflows have been triggered successfully!"
+          echo ""
+          echo "Triggered workflows:"
+          echo "- Python: https://github.com/gleanwork/api-client-python/actions"
+          echo "- TypeScript: https://github.com/gleanwork/api-client-typescript/actions"
+          echo "- Go: https://github.com/gleanwork/api-client-go/actions"
+          echo "- Java: https://github.com/gleanwork/api-client-java/actions"


### PR DESCRIPTION
This change introduces a GitHub Actions workflow that automatically triggers regeneration of the API Clients when the transform step completes (or when manually triggered).