### PR TITLE
feat(ci): Create GHA workflow to easily generate a OpenAPI diff report

### DIFF
--- a/.github/workflows/openapi-diff-report.yml
+++ b/.github/workflows/openapi-diff-report.yml
@@ -1,0 +1,45 @@
+name: OpenAPI Diff Report
+
+on:
+  pull_request:
+    paths:
+      - 'source_specs/**'
+      - 'src/**'
+  push:
+    branches:
+      - main
+    paths:
+      - 'source_specs/**'
+      - 'src/**'
+  workflow_dispatch:
+
+jobs:
+  generate-diff-report:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up mise
+        uses: jdx/mise-action@v2
+        with:
+          cache: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile --ignore-scripts
+
+      - name: Generate diff report
+        run: |
+          mkdir -p ./reports
+          pnpm diff-source-specs --report-file ./reports/index.html
+          echo "Report generated at: ./reports/changes-report.html"
+
+      - name: Upload HTML report as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: openapi-diff-report
+          path: ./reports/index.html
+          retention-days: 30

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ yarn.lock
 .speakeasy/temp
 .speakeasy/reports
 .speakeasy/logs
+/reports/

--- a/mise.toml
+++ b/mise.toml
@@ -2,3 +2,4 @@
 "aqua:speakeasy-api/speakeasy" = "latest"
 node = "20"
 pnpm = "10"
+"ubi:pb33f/openapi-changes" = "latest"

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "type": "module",
   "main": "src/index.js",
   "scripts": {
+    "diff-source-specs": "node src/diff-source-specs.js",
     "lint": "prettier --check . --ignore-unknown",
     "lint:fix": "prettier --write . --ignore-unknown",
     "test": "vitest run",
@@ -26,6 +27,7 @@
     "transform:merged_code_samples_specs": "node src/index.js --merged_code_samples_specs"
   },
   "dependencies": {
+    "execa": "^9.6.0",
     "js-yaml": "^4.1.0"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      execa:
+        specifier: ^9.6.0
+        version: 9.6.0
       js-yaml:
         specifier: ^4.1.0
         version: 4.1.0
@@ -266,8 +269,15 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@sec-ant/readable-stream@0.4.1':
+    resolution: {integrity: sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==}
+
   '@sinclair/typebox@0.27.8':
     resolution: {integrity: sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==}
+
+  '@sindresorhus/merge-streams@4.0.0':
+    resolution: {integrity: sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==}
+    engines: {node: '>=18'}
 
   '@types/estree@1.0.7':
     resolution: {integrity: sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ==}
@@ -353,6 +363,14 @@ packages:
     resolution: {integrity: sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==}
     engines: {node: '>=16.17'}
 
+  execa@9.6.0:
+    resolution: {integrity: sha512-jpWzZ1ZhwUmeWRhS7Qv3mhpOhLfwI+uAX4e5fOcXqwMR7EcJ0pj2kV1CVzHVMX/LphnKWD3LObjZCoJ71lKpHw==}
+    engines: {node: ^18.19.0 || >=20.5.0}
+
+  figures@6.1.0:
+    resolution: {integrity: sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==}
+    engines: {node: '>=18'}
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -365,13 +383,33 @@ packages:
     resolution: {integrity: sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==}
     engines: {node: '>=16'}
 
+  get-stream@9.0.1:
+    resolution: {integrity: sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==}
+    engines: {node: '>=18'}
+
   human-signals@5.0.0:
     resolution: {integrity: sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==}
     engines: {node: '>=16.17.0'}
 
+  human-signals@8.0.1:
+    resolution: {integrity: sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==}
+    engines: {node: '>=18.18.0'}
+
+  is-plain-obj@4.1.0:
+    resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
+    engines: {node: '>=12'}
+
   is-stream@3.0.0:
     resolution: {integrity: sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  is-stream@4.0.1:
+    resolution: {integrity: sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==}
+    engines: {node: '>=18'}
+
+  is-unicode-supported@2.1.0:
+    resolution: {integrity: sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==}
+    engines: {node: '>=18'}
 
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
@@ -415,12 +453,20 @@ packages:
     resolution: {integrity: sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
+  npm-run-path@6.0.0:
+    resolution: {integrity: sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==}
+    engines: {node: '>=18'}
+
   onetime@6.0.0:
     resolution: {integrity: sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==}
     engines: {node: '>=12'}
 
   p-limit@5.0.0:
     resolution: {integrity: sha512-/Eaoq+QyLSiXQ4lyYV23f14mZRQcXnxfHrN0vCai+ak9G0pp9iEQukIIZq5NccEvwRB8PUnZT0KsOoDCINS1qQ==}
+    engines: {node: '>=18'}
+
+  parse-ms@4.0.0:
+    resolution: {integrity: sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw==}
     engines: {node: '>=18'}
 
   path-key@3.1.1:
@@ -459,6 +505,10 @@ packages:
     resolution: {integrity: sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
+  pretty-ms@9.2.0:
+    resolution: {integrity: sha512-4yf0QO/sllf/1zbZWYnvWw3NxCQwLXKzIj0G849LSufP15BXKM0rbD2Z3wVnkMfjdn/CB0Dpp444gYAACdsplg==}
+    engines: {node: '>=18'}
+
   react-is@18.3.1:
     resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
 
@@ -496,6 +546,10 @@ packages:
     resolution: {integrity: sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==}
     engines: {node: '>=12'}
 
+  strip-final-newline@4.0.0:
+    resolution: {integrity: sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==}
+    engines: {node: '>=18'}
+
   strip-literal@2.1.1:
     resolution: {integrity: sha512-631UJ6O00eNGfMiWG78ck80dfBab8X6IVFB51jZK5Icd7XAs60Z5y7QdSd/wGIklnWvRbUNloVzhOKKmutxQ6Q==}
 
@@ -516,6 +570,10 @@ packages:
 
   ufo@1.6.1:
     resolution: {integrity: sha512-9a4/uxlTWJ4+a5i0ooc1rU7C7YOw3wT+UGqdeNNHWnOF9qcMBgLRS+4IYUqbczewFx4mLEig6gawh7X6mFlEkA==}
+
+  unicorn-magic@0.3.0:
+    resolution: {integrity: sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==}
+    engines: {node: '>=18'}
 
   vite-node@1.6.1:
     resolution: {integrity: sha512-YAXkfvGtuTzwWbDSACdJSg4A4DZiAqckWe90Zapc/sEX3XvHcw1NdurM/6od8J207tSDqNbSsgdCacBgvJKFuA==}
@@ -591,6 +649,10 @@ packages:
   yocto-queue@1.2.1:
     resolution: {integrity: sha512-AyeEbWOu/TAXdxlV9wmGcR0+yh2j3vYPGOECcIj2S7MkrLyC7ne+oye2BKTItt0ii2PHk4cDy+95+LshzbXnGg==}
     engines: {node: '>=12.20'}
+
+  yoctocolors@2.1.1:
+    resolution: {integrity: sha512-GQHQqAopRhwU8Kt1DDM8NjibDXHC8eoh1erhGAJPEyveY9qqVeXvVikNKrDz69sHowPMorbPUrH/mx8c50eiBQ==}
+    engines: {node: '>=18'}
 
 snapshots:
 
@@ -729,7 +791,11 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.41.1':
     optional: true
 
+  '@sec-ant/readable-stream@0.4.1': {}
+
   '@sinclair/typebox@0.27.8': {}
+
+  '@sindresorhus/merge-streams@4.0.0': {}
 
   '@types/estree@1.0.7': {}
 
@@ -850,6 +916,25 @@ snapshots:
       signal-exit: 4.1.0
       strip-final-newline: 3.0.0
 
+  execa@9.6.0:
+    dependencies:
+      '@sindresorhus/merge-streams': 4.0.0
+      cross-spawn: 7.0.6
+      figures: 6.1.0
+      get-stream: 9.0.1
+      human-signals: 8.0.1
+      is-plain-obj: 4.1.0
+      is-stream: 4.0.1
+      npm-run-path: 6.0.0
+      pretty-ms: 9.2.0
+      signal-exit: 4.1.0
+      strip-final-newline: 4.0.0
+      yoctocolors: 2.1.1
+
+  figures@6.1.0:
+    dependencies:
+      is-unicode-supported: 2.1.0
+
   fsevents@2.3.3:
     optional: true
 
@@ -857,9 +942,22 @@ snapshots:
 
   get-stream@8.0.1: {}
 
+  get-stream@9.0.1:
+    dependencies:
+      '@sec-ant/readable-stream': 0.4.1
+      is-stream: 4.0.1
+
   human-signals@5.0.0: {}
 
+  human-signals@8.0.1: {}
+
+  is-plain-obj@4.1.0: {}
+
   is-stream@3.0.0: {}
+
+  is-stream@4.0.1: {}
+
+  is-unicode-supported@2.1.0: {}
 
   isexe@2.0.0: {}
 
@@ -901,6 +999,11 @@ snapshots:
     dependencies:
       path-key: 4.0.0
 
+  npm-run-path@6.0.0:
+    dependencies:
+      path-key: 4.0.0
+      unicorn-magic: 0.3.0
+
   onetime@6.0.0:
     dependencies:
       mimic-fn: 4.0.0
@@ -908,6 +1011,8 @@ snapshots:
   p-limit@5.0.0:
     dependencies:
       yocto-queue: 1.2.1
+
+  parse-ms@4.0.0: {}
 
   path-key@3.1.1: {}
 
@@ -940,6 +1045,10 @@ snapshots:
       '@jest/schemas': 29.6.3
       ansi-styles: 5.2.0
       react-is: 18.3.1
+
+  pretty-ms@9.2.0:
+    dependencies:
+      parse-ms: 4.0.0
 
   react-is@18.3.1: {}
 
@@ -987,6 +1096,8 @@ snapshots:
 
   strip-final-newline@3.0.0: {}
 
+  strip-final-newline@4.0.0: {}
+
   strip-literal@2.1.1:
     dependencies:
       js-tokens: 9.0.1
@@ -1000,6 +1111,8 @@ snapshots:
   type-detect@4.1.0: {}
 
   ufo@1.6.1: {}
+
+  unicorn-magic@0.3.0: {}
 
   vite-node@1.6.1:
     dependencies:
@@ -1069,3 +1182,5 @@ snapshots:
       stackback: 0.0.2
 
   yocto-queue@1.2.1: {}
+
+  yoctocolors@2.1.1: {}

--- a/src/diff-source-specs.js
+++ b/src/diff-source-specs.js
@@ -1,0 +1,123 @@
+#!/usr/bin/env node
+
+import { mkdtemp, writeFile, mkdir } from 'fs/promises';
+import { execa } from 'execa';
+import { dirname, join } from 'path';
+import { tmpdir } from 'os';
+import { parseArgs } from 'util';
+
+const USAGE = `
+📊 OpenAPI Changes Report Generator
+
+Usage: node download-and-openapi-changes.js [options]
+
+Options:
+  --open        Open the HTML report after generation
+  --report-file Custom location for the report (default: temp directory)
+  --help, -h    Show this help message
+
+Examples:
+  node download-and-openapi-changes.js
+  node download-and-openapi-changes.js --open
+  node download-and-openapi-changes.js --report-file ./reports
+
+This script downloads the remote OpenAPI spec and compares it with your local
+source_specs/client_rest.yaml file, generating an HTML diff report.
+`;
+
+function showUsage() {
+  console.log(USAGE);
+}
+
+async function downloadAndDiff(options = {}) {
+  const remoteUrl =
+    'https://gleanwork.github.io/open-api/specs/source/client_rest.yaml';
+  const localFile = 'source_specs/client_rest.yaml';
+
+  try {
+    const tempDir = await mkdtemp(join(tmpdir(), 'changes-report-'));
+    const reportFile =
+      options.reportFile || join(tempDir, 'changes-report.hml');
+    const outputDir = dirname(reportFile);
+    await mkdir(outputDir, { recursive: true });
+    await mkdir(tempDir, { recursive: true });
+
+    console.log('📥 Downloading remote file...');
+    const response = await fetch(remoteUrl);
+
+    if (!response.ok) {
+      throw new Error(
+        `Failed to download: ${response.status} ${response.statusText}`,
+      );
+    }
+
+    const content = await response.text();
+    const tempFile = join(tempDir, 'client_rest.yaml');
+
+    await writeFile(tempFile, content);
+    console.log(`✅ Downloaded to: ${tempFile}`);
+
+    console.log('🚀 Running openapi-changes html-report...');
+    await execa(
+      'openapi-changes',
+      [
+        'html-report',
+        '--no-logo',
+        tempFile,
+        localFile,
+        '--report-file',
+        reportFile,
+      ],
+      { stdio: 'inherit' },
+    );
+
+    console.log(`\n✨ Process finished successfully`);
+    console.log(`📄 Report written to: ${reportFile}`);
+
+    if (options.open) {
+      try {
+        console.log('🌐 Opening report...');
+        await execa('open', [reportFile]);
+      } catch (error) {
+        console.log(`ℹ️  Could not auto-open report: ${error.message}`);
+        console.log(`   You can manually open: ${reportFile}`);
+      }
+    }
+  } catch (error) {
+    console.error('❌ Error:', error.message);
+    process.exit(1);
+  }
+}
+
+try {
+  const { values } = parseArgs({
+    options: {
+      open: {
+        type: 'boolean',
+        short: 'o',
+      },
+      'report-file': {
+        type: 'string',
+      },
+      help: {
+        type: 'boolean',
+        short: 'h',
+      },
+    },
+    allowPositionals: false,
+  });
+
+  if (values.help) {
+    showUsage();
+    process.exit(0);
+  }
+
+  downloadAndDiff({
+    open: values.open,
+    reportFile: values['report-file'],
+  });
+} catch (error) {
+  console.error(`❌ ${error.message}\n`);
+  showUsage();
+  process.exit(1);
+}


### PR DESCRIPTION
The new workflow will upload a full diff report showing the diff between the current value of `source_specs/client_rest.yaml` and the value of `source_specs/client_rest.yaml` as of the *last time* that we deployed updates of the OpenAPI specs to `developers.glean.com`.

