### PR TITLE
feat(overlay): apply corrections

### DIFF
--- a/.speakeasy/workflow.yaml
+++ b/.speakeasy/workflow.yaml
@@ -28,6 +28,7 @@ sources:
             - location: overlays/client-modifications-overlay.yaml
             - location: overlays/agent-modifications-overlay.yaml
             - location: overlays/admin-modifications-overlay.yaml
+            - location: overlays/corrections.yaml
         output: overlayed_specs/glean-client-api-specs.yaml
     glean-client-merged-code-samples-spec:
         inputs:

--- a/overlays/corrections.yaml
+++ b/overlays/corrections.yaml
@@ -1,0 +1,28 @@
+overlay: 1.0.0
+x-speakeasy-jsonpath: rfc9535
+info:
+  title: fix known issues overlay
+  version: 0.0.0
+actions:
+  # Related documents can come back with lower-case values depending on the
+  # source.  Add the lower-case cases to avoid runtime validation issues.
+  - target: $["components"]["schemas"]["RelatedDocuments"]["properties"]["relation"]["enum"][*]
+    remove: true
+  - target: $["components"]["schemas"]["RelatedDocuments"]["properties"]["relation"]["enum"]
+    update:
+      - ATTACHMENT
+      - CANONICAL
+      - CASE
+      - contact
+      - CONTACT
+      - CONVERSATION_MESSAGES
+      - EXPERT
+      - FROM
+      - HIGHLIGHT
+      - opportunity
+      - OPPORTUNITY
+      - RECENT
+      - SOURCE
+      - TICKET
+      - TRANSCRIPT
+      - WITH


### PR DESCRIPTION
The API runtime does not fully conform to the source OpenAPI specs.  Add a corrections overlay to apply targeted transformations to fix known inconsistencies so that the generated API clients will not fail runtime validation.

In particular, related documents can be returned with a relation enum value of `contact` rather than `CONTACT` and `opportunity` rather than `OPPORTUNITY`.
