### PR TITLE
fix(corrections)

### DIFF
--- a/.speakeasy/workflow.yaml
+++ b/.speakeasy/workflow.yaml
@@ -14,6 +14,7 @@ sources:
             - location: overlays/indexing-modifications-overlay.yaml
             - location: overlays/agent-modifications-overlay.yaml
             - location: overlays/admin-modifications-overlay.yaml
+            - location: overlays/corrections.yaml
         output: overlayed_specs/glean-merged-spec.yaml
         registry:
             location: registry.speakeasyapi.dev/glean-el2/sdk/glean-api-specs


### PR DESCRIPTION
Apply overlay to glean-api-specs as well as glean-client-api-specs.

The former is used for api client generation and the latter is used for code samples.
