### PR TITLE
feat: Add transformation for `x-enumDescriptions`

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,13 +140,22 @@ The processing follows this sequence:
 The transformation script processes OpenAPI YAML specification files by:
 
 1. Reading files from the `source_specs/` directory
-2. Moving the server URL subpath to each individual API path
+2. Applying various transformations to prepare specs for Speakeasy SDK generation
 3. Writing the transformed files to the `generated_specs/` directory
 
 This script performs the following transformations:
 
-- **Before**: `servers.url = "https://{domain}-be.glean.com/rest/api/v1"`, `path = "/activity"`
-- **After**: `servers.url = "https://{domain}-be.glean.com/"`, `path = "/rest/api/v1/activity"`
+- **Path normalization**: Moves server URL subpaths to individual API paths
+  - **Before**: `servers.url = "https://{domain}-be.glean.com/rest/api/v1"`, `path = "/activity"`
+  - **After**: `servers.url = "https://{domain}-be.glean.com/"`, `path = "/rest/api/v1/activity"`
+
+- **Server variables**: Renames `{domain}` to `{instance}` in server URLs and variables
+
+- **Security schemes**: Transforms `BearerAuth` to `APIToken` for consistency
+
+- **Enum descriptions**: Converts `x-enumDescriptions` to `x-speakeasy-enum-descriptions` for Speakeasy compatibility
+
+- **Component renaming**: Renames `Shortcut` to `IndexingShortcut` in indexing.yaml to avoid conflicts
 
 ## Output
 


### PR DESCRIPTION
Speakeasy requires enum descriptions to use
`x-speakeasy-enum-descriptions` instead of the generic `x-enumDescriptions` extension property.

See: https://www.speakeasy.com/docs/sdks/customize/data-model/enums#enum-value-descriptions

I don't think we can use an OpenAPI Overlay for this transformation because overlays do not support copying property values dynamically. The overlay spec only allows static values in update actions, not references to existing property values (e.g., we cannot do
`x-speakeasy-enum-descriptions: "$(@.x-enumDescriptions)"`).