### PR TITLE
fix(ci): Avoid SHA only churn for API Client generation.

### DIFF
--- a/.github/workflows/transform.yml
+++ b/.github/workflows/transform.yml
@@ -58,7 +58,63 @@ jobs:
       - name: Run post-transformation smoke tests
         run: pnpm exec vitest run tests/post_transform_smoke.test.js
 
+      - name: Check if changes are only SHA updates
+        id: check_changes
+        run: |
+          # Check if there are any changes at all
+          STATUS=$(git status --porcelain generated_specs/ overlayed_specs/ 2>/dev/null)
+          if [ -z "$STATUS" ]; then
+            echo "has_changes=false" >> $GITHUB_OUTPUT
+            echo "No changes to commit"
+            exit 0
+          fi
+
+          echo "::group::Changed files"
+          echo "$STATUS"
+          echo "::endgroup::"
+
+          # Check for new/untracked files (lines starting with ??)
+          NEW_FILES=$(echo "$STATUS" | grep "^??" | wc -l)
+          if [ "$NEW_FILES" -gt 0 ]; then
+            echo "has_changes=true" >> $GITHUB_OUTPUT
+            echo "New files detected, will commit"
+            exit 0
+          fi
+
+          # Get the diff and check if only SHA lines changed (for modified files)
+          DIFF=$(git diff --unified=0 generated_specs/ overlayed_specs/)
+
+          echo "::group::Git diff"
+          echo "$DIFF"
+          echo "::endgroup::"
+
+          # Extract only the actual content changes (lines starting with + or -)
+          # Exclude file markers (+++/---), hunk headers (@@), and get only content
+          CHANGED_LINES=$(echo "$DIFF" | grep -E "^[\+\-]" | grep -v "^[\+\-][\+\-][\+\-]" | grep -v "^@@" || true)
+
+          if [ -z "$CHANGED_LINES" ]; then
+            echo "has_changes=false" >> $GITHUB_OUTPUT
+            echo "No actual content changes detected"
+            exit 0
+          fi
+
+          # Check if all changes are SHA-related
+          NON_SHA_CHANGES=$(echo "$CHANGED_LINES" | grep -v "x-source-commit-sha" | grep -v "x-open-api-commit-sha" || true)
+
+          echo "::group::Non-SHA changes"
+          echo "$NON_SHA_CHANGES"
+          echo "::endgroup::"
+
+          if [ -z "$NON_SHA_CHANGES" ]; then
+            echo "has_changes=false" >> $GITHUB_OUTPUT
+            echo "Only SHA fields changed, skipping commit"
+          else
+            echo "has_changes=true" >> $GITHUB_OUTPUT
+            echo "Non-SHA changes detected, will commit"
+          fi
+
       - name: Commit changes
+        if: steps.check_changes.outputs.has_changes == 'true'
         uses: ./.github/actions/git-commit
         with:
           commit_message: |


### PR DESCRIPTION
When source specs are re-processed without actual content changes, the generated files only differ in their `x-source-commit-sha` and `x-open-api-commit-sha` metadata fields. This basically makes the API client generation unstable (because the `x-source-commit-sha` changes **ALL THE TIME**).

Adds a check as part of the `transform.yml` workflow that uses `git status --porcelain` and diff analysis to detect SHA-only changes and skip the commit step when appropriate. This will prevent the knock on CI tasks from running -- stabilizing the API client generation.

See https://github.com/gleanwork/open-api/pull/61 and https://github.com/gleanwork/open-api/pull/62 for more context.