### PR TITLE
Honor path-level servers when prefixing path keys

### DIFF
--- a/src/source-spec-transformer.js
+++ b/src/source-spec-transformer.js
@@ -196,23 +196,35 @@ export function transformActAsBearerTokenToAPIToken(spec) {
  * @returns {Object} Transformed spec object
  */
 export function transformServerVariables(spec) {
-  if (!spec.servers || !Array.isArray(spec.servers)) {
-    return spec;
-  }
-
-  for (const server of spec.servers) {
-    if (server.url) {
-      server.url = server.url.replace(/{domain}/g, '{instance}');
+  const updateServers = (servers) => {
+    if (!Array.isArray(servers)) {
+      return;
     }
 
-    if (server.variables && server.variables.domain) {
-      server.variables.instance = {
-        default: 'instance-name',
-        description:
-          'The instance name (typically the email domain without the TLD) that determines the deployment backend.',
-      };
+    for (const server of servers) {
+      if (server.url) {
+        server.url = server.url.replace(/{domain}/g, '{instance}');
+      }
 
-      delete server.variables.domain;
+      if (server.variables && server.variables.domain) {
+        server.variables.instance = {
+          default: 'instance-name',
+          description:
+            'The instance name (typically the email domain without the TLD) that determines the deployment backend.',
+        };
+
+        delete server.variables.domain;
+      }
+    }
+  };
+
+  updateServers(spec.servers);
+
+  if (spec.paths) {
+    for (const pathValue of Object.values(spec.paths)) {
+      if (pathValue && typeof pathValue === 'object') {
+        updateServers(pathValue.servers);
+      }
     }
   }
 
@@ -551,7 +563,28 @@ export function transform(content, filename, commitSha) {
     for (const [pathKey, pathValue] of Object.entries(spec.paths)) {
       const normalizedPath = pathKey.startsWith('/') ? pathKey : `/${pathKey}`;
 
-      const newPathKey = `${basePath}${normalizedPath}`;
+      // Honor path-level `servers:` blocks. When a path declares its own server,
+      // its basePath is the prefix that should appear in the final path key —
+      // not the global basePath. We also strip that basePath from the path-level
+      // server URL so that `pathServer.url + pathKey` composes the correct full
+      // URL (matching the convention used for the global server).
+      let pathBasePath = basePath;
+      if (Array.isArray(pathValue?.servers) && pathValue.servers.length > 0) {
+        const firstPathServerUrl = pathValue.servers[0].url;
+        if (firstPathServerUrl) {
+          const candidate = extractBasePath(firstPathServerUrl);
+          if (candidate) {
+            pathBasePath = candidate;
+            for (const pathServer of pathValue.servers) {
+              if (pathServer.url) {
+                pathServer.url = pathServer.url.replace(candidate, '');
+              }
+            }
+          }
+        }
+      }
+
+      const newPathKey = `${pathBasePath}${normalizedPath}`;
       newPaths[newPathKey] = pathValue;
     }
     spec.paths = newPaths;

--- a/tests/fixtures/path-level-servers.yaml
+++ b/tests/fixtures/path-level-servers.yaml
@@ -1,0 +1,25 @@
+openapi: 3.0.0
+info:
+  title: Path-Level Servers Test Fixture
+  version: 0.0.1
+servers:
+  - url: https://{domain}-be.glean.com/api/index/v1
+    variables:
+      domain:
+        default: domain
+paths:
+  /indexdocument:
+    post:
+      responses:
+        "200":
+          description: OK
+  /document/{docId}/custom-metadata/{groupName}:
+    servers:
+      - url: https://{domain}-be.glean.com/rest/api/index
+        variables:
+          domain:
+            default: domain
+    put:
+      responses:
+        "200":
+          description: OK

--- a/tests/fixtures/path-level-servers.yaml
+++ b/tests/fixtures/path-level-servers.yaml
@@ -11,7 +11,7 @@ paths:
   /indexdocument:
     post:
       responses:
-        "200":
+        '200':
           description: OK
   /document/{docId}/custom-metadata/{groupName}:
     servers:
@@ -21,5 +21,5 @@ paths:
             default: domain
     put:
       responses:
-        "200":
+        '200':
           description: OK

--- a/tests/source-spec-transformer.test.js
+++ b/tests/source-spec-transformer.test.js
@@ -182,8 +182,7 @@ describe('OpenAPI YAML Transformer', () => {
 
     // The path-level server URL has its basePath stripped, so server.url + pathKey
     // composes the correct full URL (no doubled prefix).
-    const pathLevelServers =
-      transformedSpec.paths[customMetadataKey].servers;
+    const pathLevelServers = transformedSpec.paths[customMetadataKey].servers;
     expect(pathLevelServers[0].url).toBe('https://{instance}-be.glean.com');
 
     // Top-level server URL is also stripped of its global basePath.

--- a/tests/source-spec-transformer.test.js
+++ b/tests/source-spec-transformer.test.js
@@ -18,6 +18,11 @@ function readFixture(filename) {
   return fs.readFileSync(sourceFile, 'utf8');
 }
 
+function readTestFixture(filename) {
+  const sourceFile = path.join(process.cwd(), 'tests', 'fixtures', filename);
+  return fs.readFileSync(sourceFile, 'utf8');
+}
+
 describe('OpenAPI YAML Transformer', () => {
   test('extractBasePath extracts path correctly', () => {
     expect(extractBasePath('https://{domain}-be.glean.com/rest/api/v1')).toBe(
@@ -158,6 +163,37 @@ describe('OpenAPI YAML Transformer', () => {
         Object.keys(originalOperation.responses),
       );
     }
+  });
+
+  test('honors path-level servers when prefixing path keys', () => {
+    const sourceYaml = readTestFixture('path-level-servers.yaml');
+    const transformedSpec = yaml.load(transform(sourceYaml, 'indexing.yaml'));
+
+    // Global-server path keeps the global basePath prefix.
+    expect(transformedSpec.paths).toHaveProperty('/api/index/v1/indexdocument');
+
+    // Path-level-server path is prefixed with its OWN basePath, not the global one.
+    const customMetadataKey =
+      '/rest/api/index/document/{docId}/custom-metadata/{groupName}';
+    expect(transformedSpec.paths).toHaveProperty(customMetadataKey);
+    expect(transformedSpec.paths).not.toHaveProperty(
+      '/api/index/v1/document/{docId}/custom-metadata/{groupName}',
+    );
+
+    // The path-level server URL has its basePath stripped, so server.url + pathKey
+    // composes the correct full URL (no doubled prefix).
+    const pathLevelServers =
+      transformedSpec.paths[customMetadataKey].servers;
+    expect(pathLevelServers[0].url).toBe('https://{instance}-be.glean.com');
+
+    // Top-level server URL is also stripped of its global basePath.
+    expect(transformedSpec.servers[0].url).toBe(
+      'https://{instance}-be.glean.com',
+    );
+
+    // {domain} → {instance} variable rename applies to path-level servers too.
+    expect(pathLevelServers[0].variables).toHaveProperty('instance');
+    expect(pathLevelServers[0].variables).not.toHaveProperty('domain');
   });
 
   test('transformShortcutComponent renames Shortcut to IndexingShortcut', () => {


### PR DESCRIPTION
## Summary

- `transform()` previously prepended the global server's basePath to every path key, even when a path declared its own `servers:` block. With OpenAPI's path-level-server-wins resolution rule, `pathServer.url + pathKey` then composed a doubled prefix (e.g. `/rest/api/index` + `/api/index/v1/document/...`), surfacing as a wrong URL in Redoc, Speakeasy SDKs, and any "Try it" widget.
- The transformer now derives the prefix from a path's own `servers:` block when one is present, and strips that basePath from the path-level server URL so the composed URL matches the global-server convention.
- `transformServerVariables` extended to apply `{domain}` → `{instance}` to path-level servers as well, so the rename is consistent.

## Why now

The Custom Metadata API endpoints (currently `x-internal: true`) live under `/rest/api/index` rather than the indexing API's main `/api/index/v1`. Those endpoints are slated for GA in a follow-up PR; without this fix the published path keys and SDK URLs would be wrong.

No existing fixture in `source_specs/` has a path-level `servers:` block, so no behavior changes for current specs — verified by the existing 54 tests still passing.

## Test plan

- [x] `pnpm test` — all 55 tests pass (added one new test `honors path-level servers when prefixing path keys` backed by `tests/fixtures/path-level-servers.yaml`)
- [x] Manual sanity check: piped a synthetic spec with a path-level server through `transform()` and confirmed:
  - Path key becomes `/rest/api/index/document/...` (its own basePath, not the global one)
  - Path-level server URL stripped to `https://{instance}-be.glean.com`
  - `{domain}` → `{instance}` propagated through to path-level server variables
