### PR TITLE
[NI][SDK] Add platform API generation input

### DIFF
--- a/.speakeasy/workflow.lock
+++ b/.speakeasy/workflow.lock
@@ -2,8 +2,8 @@ speakeasyVersion: 1.762.0
 sources:
     glean-api-specs:
         sourceNamespace: glean-api-specs
-        sourceRevisionDigest: sha256:e6cb5e22bf01b22978f30cf12b0a18ab2ea32a3e82e60e86cca2e0435b0e26f4
-        sourceBlobDigest: sha256:47cb8217e6566bb90d49ae324de9bf0ac1132afcc81b8316dc58fa225b31d9d1
+        sourceRevisionDigest: sha256:9e0e82f4589f04f6a8ad2a8a1b066b9ac22f283c3bb02ef75559a664ffaa5dbb
+        sourceBlobDigest: sha256:af0d1e5abfefc7985028476911e56c015d9b99e67e30fd740e1b14b877b20296
         tags:
             - latest
             - main

--- a/.speakeasy/workflow.lock
+++ b/.speakeasy/workflow.lock
@@ -52,6 +52,7 @@ workflow:
     sources:
         glean-api-specs:
             inputs:
+                - location: generated_specs/platform.yaml
                 - location: generated_specs/client_rest.yaml
                 - location: generated_specs/indexing.yaml
                 - location: generated_specs/admin_rest.yaml

--- a/.speakeasy/workflow.yaml
+++ b/.speakeasy/workflow.yaml
@@ -3,6 +3,7 @@ speakeasyVersion: latest
 sources:
     glean-api-specs:
         inputs:
+            - location: generated_specs/platform.yaml
             - location: generated_specs/client_rest.yaml
             - location: generated_specs/indexing.yaml
             - location: generated_specs/admin_rest.yaml

--- a/generated_specs/platform.yaml
+++ b/generated_specs/platform.yaml
@@ -22,7 +22,6 @@ paths:
       operationId: platform-search
       x-visibility: Public
       x-glean-experimental:
-        gated-by: platform.apiSearchEnabled
         id: 5ab612fc-ed50-4419-bec3-e5fe83934653
         introduced: "2026-04-08"
       x-codegen-request-body-name: payload

--- a/generated_specs/platform.yaml
+++ b/generated_specs/platform.yaml
@@ -19,7 +19,7 @@ paths:
       summary: Search
       description: |
         Execute a search query and retrieve ranked results. This is the data retrieval variant of the search API and returns only results and pagination state.
-      operationId: platform-search-query
+      operationId: platform-search
       x-visibility: Public
       x-glean-experimental:
         gated-by: platform.apiSearchEnabled

--- a/generated_specs/platform.yaml
+++ b/generated_specs/platform.yaml
@@ -1,0 +1,341 @@
+openapi: 3.0.0
+info:
+  version: "2026-04-01"
+  title: Glean Platform API
+  x-source-commit-sha: __SCIO_COMMIT_SHA__
+servers:
+  - url: https://{instance}-be.glean.com
+    variables:
+      instance:
+        default: instance-name
+        description: The instance name (typically the email domain without the TLD) that determines the deployment backend.
+security:
+  - APIToken: []
+paths:
+  /api/search:
+    post:
+      tags:
+        - Search
+      summary: Search
+      description: |
+        Execute a search query and retrieve ranked results. This is the data retrieval variant of the search API and returns only results and pagination state.
+      operationId: platform-search-query
+      x-visibility: Public
+      x-glean-experimental:
+        gated-by: platform.apiSearchEnabled
+        id: 5ab612fc-ed50-4419-bec3-e5fe83934653
+        introduced: "2026-04-08"
+      x-codegen-request-body-name: payload
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PlatformSearchRequest"
+      responses:
+        "200":
+          description: Successful search.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlatformSearchResponse"
+        "400":
+          $ref: "#/components/responses/PlatformBadRequest"
+        "401":
+          $ref: "#/components/responses/PlatformUnauthorized"
+        "403":
+          $ref: "#/components/responses/PlatformForbidden"
+        "404":
+          $ref: "#/components/responses/PlatformNotFound"
+        "408":
+          $ref: "#/components/responses/PlatformRequestTimeout"
+        "429":
+          $ref: "#/components/responses/PlatformTooManyRequests"
+        "500":
+          $ref: "#/components/responses/PlatformInternalServerError"
+        "503":
+          $ref: "#/components/responses/PlatformServiceUnavailable"
+      x-speakeasy-group: platform.search
+      x-speakeasy-name-override: query
+components:
+  securitySchemes:
+    APIToken:
+      type: http
+      scheme: bearer
+      description: |
+        Glean API token. Obtain via Admin Console -> Platform -> API Tokens, or via OAuth 2.0 client credentials flow.
+  schemas:
+    PlatformFilter:
+      type: object
+      required:
+        - field
+        - values
+      description: |
+        A single filter criterion. Multiple values within a filter are OR'd. Filters are AND'd with each other and with any inline query operators.
+      properties:
+        field:
+          type: string
+          description: |
+            The field to filter on. Accepts built-in operator names such as `type`, `owner`, `from`, `author`, `channel`, `status`, `assignee`, `reporter`, `component`, `mentions`, and `collection`, plus custom datasource property names.
+          example: type
+        values:
+          type: array
+          minItems: 1
+          items:
+            type: string
+          description: One or more values to match.
+          example:
+            - spreadsheet
+            - presentation
+        exclude:
+          type: boolean
+          default: false
+          description: Excludes results matching any of the specified values when true.
+    PlatformTimeRange:
+      type: object
+      description: Filter results to those last updated within this range.
+      properties:
+        start:
+          type: string
+          format: date-time
+          description: Inclusive lower bound in ISO 8601 format.
+        end:
+          type: string
+          format: date-time
+          description: Exclusive upper bound in ISO 8601 format.
+    PlatformSearchRequest:
+      type: object
+      additionalProperties: false
+      required:
+        - query
+      properties:
+        query:
+          type: string
+          description: |
+            The search query string. Supports inline operators such as `from:jane type:document app:confluence`. Inline operators are AND'd with structured `filters`.
+          example: quarterly planning 2026
+        page_size:
+          type: integer
+          minimum: 1
+          maximum: 100
+          default: 10
+          description: Number of results to return per page.
+        cursor:
+          type: string
+          nullable: true
+          description: |
+            Opaque pagination token from a previous response's `next_cursor` field. Omit on the first request.
+        datasources:
+          type: array
+          items:
+            type: string
+          description: Restrict results to specific datasources.
+          example:
+            - confluence
+            - google_drive
+        filters:
+          type: array
+          items:
+            $ref: "#/components/schemas/PlatformFilter"
+          description: |
+            Structured filters applied to search results. Multiple values within a filter are OR'd. Multiple filters are AND'd together. Filters are AND'd with any inline operators in `query`. Note that conflicting constraints on the same field (e.g., `type:document` in the query and `type: spreadsheet` in a filter) produce an empty result set.
+        time_range:
+          $ref: "#/components/schemas/PlatformTimeRange"
+    PlatformPerson:
+      type: object
+      nullable: true
+      description: A person associated with the result.
+      properties:
+        name:
+          type: string
+          description: Display name.
+          example: Jane Smith
+        email:
+          type: string
+          format: email
+          description: Email address.
+          example: jane.smith@company.com
+    PlatformResult:
+      type: object
+      required:
+        - url
+        - title
+        - datasource
+      properties:
+        url:
+          type: string
+          format: uri
+          description: Canonical URL of the result.
+          example: https://company.atlassian.net/wiki/spaces/ENG/pages/12345
+        title:
+          type: string
+          description: Result title.
+          example: Q2 2026 Platform Roadmap
+        snippets:
+          type: array
+          items:
+            type: string
+          description: Query-relevant plain-text excerpts from the result body.
+          example:
+            - The platform team will focus on API stability and...
+        datasource:
+          type: string
+          description: The datasource this result originates from.
+          example: confluence
+        document_type:
+          type: string
+          nullable: true
+          description: The document type within the datasource.
+          example: page
+        creator:
+          $ref: "#/components/schemas/PlatformPerson"
+        owner:
+          $ref: "#/components/schemas/PlatformPerson"
+        updated_at:
+          type: string
+          format: date-time
+          nullable: true
+          description: When the result was last modified.
+        created_at:
+          type: string
+          format: date-time
+          nullable: true
+          description: When the result was created.
+    PlatformSearchResponse:
+      type: object
+      required:
+        - results
+        - has_more
+        - next_cursor
+        - request_id
+      properties:
+        results:
+          type: array
+          items:
+            $ref: "#/components/schemas/PlatformResult"
+          description: Ordered list of search results.
+        has_more:
+          type: boolean
+          description: Indicates whether additional pages of results are available.
+        next_cursor:
+          type: string
+          nullable: true
+          description: Opaque token to pass as `cursor` in the next request.
+        request_id:
+          type: string
+          description: Platform-generated request ID for support correlation.
+    PlatformProblemDetail:
+      type: object
+      required:
+        - type
+        - title
+        - status
+        - detail
+        - code
+        - request_id
+      description: |
+        Error response following RFC 9457, extended with `code` and `documentation_url` for machine-readable classification and self-service remediation.
+      properties:
+        type:
+          type: string
+          format: uri
+          description: URI identifying the error type.
+          example: https://developer.glean.com/errors/invalid-cursor
+        title:
+          type: string
+          description: Short, human-readable summary of the error.
+          example: Invalid Pagination Cursor
+        status:
+          type: integer
+          description: HTTP status code mirrored from the response.
+          example: 400
+        detail:
+          type: string
+          description: Human-readable explanation specific to this occurrence.
+          example: |
+            The provided cursor has expired. Start a new search to get a fresh cursor.
+        code:
+          type: string
+          description: Stable machine-readable error code.
+          enum:
+            - invalid_request
+            - missing_required_field
+            - invalid_parameter
+            - invalid_cursor
+            - expired_cursor
+            - invalid_filter
+            - authentication_required
+            - token_expired
+            - insufficient_permissions
+            - resource_not_found
+            - request_timeout
+            - conflict
+            - gone
+            - unprocessable_query
+            - rate_limit_exceeded
+            - internal_error
+            - service_unavailable
+          example: invalid_cursor
+        documentation_url:
+          type: string
+          format: uri
+          description: Direct URL to documentation for this error code.
+          example: https://developer.glean.com/errors/invalid-cursor
+        request_id:
+          type: string
+          description: Platform-generated request ID for support correlation.
+          example: req_7f8a9b0c1d2e
+  responses:
+    PlatformBadRequest:
+      description: Invalid request (malformed JSON, invalid parameter values, unknown fields).
+      content:
+        application/problem+json:
+          schema:
+            $ref: "#/components/schemas/PlatformProblemDetail"
+    PlatformUnauthorized:
+      description: Missing or invalid authentication token.
+      content:
+        application/problem+json:
+          schema:
+            $ref: "#/components/schemas/PlatformProblemDetail"
+    PlatformForbidden:
+      description: Token valid but lacks permission for the requested operation.
+      content:
+        application/problem+json:
+          schema:
+            $ref: "#/components/schemas/PlatformProblemDetail"
+    PlatformNotFound:
+      description: Resource not found.
+      content:
+        application/problem+json:
+          schema:
+            $ref: "#/components/schemas/PlatformProblemDetail"
+    PlatformRequestTimeout:
+      description: Backend did not respond within the timeout window.
+      content:
+        application/problem+json:
+          schema:
+            $ref: "#/components/schemas/PlatformProblemDetail"
+    PlatformTooManyRequests:
+      description: Rate limit exceeded. Includes Retry-After header.
+      content:
+        application/problem+json:
+          schema:
+            $ref: "#/components/schemas/PlatformProblemDetail"
+    PlatformInternalServerError:
+      description: Unexpected server-side failure.
+      content:
+        application/problem+json:
+          schema:
+            $ref: "#/components/schemas/PlatformProblemDetail"
+    PlatformServiceUnavailable:
+      description: Backend temporarily unavailable.
+      content:
+        application/problem+json:
+          schema:
+            $ref: "#/components/schemas/PlatformProblemDetail"
+x-tagGroups:
+  - name: Data Retrieval
+    tags:
+      - Search
+      - Tools

--- a/generated_specs/platform.yaml
+++ b/generated_specs/platform.yaml
@@ -12,6 +12,54 @@ servers:
 security:
   - APIToken: []
 paths:
+  /api/tools:
+    get:
+      tags:
+        - Tools
+      summary: List tools
+      description: |
+        List tools available to the authenticated user, optionally filtered by tool name.
+      operationId: platform-tools-list
+      x-visibility: Public
+      x-glean-experimental:
+        id: 3cb43a04-ad52-4c25-be62-3ce1daffd513
+        introduced: "2026-05-06"
+      parameters:
+        - in: query
+          name: tool_names
+          description: Optional comma-delimited list of tool names to return.
+          required: false
+          style: form
+          explode: false
+          schema:
+            type: array
+            items:
+              type: string
+      responses:
+        "200":
+          description: Successful response.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlatformToolsListResponse"
+        "400":
+          $ref: "#/components/responses/PlatformBadRequest"
+        "401":
+          $ref: "#/components/responses/PlatformUnauthorized"
+        "403":
+          $ref: "#/components/responses/PlatformForbidden"
+        "404":
+          $ref: "#/components/responses/PlatformNotFound"
+        "408":
+          $ref: "#/components/responses/PlatformRequestTimeout"
+        "429":
+          $ref: "#/components/responses/PlatformTooManyRequests"
+        "500":
+          $ref: "#/components/responses/PlatformInternalServerError"
+        "503":
+          $ref: "#/components/responses/PlatformServiceUnavailable"
+      x-speakeasy-group: platform.tools
+      x-speakeasy-name-override: list
   /api/search:
     post:
       tags:
@@ -64,6 +112,143 @@ components:
       description: |
         Glean API token. Obtain via Admin Console -> Platform -> API Tokens, or via OAuth 2.0 client credentials flow.
   schemas:
+    PlatformToolParameter:
+      type: object
+      properties:
+        type:
+          type: string
+          description: Parameter type.
+          enum:
+            - string
+            - number
+            - boolean
+            - object
+            - array
+        name:
+          type: string
+          description: Parameter name.
+        description:
+          type: string
+          description: Parameter description.
+        is_required:
+          type: boolean
+          description: Whether the parameter is required.
+        possible_values:
+          type: array
+          description: Possible primitive values for the parameter.
+          items:
+            type: string
+        items:
+          $ref: "#/components/schemas/PlatformToolParameter"
+        properties:
+          type: object
+          description: Object properties for object parameters.
+          additionalProperties:
+            $ref: "#/components/schemas/PlatformToolParameter"
+    PlatformTool:
+      type: object
+      required:
+        - type
+        - name
+        - display_name
+        - description
+        - parameters
+      properties:
+        type:
+          type: string
+          description: Type of tool.
+          enum:
+            - READ
+            - WRITE
+        name:
+          type: string
+          description: Unique identifier for the tool.
+        display_name:
+          type: string
+          description: Human-readable name.
+        description:
+          type: string
+          description: LLM-friendly description of the tool.
+        parameters:
+          type: object
+          description: Parameters supported by the tool.
+          additionalProperties:
+            $ref: "#/components/schemas/PlatformToolParameter"
+    PlatformToolsListResponse:
+      type: object
+      required:
+        - tools
+        - request_id
+      properties:
+        tools:
+          type: array
+          description: List of tools available to the user.
+          items:
+            $ref: "#/components/schemas/PlatformTool"
+        request_id:
+          type: string
+          description: Platform-generated request ID for support correlation.
+    PlatformProblemDetail:
+      type: object
+      required:
+        - type
+        - title
+        - status
+        - detail
+        - code
+        - request_id
+      description: |
+        Error response following RFC 9457, extended with `code` and `documentation_url` for machine-readable classification and self-service remediation.
+      properties:
+        type:
+          type: string
+          format: uri
+          description: URI identifying the error type.
+          example: https://developer.glean.com/errors/invalid-cursor
+        title:
+          type: string
+          description: Short, human-readable summary of the error.
+          example: Invalid Pagination Cursor
+        status:
+          type: integer
+          description: HTTP status code mirrored from the response.
+          example: 400
+        detail:
+          type: string
+          description: Human-readable explanation specific to this occurrence.
+          example: |
+            The provided cursor has expired. Start a new search to get a fresh cursor.
+        code:
+          type: string
+          description: Stable machine-readable error code.
+          enum:
+            - invalid_request
+            - missing_required_field
+            - invalid_parameter
+            - invalid_cursor
+            - expired_cursor
+            - invalid_filter
+            - authentication_required
+            - token_expired
+            - insufficient_permissions
+            - resource_not_found
+            - request_timeout
+            - conflict
+            - gone
+            - unprocessable_query
+            - rate_limit_exceeded
+            - internal_error
+            - service_unavailable
+          example: invalid_cursor
+        documentation_url:
+          type: string
+          format: uri
+          description: Direct URL to documentation for this error code.
+          example: https://developer.glean.com/errors/invalid-cursor
+        request_id:
+          type: string
+          description: Platform-generated request ID for support correlation.
+          example: req_7f8a9b0c1d2e
     PlatformFilter:
       type: object
       required:
@@ -223,67 +408,6 @@ components:
         request_id:
           type: string
           description: Platform-generated request ID for support correlation.
-    PlatformProblemDetail:
-      type: object
-      required:
-        - type
-        - title
-        - status
-        - detail
-        - code
-        - request_id
-      description: |
-        Error response following RFC 9457, extended with `code` and `documentation_url` for machine-readable classification and self-service remediation.
-      properties:
-        type:
-          type: string
-          format: uri
-          description: URI identifying the error type.
-          example: https://developer.glean.com/errors/invalid-cursor
-        title:
-          type: string
-          description: Short, human-readable summary of the error.
-          example: Invalid Pagination Cursor
-        status:
-          type: integer
-          description: HTTP status code mirrored from the response.
-          example: 400
-        detail:
-          type: string
-          description: Human-readable explanation specific to this occurrence.
-          example: |
-            The provided cursor has expired. Start a new search to get a fresh cursor.
-        code:
-          type: string
-          description: Stable machine-readable error code.
-          enum:
-            - invalid_request
-            - missing_required_field
-            - invalid_parameter
-            - invalid_cursor
-            - expired_cursor
-            - invalid_filter
-            - authentication_required
-            - token_expired
-            - insufficient_permissions
-            - resource_not_found
-            - request_timeout
-            - conflict
-            - gone
-            - unprocessable_query
-            - rate_limit_exceeded
-            - internal_error
-            - service_unavailable
-          example: invalid_cursor
-        documentation_url:
-          type: string
-          format: uri
-          description: Direct URL to documentation for this error code.
-          example: https://developer.glean.com/errors/invalid-cursor
-        request_id:
-          type: string
-          description: Platform-generated request ID for support correlation.
-          example: req_7f8a9b0c1d2e
   responses:
     PlatformBadRequest:
       description: Invalid request (malformed JSON, invalid parameter values, unknown fields).

--- a/overlayed_specs/glean-merged-spec.yaml
+++ b/overlayed_specs/glean-merged-spec.yaml
@@ -31,6 +31,56 @@ servers:
         default: instance-name
         description: The instance name (typically the email domain without the TLD) that determines the deployment backend.
 paths:
+  /api/tools:
+    get:
+      tags:
+        - Tools
+      summary: List tools
+      description: |
+        List tools available to the authenticated user, optionally filtered by tool name.
+      operationId: platform-tools-list
+      x-visibility: Public
+      x-glean-experimental:
+        id: 3cb43a04-ad52-4c25-be62-3ce1daffd513
+        introduced: "2026-05-06"
+      parameters:
+        - in: query
+          name: tool_names
+          description: Optional comma-delimited list of tool names to return.
+          required: false
+          style: form
+          explode: false
+          schema:
+            type: array
+            items:
+              type: string
+      responses:
+        "200":
+          description: Successful response.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlatformToolsListResponse"
+        "400":
+          $ref: "#/components/responses/PlatformBadRequest"
+        "401":
+          $ref: "#/components/responses/PlatformUnauthorized"
+        "403":
+          $ref: "#/components/responses/PlatformForbidden"
+        "404":
+          $ref: "#/components/responses/PlatformNotFound"
+        "408":
+          $ref: "#/components/responses/PlatformRequestTimeout"
+        "429":
+          $ref: "#/components/responses/PlatformTooManyRequests"
+        "500":
+          $ref: "#/components/responses/PlatformInternalServerError"
+        "503":
+          $ref: "#/components/responses/PlatformServiceUnavailable"
+      x-speakeasy-group: platform.tools
+      x-speakeasy-name-override: list
+      security:
+        - APIToken: []
   /api/search:
     post:
       tags:
@@ -4503,6 +4553,143 @@ components:
       type: http
       scheme: bearer
   schemas:
+    PlatformToolParameter:
+      type: object
+      properties:
+        type:
+          type: string
+          description: Parameter type.
+          enum:
+            - string
+            - number
+            - boolean
+            - object
+            - array
+        name:
+          type: string
+          description: Parameter name.
+        description:
+          type: string
+          description: Parameter description.
+        is_required:
+          type: boolean
+          description: Whether the parameter is required.
+        possible_values:
+          type: array
+          description: Possible primitive values for the parameter.
+          items:
+            type: string
+        items:
+          $ref: "#/components/schemas/PlatformToolParameter"
+        properties:
+          type: object
+          description: Object properties for object parameters.
+          additionalProperties:
+            $ref: "#/components/schemas/PlatformToolParameter"
+    PlatformTool:
+      type: object
+      required:
+        - type
+        - name
+        - display_name
+        - description
+        - parameters
+      properties:
+        type:
+          type: string
+          description: Type of tool.
+          enum:
+            - READ
+            - WRITE
+        name:
+          type: string
+          description: Unique identifier for the tool.
+        display_name:
+          type: string
+          description: Human-readable name.
+        description:
+          type: string
+          description: LLM-friendly description of the tool.
+        parameters:
+          type: object
+          description: Parameters supported by the tool.
+          additionalProperties:
+            $ref: "#/components/schemas/PlatformToolParameter"
+    PlatformToolsListResponse:
+      type: object
+      required:
+        - tools
+        - request_id
+      properties:
+        tools:
+          type: array
+          description: List of tools available to the user.
+          items:
+            $ref: "#/components/schemas/PlatformTool"
+        request_id:
+          type: string
+          description: Platform-generated request ID for support correlation.
+    PlatformProblemDetail:
+      type: object
+      required:
+        - type
+        - title
+        - status
+        - detail
+        - code
+        - request_id
+      description: |
+        Error response following RFC 9457, extended with `code` and `documentation_url` for machine-readable classification and self-service remediation.
+      properties:
+        type:
+          type: string
+          format: uri
+          description: URI identifying the error type.
+          example: https://developer.glean.com/errors/invalid-cursor
+        title:
+          type: string
+          description: Short, human-readable summary of the error.
+          example: Invalid Pagination Cursor
+        status:
+          type: integer
+          description: HTTP status code mirrored from the response.
+          example: 400
+        detail:
+          type: string
+          description: Human-readable explanation specific to this occurrence.
+          example: |
+            The provided cursor has expired. Start a new search to get a fresh cursor.
+        code:
+          type: string
+          description: Stable machine-readable error code.
+          enum:
+            - invalid_request
+            - missing_required_field
+            - invalid_parameter
+            - invalid_cursor
+            - expired_cursor
+            - invalid_filter
+            - authentication_required
+            - token_expired
+            - insufficient_permissions
+            - resource_not_found
+            - request_timeout
+            - conflict
+            - gone
+            - unprocessable_query
+            - rate_limit_exceeded
+            - internal_error
+            - service_unavailable
+          example: invalid_cursor
+        documentation_url:
+          type: string
+          format: uri
+          description: Direct URL to documentation for this error code.
+          example: https://developer.glean.com/errors/invalid-cursor
+        request_id:
+          type: string
+          description: Platform-generated request ID for support correlation.
+          example: req_7f8a9b0c1d2e
     PlatformFilter:
       type: object
       required:
@@ -4662,67 +4849,6 @@ components:
         request_id:
           type: string
           description: Platform-generated request ID for support correlation.
-    PlatformProblemDetail:
-      type: object
-      required:
-        - type
-        - title
-        - status
-        - detail
-        - code
-        - request_id
-      description: |
-        Error response following RFC 9457, extended with `code` and `documentation_url` for machine-readable classification and self-service remediation.
-      properties:
-        type:
-          type: string
-          format: uri
-          description: URI identifying the error type.
-          example: https://developer.glean.com/errors/invalid-cursor
-        title:
-          type: string
-          description: Short, human-readable summary of the error.
-          example: Invalid Pagination Cursor
-        status:
-          type: integer
-          description: HTTP status code mirrored from the response.
-          example: 400
-        detail:
-          type: string
-          description: Human-readable explanation specific to this occurrence.
-          example: |
-            The provided cursor has expired. Start a new search to get a fresh cursor.
-        code:
-          type: string
-          description: Stable machine-readable error code.
-          enum:
-            - invalid_request
-            - missing_required_field
-            - invalid_parameter
-            - invalid_cursor
-            - expired_cursor
-            - invalid_filter
-            - authentication_required
-            - token_expired
-            - insufficient_permissions
-            - resource_not_found
-            - request_timeout
-            - conflict
-            - gone
-            - unprocessable_query
-            - rate_limit_exceeded
-            - internal_error
-            - service_unavailable
-          example: invalid_cursor
-        documentation_url:
-          type: string
-          format: uri
-          description: Direct URL to documentation for this error code.
-          example: https://developer.glean.com/errors/invalid-cursor
-        request_id:
-          type: string
-          description: Platform-generated request ID for support correlation.
-          example: req_7f8a9b0c1d2e
     ActivityEventParams:
       properties:
         bodyContent:

--- a/overlayed_specs/glean-merged-spec.yaml
+++ b/overlayed_specs/glean-merged-spec.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.0
 info:
   version: "0.9.0"
   title: Glean API
-  x-source-commit-sha: be392b09dbb2d90d1eb33786d69d1b8df8ea98ec
+  x-source-commit-sha: __SCIO_COMMIT_SHA__
   description: |
     # Introduction
     In addition to the data sources that Glean has built-in support for, Glean also provides a REST API that enables customers to put arbitrary content in the search index. This is useful, for example, for doing permissions-aware search over content in internal tools that reside on-prem as well as for searching over applications that Glean does not currently support first class. In addition these APIs allow the customer to push organization data (people info, organization structure etc) into Glean.
@@ -22,7 +22,6 @@ info:
     These API clients provide type-safe, idiomatic interfaces for working with Glean IndexingAPIs in your language of choice.
   x-logo:
     url: https://app.glean.com/images/glean-text2.svg
-  x-open-api-commit-sha: 127bc440bea5368e5d1cea27cd51c5ef900b9147
   x-speakeasy-name: 'Glean API'
 servers:
   - url: https://{instance}-be.glean.com
@@ -38,7 +37,7 @@ paths:
       summary: Search
       description: |
         Execute a search query and retrieve ranked results. This is the data retrieval variant of the search API and returns only results and pagination state.
-      operationId: platform-search-query
+      operationId: platform-search
       x-visibility: Public
       x-glean-experimental:
         gated-by: platform.apiSearchEnabled
@@ -6202,12 +6201,6 @@ components:
           enum:
             - DOCUMENT
             - ASSISTANT
-    UgcTrackingSignals:
-      type: object
-      properties:
-        trackingToken:
-          type: string
-          description: An opaque token that represents this particular UGC. To be used for `/feedback` reporting.
     StructuredText:
       allOf:
         - $ref: '#/components/schemas/StructuredTextMutableProperties'
@@ -6492,7 +6485,6 @@ components:
       allOf:
         - $ref: '#/components/schemas/CollectionMutableProperties'
         - $ref: '#/components/schemas/PermissionedObject'
-        - $ref: '#/components/schemas/UgcTrackingSignals'
         - type: object
           properties:
             id:
@@ -6635,7 +6627,6 @@ components:
         - $ref: '#/components/schemas/AnswerDocId'
         - $ref: '#/components/schemas/AnswerMutableProperties'
         - $ref: '#/components/schemas/PermissionedObject'
-        - $ref: '#/components/schemas/UgcTrackingSignals'
         - type: object
           properties:
             combinedAnswerText:
@@ -8145,7 +8136,6 @@ components:
         - $ref: '#/components/schemas/AnnouncementMutableProperties'
         - $ref: '#/components/schemas/DraftProperties'
         - $ref: '#/components/schemas/PermissionedObject'
-        - $ref: '#/components/schemas/UgcTrackingSignals'
         - type: object
           properties:
             id:
@@ -8254,14 +8244,7 @@ components:
           $ref: '#/components/schemas/Answer'
         trackingToken:
           type: string
-          description: Use `answer.trackingToken` instead.
-          deprecated: true
-          x-glean-deprecated:
-            id: 62de643b-f182-4d4d-a2fc-5e2cbfee7320
-            introduced: "2026-05-07"
-            message: Use `answer.trackingToken` instead.
-            removal: "2027-01-15"
-          x-speakeasy-deprecation-message: "Deprecated on 2026-05-07, removal scheduled for 2027-01-15: Use `answer.trackingToken` instead."
+          description: An opaque token that represents this particular Answer. To be used for `/feedback` reporting.
       required:
         - answer
     GetAnswerError:
@@ -9445,18 +9428,11 @@ components:
           $ref: '#/components/schemas/Collection'
         rootCollection:
           $ref: '#/components/schemas/Collection'
-        error:
-          $ref: '#/components/schemas/CollectionError'
         trackingToken:
           type: string
-          description: Use `collection.trackingToken` instead.
-          deprecated: true
-          x-glean-deprecated:
-            id: 2d6ca3a7-4763-4137-9ebd-740568fe8300
-            introduced: "2026-05-07"
-            message: Use `collection.trackingToken` instead.
-            removal: "2027-01-15"
-          x-speakeasy-deprecation-message: "Deprecated on 2026-05-07, removal scheduled for 2027-01-15: Use `collection.trackingToken` instead."
+          description: An opaque token that represents this particular Collection. To be used for `/feedback` reporting.
+        error:
+          $ref: '#/components/schemas/CollectionError'
     ListCollectionsRequest:
       properties:
         includeAudience:

--- a/overlayed_specs/glean-merged-spec.yaml
+++ b/overlayed_specs/glean-merged-spec.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.0
 info:
-  version: 0.9.0
+  version: "0.9.0"
   title: Glean API
   x-source-commit-sha: be392b09dbb2d90d1eb33786d69d1b8df8ea98ec
   description: |
@@ -31,20 +31,67 @@ servers:
         default: instance-name
         description: The instance name (typically the email domain without the TLD) that determines the deployment backend.
 paths:
-  /rest/api/v1/activity:
+  /api/search:
     post:
       tags:
-        - Activity
+        - Search
+      summary: Search
+      description: |
+        Execute a search query and retrieve ranked results. This is the data retrieval variant of the search API and returns only results and pagination state.
+      operationId: platform-search-query
+      x-visibility: Public
+      x-glean-experimental:
+        gated-by: platform.apiSearchEnabled
+        id: 5ab612fc-ed50-4419-bec3-e5fe83934653
+        introduced: "2026-04-08"
+      x-codegen-request-body-name: payload
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PlatformSearchRequest"
+      responses:
+        "200":
+          description: Successful search.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlatformSearchResponse"
+        "400":
+          $ref: "#/components/responses/PlatformBadRequest"
+        "401":
+          $ref: "#/components/responses/PlatformUnauthorized"
+        "403":
+          $ref: "#/components/responses/PlatformForbidden"
+        "404":
+          $ref: "#/components/responses/PlatformNotFound"
+        "408":
+          $ref: "#/components/responses/PlatformRequestTimeout"
+        "429":
+          $ref: "#/components/responses/PlatformTooManyRequests"
+        "500":
+          $ref: "#/components/responses/PlatformInternalServerError"
+        "503":
+          $ref: "#/components/responses/PlatformServiceUnavailable"
+      x-speakeasy-group: platform.search
+      x-speakeasy-name-override: query
+      security:
+        - APIToken: []
+  /rest/api/v1/activity:
+    post:
+      operationId: activity
       summary: Report document activity
       description: Report user activity that occurs on indexed documents such as viewing or editing. This signal improves search quality.
-      operationId: activity
-      x-visibility: Public
-      x-codegen-request-body-name: payload
+      tags:
+        - Activity
+      security:
+        - APIToken: []
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/Activity"
+              $ref: '#/components/schemas/Activity'
         required: true
         x-exportParamName: Activity
       responses:
@@ -56,19 +103,19 @@ paths:
           description: Not Authorized
         "429":
           description: Too Many Requests
-      security:
-        - APIToken: []
+      x-visibility: Public
+      x-codegen-request-body-name: payload
       x-speakeasy-name-override: report
       x-speakeasy-group: client.activity
   /rest/api/v1/feedback:
     post:
-      tags:
-        - Activity
+      operationId: feedback
       summary: Report client activity
       description: Report events that happen to results within a Glean client UI, such as search result views and clicks.  This signal improves search quality.
-      operationId: feedback
-      x-visibility: Public
-      x-codegen-request-body-name: payload
+      tags:
+        - Activity
+      security:
+        - APIToken: []
       parameters:
         - name: feedback
           in: query
@@ -80,7 +127,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/Feedback"
+              $ref: '#/components/schemas/Feedback'
         x-exportParamName: Feedback
       responses:
         "200":
@@ -91,26 +138,26 @@ paths:
           description: Not Authorized
         "429":
           description: Too Many Requests
-      security:
-        - APIToken: []
+      x-visibility: Public
+      x-codegen-request-body-name: payload
       x-speakeasy-group: client.activity
   /rest/api/v1/createannouncement:
     post:
-      tags:
-        - Announcements
+      operationId: createannouncement
       summary: Create Announcement
       description: Create a textual announcement visible to some set of users based on department and location.
-      operationId: createannouncement
-      x-visibility: Public
-      x-codegen-request-body-name: payload
+      tags:
+        - Announcements
+      security:
+        - APIToken: []
       parameters:
-        - $ref: "#/components/parameters/locale"
+        - $ref: '#/components/parameters/locale'
       requestBody:
+        description: Announcement content
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/CreateAnnouncementRequest"
-        description: Announcement content
+              $ref: '#/components/schemas/CreateAnnouncementRequest'
         required: true
         x-exportParamName: Request
       responses:
@@ -119,34 +166,34 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Announcement"
+                $ref: '#/components/schemas/Announcement'
         "400":
           description: Invalid request
         "401":
           description: Not Authorized
         "429":
           description: Too Many Requests
-      security:
-        - APIToken: []
+      x-visibility: Public
+      x-codegen-request-body-name: payload
       x-speakeasy-name-override: create
       x-speakeasy-group: client.announcements
   /rest/api/v1/deleteannouncement:
     post:
-      tags:
-        - Announcements
+      operationId: deleteannouncement
       summary: Delete Announcement
       description: Delete an existing user-generated announcement.
-      operationId: deleteannouncement
-      x-visibility: Public
-      x-codegen-request-body-name: payload
+      tags:
+        - Announcements
+      security:
+        - APIToken: []
       parameters:
-        - $ref: "#/components/parameters/locale"
+        - $ref: '#/components/parameters/locale'
       requestBody:
+        description: Delete announcement request
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/DeleteAnnouncementRequest"
-        description: Delete announcement request
+              $ref: '#/components/schemas/DeleteAnnouncementRequest'
         required: true
         x-exportParamName: Request
       responses:
@@ -158,27 +205,27 @@ paths:
           description: Not Authorized
         "429":
           description: Too Many Requests
-      security:
-        - APIToken: []
+      x-visibility: Public
+      x-codegen-request-body-name: payload
       x-speakeasy-name-override: delete
       x-speakeasy-group: client.announcements
   /rest/api/v1/updateannouncement:
     post:
-      tags:
-        - Announcements
+      operationId: updateannouncement
       summary: Update Announcement
       description: Update a textual announcement visible to some set of users based on department and location.
-      operationId: updateannouncement
-      x-visibility: Public
-      x-codegen-request-body-name: payload
+      tags:
+        - Announcements
+      security:
+        - APIToken: []
       parameters:
-        - $ref: "#/components/parameters/locale"
+        - $ref: '#/components/parameters/locale'
       requestBody:
+        description: Announcement content. Id need to be specified for the announcement.
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/UpdateAnnouncementRequest"
-        description: Announcement content. Id need to be specified for the announcement.
+              $ref: '#/components/schemas/UpdateAnnouncementRequest'
         required: true
         x-exportParamName: Request
       responses:
@@ -187,34 +234,34 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Announcement"
+                $ref: '#/components/schemas/Announcement'
         "400":
           description: Invalid request
         "401":
           description: Not Authorized
         "429":
           description: Too Many Requests
-      security:
-        - APIToken: []
+      x-visibility: Public
+      x-codegen-request-body-name: payload
       x-speakeasy-name-override: update
       x-speakeasy-group: client.announcements
   /rest/api/v1/createanswer:
     post:
-      tags:
-        - Answers
+      operationId: createanswer
       summary: Create Answer
       description: Create a user-generated Answer that contains a question and answer.
-      operationId: createanswer
-      x-visibility: Public
-      x-codegen-request-body-name: payload
+      tags:
+        - Answers
+      security:
+        - APIToken: []
       parameters:
-        - $ref: "#/components/parameters/locale"
+        - $ref: '#/components/parameters/locale'
       requestBody:
+        description: CreateAnswer request
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/CreateAnswerRequest"
-        description: CreateAnswer request
+              $ref: '#/components/schemas/CreateAnswerRequest'
         required: true
         x-exportParamName: Request
       responses:
@@ -223,34 +270,34 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Answer"
+                $ref: '#/components/schemas/Answer'
         "400":
           description: Invalid request
         "401":
           description: Not Authorized
         "429":
           description: Too Many Requests
-      security:
-        - APIToken: []
+      x-visibility: Public
+      x-codegen-request-body-name: payload
       x-speakeasy-name-override: create
       x-speakeasy-group: client.answers
   /rest/api/v1/deleteanswer:
     post:
-      tags:
-        - Answers
+      operationId: deleteanswer
       summary: Delete Answer
       description: Delete an existing user-generated Answer.
-      operationId: deleteanswer
-      x-visibility: Public
-      x-codegen-request-body-name: payload
+      tags:
+        - Answers
+      security:
+        - APIToken: []
       parameters:
-        - $ref: "#/components/parameters/locale"
+        - $ref: '#/components/parameters/locale'
       requestBody:
+        description: DeleteAnswer request
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/DeleteAnswerRequest"
-        description: DeleteAnswer request
+              $ref: '#/components/schemas/DeleteAnswerRequest'
         required: true
         x-exportParamName: Request
       responses:
@@ -262,27 +309,27 @@ paths:
           description: Not Authorized
         "429":
           description: Too Many Requests
-      security:
-        - APIToken: []
+      x-visibility: Public
+      x-codegen-request-body-name: payload
       x-speakeasy-name-override: delete
       x-speakeasy-group: client.answers
   /rest/api/v1/editanswer:
     post:
-      tags:
-        - Answers
+      operationId: editanswer
       summary: Update Answer
       description: Update an existing user-generated Answer.
-      operationId: editanswer
-      x-visibility: Public
-      x-codegen-request-body-name: payload
+      tags:
+        - Answers
+      security:
+        - APIToken: []
       parameters:
-        - $ref: "#/components/parameters/locale"
+        - $ref: '#/components/parameters/locale'
       requestBody:
+        description: EditAnswer request
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/EditAnswerRequest"
-        description: EditAnswer request
+              $ref: '#/components/schemas/EditAnswerRequest'
         required: true
         x-exportParamName: Request
       responses:
@@ -291,34 +338,34 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Answer"
+                $ref: '#/components/schemas/Answer'
         "400":
           description: Invalid request
         "401":
           description: Not Authorized
         "429":
           description: Too Many Requests
-      security:
-        - APIToken: []
+      x-visibility: Public
+      x-codegen-request-body-name: payload
       x-speakeasy-name-override: update
       x-speakeasy-group: client.answers
   /rest/api/v1/getanswer:
     post:
-      tags:
-        - Answers
+      operationId: getanswer
       summary: Read Answer
       description: Read the details of a particular Answer given its ID.
-      operationId: getanswer
-      x-visibility: Public
-      x-codegen-request-body-name: payload
+      tags:
+        - Answers
+      security:
+        - APIToken: []
       parameters:
-        - $ref: "#/components/parameters/locale"
+        - $ref: '#/components/parameters/locale'
       requestBody:
+        description: GetAnswer request
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/GetAnswerRequest"
-        description: GetAnswer request
+              $ref: '#/components/schemas/GetAnswerRequest'
         required: true
         x-exportParamName: Request
       responses:
@@ -327,35 +374,34 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/GetAnswerResponse"
+                $ref: '#/components/schemas/GetAnswerResponse'
         "400":
           description: Invalid request
         "401":
           description: Not Authorized
         "429":
           description: Too Many Requests
-      security:
-        - APIToken: []
+      x-visibility: Public
+      x-codegen-request-body-name: payload
       x-speakeasy-name-override: retrieve
       x-speakeasy-group: client.answers
   /rest/api/v1/listanswers:
     post:
-      tags:
-        - Answers
+      operationId: listanswers
       summary: List Answers
       description: List Answers created by the current user.
-      operationId: listanswers
-      deprecated: true
-      x-visibility: Public
-      x-codegen-request-body-name: payload
+      tags:
+        - Answers
+      security:
+        - APIToken: []
       parameters:
-        - $ref: "#/components/parameters/locale"
+        - $ref: '#/components/parameters/locale'
       requestBody:
+        description: ListAnswers request
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/ListAnswersRequest"
-        description: ListAnswers request
+              $ref: '#/components/schemas/ListAnswersRequest'
         required: true
         x-exportParamName: Request
       responses:
@@ -364,27 +410,27 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ListAnswersResponse"
+                $ref: '#/components/schemas/ListAnswersResponse'
         "400":
           description: Invalid request
         "401":
           description: Not Authorized
         "429":
           description: Too Many Requests
+      deprecated: true
+      x-visibility: Public
+      x-codegen-request-body-name: payload
       x-glean-deprecated:
         id: 4c0923bd-64c7-45b9-99a5-b36f2705e618
         introduced: "2026-01-21"
         message: Answer boards have been removed and this endpoint no longer serves a purpose
         removal: "2026-10-15"
       x-speakeasy-deprecation-message: "Deprecated on 2026-01-21, removal scheduled for 2026-10-15: Answer boards have been removed and this endpoint no longer serves a purpose"
-      security:
-        - APIToken: []
       x-speakeasy-name-override: list
       x-speakeasy-group: client.answers
   /rest/api/v1/checkdatasourceauth:
     post:
-      tags:
-        - Authentication
+      operationId: checkdatasourceauth
       summary: Check datasource authorization
       description: |
         Returns all datasource instances that require per-user OAuth authorization
@@ -394,8 +440,10 @@ paths:
         Clients construct the full OAuth URL by combining the backend base URL,
         the `authUrlRelativePath` from each instance, and the transient auth token:
         `<backend>/<authUrlRelativePath>?transient_auth_token=<token>`.
-      operationId: checkdatasourceauth
-      x-visibility: Public
+      tags:
+        - Authentication
+      security:
+        - APIToken: []
       parameters: []
       responses:
         "200":
@@ -403,17 +451,15 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/CheckDatasourceAuthResponse"
+                $ref: '#/components/schemas/CheckDatasourceAuthResponse'
         "401":
           description: Not Authorized
         "429":
           description: Too Many Requests
-      security:
-        - APIToken: []
+      x-visibility: Public
   /rest/api/v1/createauthtoken:
     post:
-      tags:
-        - Authentication
+      operationId: createauthtoken
       summary: Create authentication token
       description: |
         Creates an authentication token for the authenticated user. These are
@@ -421,8 +467,10 @@ paths:
 
         Note: The tokens generated from this endpoint are **not** valid tokens
         for use with the Client API (e.g. `/rest/api/v1/*`).
-      operationId: createauthtoken
-      x-visibility: Public
+      tags:
+        - Authentication
+      security:
+        - APIToken: []
       parameters: []
       responses:
         "200":
@@ -430,34 +478,34 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/CreateAuthTokenResponse"
+                $ref: '#/components/schemas/CreateAuthTokenResponse'
         "400":
           description: Invalid Request
         "401":
           description: Not Authorized
         "429":
           description: Too Many Requests
-      security:
-        - APIToken: []
+      x-visibility: Public
       x-speakeasy-name-override: createToken
       x-speakeasy-group: client.authentication
   /rest/api/v1/chat:
     post:
-      tags:
-        - Chat
+      operationId: chat
       summary: Chat
       description: Have a conversation with Glean AI.
-      operationId: chat
-      x-visibility: Public
-      x-codegen-request-body-name: payload
+      tags:
+        - Chat
+      security:
+        - APIToken: []
       parameters:
-        - $ref: "#/components/parameters/locale"
-        - $ref: "#/components/parameters/timezoneOffset"
+        - $ref: '#/components/parameters/locale'
+        - $ref: '#/components/parameters/timezoneOffset'
       requestBody:
+        description: Includes chat history for Glean AI to respond to.
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/ChatRequest"
+              $ref: '#/components/schemas/ChatRequest'
             examples:
               defaultExample:
                 value:
@@ -475,7 +523,6 @@ paths:
                       messageType: CONTENT
                       fragments:
                         - text: Who was the first person to land on the moon?
-        description: Includes chat history for Glean AI to respond to.
         required: true
         x-exportParamName: Request
       responses:
@@ -577,23 +624,23 @@ paths:
           description: Request Timeout
         "429":
           description: Too Many Requests
-      security:
-        - APIToken: []
+      x-visibility: Public
+      x-codegen-request-body-name: payload
       x-speakeasy-group: client.chat
       x-speakeasy-name-override: create
       x-speakeasy-usage-example: true
   /rest/api/v1/deleteallchats:
     post:
-      tags:
-        - Chat
+      operationId: deleteallchats
       summary: Deletes all saved Chats owned by a user
       description: Deletes all saved Chats a user has had and all their contained conversational content.
-      operationId: deleteallchats
-      x-visibility: Public
-      x-codegen-request-body-name: payload
+      tags:
+        - Chat
+      security:
+        - APIToken: []
       parameters:
-        - $ref: "#/components/parameters/locale"
-        - $ref: "#/components/parameters/timezoneOffset"
+        - $ref: '#/components/parameters/locale'
+        - $ref: '#/components/parameters/timezoneOffset'
       responses:
         "200":
           description: OK
@@ -603,27 +650,27 @@ paths:
           description: Not Authorized
         "403":
           description: Forbidden
-      security:
-        - APIToken: []
+      x-visibility: Public
+      x-codegen-request-body-name: payload
       x-speakeasy-name-override: deleteAll
       x-speakeasy-group: client.chat
   /rest/api/v1/deletechats:
     post:
-      tags:
-        - Chat
+      operationId: deletechats
       summary: Deletes saved Chats
       description: Deletes saved Chats and all their contained conversational content.
-      operationId: deletechats
-      x-visibility: Public
-      x-codegen-request-body-name: payload
+      tags:
+        - Chat
+      security:
+        - APIToken: []
       parameters:
-        - $ref: "#/components/parameters/locale"
-        - $ref: "#/components/parameters/timezoneOffset"
+        - $ref: '#/components/parameters/locale'
+        - $ref: '#/components/parameters/timezoneOffset'
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/DeleteChatsRequest"
+              $ref: '#/components/schemas/DeleteChatsRequest'
         required: true
         x-exportParamName: Request
       responses:
@@ -637,27 +684,27 @@ paths:
           description: Forbidden
         "429":
           description: Too Many Requests
-      security:
-        - APIToken: []
+      x-visibility: Public
+      x-codegen-request-body-name: payload
       x-speakeasy-name-override: delete
       x-speakeasy-group: client.chat
   /rest/api/v1/getchat:
     post:
-      tags:
-        - Chat
+      operationId: getchat
       summary: Retrieves a Chat
       description: Retrieves the chat history between Glean Assistant and the user for a given Chat.
-      operationId: getchat
-      x-visibility: Public
-      x-codegen-request-body-name: payload
+      tags:
+        - Chat
+      security:
+        - APIToken: []
       parameters:
-        - $ref: "#/components/parameters/locale"
-        - $ref: "#/components/parameters/timezoneOffset"
+        - $ref: '#/components/parameters/locale'
+        - $ref: '#/components/parameters/timezoneOffset'
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/GetChatRequest"
+              $ref: '#/components/schemas/GetChatRequest'
         required: true
         x-exportParamName: Request
       responses:
@@ -666,7 +713,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/GetChatResponse"
+                $ref: '#/components/schemas/GetChatResponse'
         "400":
           description: Invalid request
         "401":
@@ -675,56 +722,56 @@ paths:
           description: Forbidden
         "429":
           description: Too Many Requests
-      security:
-        - APIToken: []
+      x-visibility: Public
+      x-codegen-request-body-name: payload
       x-speakeasy-name-override: retrieve
       x-speakeasy-group: client.chat
   /rest/api/v1/listchats:
     post:
-      tags:
-        - Chat
+      operationId: listchats
       summary: Retrieves all saved Chats
       description: Retrieves all the saved Chats between Glean Assistant and the user. The returned Chats contain only metadata and no conversational content.
-      operationId: listchats
-      x-visibility: Public
-      x-codegen-request-body-name: payload
+      tags:
+        - Chat
+      security:
+        - APIToken: []
       parameters:
-        - $ref: "#/components/parameters/locale"
-        - $ref: "#/components/parameters/timezoneOffset"
+        - $ref: '#/components/parameters/locale'
+        - $ref: '#/components/parameters/timezoneOffset'
       responses:
         "200":
           description: OK
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ListChatsResponse"
+                $ref: '#/components/schemas/ListChatsResponse'
         "401":
           description: Not Authorized
         "403":
           description: Forbidden
         "429":
           description: Too Many Requests
-      security:
-        - APIToken: []
+      x-visibility: Public
+      x-codegen-request-body-name: payload
       x-speakeasy-name-override: list
       x-speakeasy-group: client.chat
   /rest/api/v1/getchatapplication:
     post:
-      tags:
-        - Chat
+      operationId: getchatapplication
       summary: Gets the metadata for a custom Chat application
       description: Gets the Chat application details for the specified application ID.
-      operationId: getchatapplication
-      x-visibility: Preview
-      x-codegen-request-body-name: payload
+      tags:
+        - Chat
+      security:
+        - APIToken: []
       parameters:
-        - $ref: "#/components/parameters/locale"
-        - $ref: "#/components/parameters/timezoneOffset"
+        - $ref: '#/components/parameters/locale'
+        - $ref: '#/components/parameters/timezoneOffset'
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/GetChatApplicationRequest"
+              $ref: '#/components/schemas/GetChatApplicationRequest'
         required: true
         x-exportParamName: Request
       responses:
@@ -733,34 +780,35 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/GetChatApplicationResponse"
+                $ref: '#/components/schemas/GetChatApplicationResponse'
         "400":
           description: Invalid request
         "401":
           description: Not Authorized
         "403":
           description: Forbidden
-      security:
-        - APIToken: []
+      x-visibility: Preview
+      x-codegen-request-body-name: payload
       x-speakeasy-name-override: retrieveApplication
       x-speakeasy-group: client.chat
   /rest/api/v1/uploadchatfiles:
     post:
-      tags:
-        - Chat
+      operationId: uploadchatfiles
       summary: Upload files for Chat
       description: Upload files for Chat.
-      operationId: uploadchatfiles
-      x-visibility: Public
+      tags:
+        - Chat
+      security:
+        - APIToken: []
       parameters:
-        - $ref: "#/components/parameters/locale"
-        - $ref: "#/components/parameters/timezoneOffset"
+        - $ref: '#/components/parameters/locale'
+        - $ref: '#/components/parameters/timezoneOffset'
       requestBody:
-        required: true
         content:
           multipart/form-data:
             schema:
-              $ref: "#/components/schemas/UploadChatFilesRequest"
+              $ref: '#/components/schemas/UploadChatFilesRequest'
+        required: true
         x-exportParamName: Request
       responses:
         "200":
@@ -768,7 +816,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/UploadChatFilesResponse"
+                $ref: '#/components/schemas/UploadChatFilesResponse'
         "400":
           description: Invalid request
         "401":
@@ -777,27 +825,27 @@ paths:
           description: Forbidden
         "429":
           description: Too Many Requests
-      security:
-        - APIToken: []
+      x-visibility: Public
       x-speakeasy-name-override: uploadFiles
       x-speakeasy-group: client.chat
   /rest/api/v1/getchatfiles:
     post:
-      tags:
-        - Chat
+      operationId: getchatfiles
       summary: Get files uploaded by a user for Chat
       description: Get files uploaded by a user for Chat.
-      operationId: getchatfiles
-      x-visibility: Public
+      tags:
+        - Chat
+      security:
+        - APIToken: []
       parameters:
-        - $ref: "#/components/parameters/locale"
-        - $ref: "#/components/parameters/timezoneOffset"
+        - $ref: '#/components/parameters/locale'
+        - $ref: '#/components/parameters/timezoneOffset'
       requestBody:
-        required: true
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/GetChatFilesRequest"
+              $ref: '#/components/schemas/GetChatFilesRequest'
+        required: true
         x-exportParamName: Request
       responses:
         "200":
@@ -805,7 +853,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/GetChatFilesResponse"
+                $ref: '#/components/schemas/GetChatFilesResponse'
         "400":
           description: Invalid request
         "401":
@@ -814,27 +862,27 @@ paths:
           description: Forbidden
         "429":
           description: Too Many Requests
-      security:
-        - APIToken: []
+      x-visibility: Public
       x-speakeasy-name-override: retrieveFiles
       x-speakeasy-group: client.chat
   /rest/api/v1/deletechatfiles:
     post:
-      tags:
-        - Chat
+      operationId: deletechatfiles
       summary: Delete files uploaded by a user for chat
       description: Delete files uploaded by a user for Chat.
-      operationId: deletechatfiles
-      x-visibility: Public
+      tags:
+        - Chat
+      security:
+        - APIToken: []
       parameters:
-        - $ref: "#/components/parameters/locale"
-        - $ref: "#/components/parameters/timezoneOffset"
+        - $ref: '#/components/parameters/locale'
+        - $ref: '#/components/parameters/timezoneOffset'
       requestBody:
-        required: true
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/DeleteChatFilesRequest"
+              $ref: '#/components/schemas/DeleteChatFilesRequest'
+        required: true
       responses:
         "200":
           description: OK
@@ -846,31 +894,31 @@ paths:
           description: Forbidden
         "429":
           description: Too Many Requests
-      security:
-        - APIToken: []
+      x-visibility: Public
       x-speakeasy-name-override: deleteFiles
       x-speakeasy-group: client.chat
   /rest/api/v1/chat-files/{fileId}:
     get:
-      tags:
-        - Chat
+      operationId: getChatFile
       summary: Download a chat file
       description: |
         Download the raw content of a file generated or uploaded during a chat session (for example, an image produced by the assistant). Returns the file bytes with a Content-Type header matching the file's MIME type.
-      operationId: getChatFile
-      x-visibility: Public
+      tags:
+        - Chat
+      security:
+        - APIToken: []
       parameters:
         - name: fileId
           in: path
-          required: true
           description: Identifier of the chat file to download.
+          required: true
           schema:
             type: string
         - name: preview
           in: query
-          required: false
           description: |
             When true and the file is a PDF, the response is served inline (Content-Disposition: inline) instead of as an attachment.
+          required: false
           schema:
             type: boolean
       responses:
@@ -891,34 +939,34 @@ paths:
           description: File not found.
         "500":
           description: Internal server error.
-      security:
-        - APIToken: []
+      x-visibility: Public
   /rest/api/v1/agents/{agent_id}:
     get:
-      tags:
-        - Agents
+      operationId: getAgent
       summary: Retrieve an agent
       description: Returns details of an [agent](https://developers.glean.com/agents/agents-api) created in the Agent Builder.
-      operationId: getAgent
-      x-visibility: Preview
+      tags:
+        - Agents
+      security:
+        - APIToken: []
       parameters:
-        - $ref: "#/components/parameters/locale"
-        - $ref: "#/components/parameters/timezoneOffset"
-        - description: The ID of the agent.
+        - $ref: '#/components/parameters/locale'
+        - $ref: '#/components/parameters/timezoneOffset'
+        - name: agent_id
+          in: path
+          description: The ID of the agent.
           required: true
           schema:
             type: string
             title: Agent ID
             description: The ID of the agent.
-          name: agent_id
-          in: path
       responses:
         "200":
           description: Success
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Agent"
+                $ref: '#/components/schemas/Agent'
         "400":
           description: Bad request
         "403":
@@ -928,37 +976,37 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ErrorResponse"
+                $ref: '#/components/schemas/ErrorResponse'
         "500":
           description: Internal server error
-      security:
-        - APIToken: []
+      x-visibility: Preview
       x-speakeasy-group: client.agents
       x-speakeasy-name-override: retrieve
     post:
-      tags:
-        - Agents
+      operationId: editAgent
       summary: Edit an agent
       description: Creates a draft or publishes an [agent](https://developers.glean.com/agents/agents-api). Use `isDraft=true` to save a draft, or `isDraft=false` (or omit) to publish immediately. Only draft and publish modes are supported.
-      operationId: editAgent
-      x-visibility: Preview
+      tags:
+        - Agents
+      security:
+        - APIToken: []
       parameters:
-        - $ref: "#/components/parameters/locale"
-        - $ref: "#/components/parameters/timezoneOffset"
-        - description: The ID of the agent.
+        - $ref: '#/components/parameters/locale'
+        - $ref: '#/components/parameters/timezoneOffset'
+        - name: agent_id
+          in: path
+          description: The ID of the agent.
           required: true
           schema:
             type: string
             title: Agent ID
             description: The ID of the agent.
-          name: agent_id
-          in: path
       requestBody:
-        required: true
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/EditWorkflowRequest"
+              $ref: '#/components/schemas/EditWorkflowRequest'
+        required: true
       responses:
         "200":
           description: Success
@@ -973,37 +1021,37 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ErrorResponse"
+                $ref: '#/components/schemas/ErrorResponse'
         "500":
           description: Internal server error
-      security:
-        - APIToken: []
+      x-visibility: Preview
   /rest/api/v1/agents/{agent_id}/schemas:
     get:
-      tags:
-        - Agents
+      operationId: getAgentSchemas
       summary: List an agent's schemas
       description: Return [agent](https://developers.glean.com/agents/agents-api)'s input and output schemas. You can use these schemas to detect changes to an agent's input or output structure.
-      operationId: getAgentSchemas
-      x-visibility: Preview
+      tags:
+        - Agents
+      security:
+        - APIToken: []
       parameters:
-        - $ref: "#/components/parameters/locale"
-        - $ref: "#/components/parameters/timezoneOffset"
-        - description: The ID of the agent.
+        - $ref: '#/components/parameters/locale'
+        - $ref: '#/components/parameters/timezoneOffset'
+        - name: agent_id
+          in: path
+          description: The ID of the agent.
           required: true
           schema:
             type: string
             title: Agent Id
             description: The ID of the agent.
-          name: agent_id
-          in: path
       responses:
         "200":
           description: Success
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/AgentSchemas"
+                $ref: '#/components/schemas/AgentSchemas'
         "400":
           description: Bad request
         "403":
@@ -1013,40 +1061,40 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ErrorResponse"
+                $ref: '#/components/schemas/ErrorResponse'
         "422":
           description: Validation Error
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ErrorResponse"
+                $ref: '#/components/schemas/ErrorResponse'
         "500":
           description: Internal server error
-      security:
-        - APIToken: []
+      x-visibility: Preview
       x-speakeasy-group: client.agents
       x-speakeasy-name-override: retrieveSchemas
   /rest/api/v1/agents/search:
     post:
-      tags:
-        - Agents
+      operationId: searchAgents
       summary: Search agents
       description: Search for [agents](https://developers.glean.com/agents/agents-api) by agent name.
-      operationId: searchAgents
-      x-visibility: Preview
+      tags:
+        - Agents
+      security:
+        - APIToken: []
       requestBody:
-        required: true
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/SearchAgentsRequest"
+              $ref: '#/components/schemas/SearchAgentsRequest'
+        required: true
       responses:
         "200":
           description: Success
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/SearchAgentsResponse"
+                $ref: '#/components/schemas/SearchAgentsResponse'
         "400":
           description: Bad request
         "403":
@@ -1056,32 +1104,32 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ErrorResponse"
+                $ref: '#/components/schemas/ErrorResponse'
         "422":
           description: Validation Error
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ErrorResponse"
+                $ref: '#/components/schemas/ErrorResponse'
         "500":
           description: Internal server error
-      security:
-        - APIToken: []
+      x-visibility: Preview
       x-speakeasy-group: client.agents
       x-speakeasy-name-override: list
   /rest/api/v1/agents/runs/stream:
     post:
+      operationId: createAndStreamRun
+      summary: Create an agent run and stream the response
+      description: 'Executes an [agent](https://developers.glean.com/agents/agents-api) run and returns the result as a stream of server-sent events (SSE). **Note**: If the agent uses an input form trigger, all form fields (including optional fields) must be included in the `input` object.'
       tags:
         - Agents
-      summary: Create an agent run and stream the response
-      description: "Executes an [agent](https://developers.glean.com/agents/agents-api) run and returns the result as a stream of server-sent events (SSE). **Note**: If the agent uses an input form trigger, all form fields (including optional fields) must be included in the `input` object."
-      operationId: createAndStreamRun
-      x-visibility: Preview
+      security:
+        - APIToken: []
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/AgentRunCreate"
+              $ref: '#/components/schemas/AgentRunCreate'
         required: true
       responses:
         "200":
@@ -1116,38 +1164,38 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ErrorResponse"
+                $ref: '#/components/schemas/ErrorResponse'
         "409":
           description: Conflict
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ErrorResponse"
+                $ref: '#/components/schemas/ErrorResponse'
         "422":
           description: Validation Error
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ErrorResponse"
+                $ref: '#/components/schemas/ErrorResponse'
         "500":
           description: Internal server error
-      security:
-        - APIToken: []
+      x-visibility: Preview
       x-speakeasy-group: client.agents
       x-speakeasy-name-override: runStream
   /rest/api/v1/agents/runs/wait:
     post:
+      operationId: createAndWaitRun
+      summary: Create an agent run and wait for the response
+      description: 'Executes an [agent](https://developers.glean.com/agents/agents-api) run and returns the final response. **Note**: If the agent uses an input form trigger, all form fields (including optional fields) must be included in the `input` object.'
       tags:
         - Agents
-      summary: Create an agent run and wait for the response
-      description: "Executes an [agent](https://developers.glean.com/agents/agents-api) run and returns the final response. **Note**: If the agent uses an input form trigger, all form fields (including optional fields) must be included in the `input` object."
-      operationId: createAndWaitRun
-      x-visibility: Preview
+      security:
+        - APIToken: []
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/AgentRunCreate"
+              $ref: '#/components/schemas/AgentRunCreate'
         required: true
       responses:
         "200":
@@ -1155,7 +1203,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/AgentRunWaitResponse"
+                $ref: '#/components/schemas/AgentRunWaitResponse'
         "400":
           description: Bad request
         "403":
@@ -1168,27 +1216,26 @@ paths:
           description: Validation Error
         "500":
           description: Internal server error
-      security:
-        - APIToken: []
+      x-visibility: Preview
       x-speakeasy-group: client.agents
       x-speakeasy-name-override: run
   /rest/api/v1/addcollectionitems:
     post:
-      tags:
-        - Collections
+      operationId: addcollectionitems
       summary: Add Collection item
       description: Add items to a Collection.
-      operationId: addcollectionitems
-      x-visibility: Public
-      x-codegen-request-body-name: payload
+      tags:
+        - Collections
+      security:
+        - APIToken: []
       parameters:
-        - $ref: "#/components/parameters/locale"
+        - $ref: '#/components/parameters/locale'
       requestBody:
+        description: Data describing the add operation.
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/AddCollectionItemsRequest"
-        description: Data describing the add operation.
+              $ref: '#/components/schemas/AddCollectionItemsRequest'
         required: true
         x-exportParamName: Request
       responses:
@@ -1197,34 +1244,34 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/AddCollectionItemsResponse"
+                $ref: '#/components/schemas/AddCollectionItemsResponse'
         "400":
           description: Invalid request
         "401":
           description: Not Authorized
         "429":
           description: Too Many Requests
-      security:
-        - APIToken: []
+      x-visibility: Public
+      x-codegen-request-body-name: payload
       x-speakeasy-name-override: addItems
       x-speakeasy-group: client.collections
   /rest/api/v1/createcollection:
     post:
-      tags:
-        - Collections
+      operationId: createcollection
       summary: Create Collection
       description: Create a publicly visible (empty) Collection of documents.
-      operationId: createcollection
-      x-visibility: Public
-      x-codegen-request-body-name: payload
+      tags:
+        - Collections
+      security:
+        - APIToken: []
       parameters:
-        - $ref: "#/components/parameters/locale"
+        - $ref: '#/components/parameters/locale'
       requestBody:
+        description: Collection content plus any additional metadata for the request.
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/CreateCollectionRequest"
-        description: Collection content plus any additional metadata for the request.
+              $ref: '#/components/schemas/CreateCollectionRequest'
         required: true
         x-exportParamName: Request
       responses:
@@ -1233,7 +1280,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/CreateCollectionResponse"
+                $ref: '#/components/schemas/CreateCollectionResponse'
         "400":
           description: Invalid request
         "401":
@@ -1243,30 +1290,30 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/CollectionError"
+                $ref: '#/components/schemas/CollectionError'
         "429":
           description: Too Many Requests
-      security:
-        - APIToken: []
+      x-visibility: Public
+      x-codegen-request-body-name: payload
       x-speakeasy-group: client.collections
       x-speakeasy-name-override: create
   /rest/api/v1/deletecollection:
     post:
-      tags:
-        - Collections
+      operationId: deletecollection
       summary: Delete Collection
       description: Delete a Collection given the Collection's ID.
-      operationId: deletecollection
-      x-visibility: Public
-      x-codegen-request-body-name: payload
+      tags:
+        - Collections
+      security:
+        - APIToken: []
       parameters:
-        - $ref: "#/components/parameters/locale"
+        - $ref: '#/components/parameters/locale'
       requestBody:
+        description: DeleteCollection request
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/DeleteCollectionRequest"
-        description: DeleteCollection request
+              $ref: '#/components/schemas/DeleteCollectionRequest'
         required: true
         x-exportParamName: Request
       responses:
@@ -1281,30 +1328,30 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/CollectionError"
+                $ref: '#/components/schemas/CollectionError'
         "429":
           description: Too Many Requests
-      security:
-        - APIToken: []
+      x-visibility: Public
+      x-codegen-request-body-name: payload
       x-speakeasy-name-override: delete
       x-speakeasy-group: client.collections
   /rest/api/v1/deletecollectionitem:
     post:
-      tags:
-        - Collections
+      operationId: deletecollectionitem
       summary: Delete Collection item
       description: Delete a single item from a Collection.
-      operationId: deletecollectionitem
-      x-visibility: Public
-      x-codegen-request-body-name: payload
+      tags:
+        - Collections
+      security:
+        - APIToken: []
       parameters:
-        - $ref: "#/components/parameters/locale"
+        - $ref: '#/components/parameters/locale'
       requestBody:
+        description: Data describing the delete operation.
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/DeleteCollectionItemRequest"
-        description: Data describing the delete operation.
+              $ref: '#/components/schemas/DeleteCollectionItemRequest'
         required: true
         x-exportParamName: Request
       responses:
@@ -1313,7 +1360,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/DeleteCollectionItemResponse"
+                $ref: '#/components/schemas/DeleteCollectionItemResponse'
         "400":
           description: Invalid request
         "401":
@@ -1322,27 +1369,27 @@ paths:
           description: Failed to save deletion
         "429":
           description: Too Many Requests
-      security:
-        - APIToken: []
+      x-visibility: Public
+      x-codegen-request-body-name: payload
       x-speakeasy-name-override: deleteItem
       x-speakeasy-group: client.collections
   /rest/api/v1/editcollection:
     post:
-      tags:
-        - Collections
+      operationId: editcollection
       summary: Update Collection
       description: Update the properties of an existing Collection.
-      operationId: editcollection
-      x-visibility: Public
-      x-codegen-request-body-name: payload
+      tags:
+        - Collections
+      security:
+        - APIToken: []
       parameters:
-        - $ref: "#/components/parameters/locale"
+        - $ref: '#/components/parameters/locale'
       requestBody:
+        description: Collection content plus any additional metadata for the request.
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/EditCollectionRequest"
-        description: Collection content plus any additional metadata for the request.
+              $ref: '#/components/schemas/EditCollectionRequest'
         required: true
         x-exportParamName: Request
       responses:
@@ -1351,7 +1398,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/EditCollectionResponse"
+                $ref: '#/components/schemas/EditCollectionResponse'
         "400":
           description: Invalid request
         "401":
@@ -1361,30 +1408,30 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/CollectionError"
+                $ref: '#/components/schemas/CollectionError'
         "429":
           description: Too Many Requests
-      security:
-        - APIToken: []
+      x-visibility: Public
+      x-codegen-request-body-name: payload
       x-speakeasy-name-override: update
       x-speakeasy-group: client.collections
   /rest/api/v1/editcollectionitem:
     post:
-      tags:
-        - Collections
+      operationId: editcollectionitem
       summary: Update Collection item
       description: Update the URL, Glean Document ID, description of an item within a Collection given its ID.
-      operationId: editcollectionitem
-      x-visibility: Public
-      x-codegen-request-body-name: payload
+      tags:
+        - Collections
+      security:
+        - APIToken: []
       parameters:
-        - $ref: "#/components/parameters/locale"
+        - $ref: '#/components/parameters/locale'
       requestBody:
+        description: Edit Collection Items request
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/EditCollectionItemRequest"
-        description: Edit Collection Items request
+              $ref: '#/components/schemas/EditCollectionItemRequest'
         required: true
         x-exportParamName: Request
       responses:
@@ -1393,34 +1440,34 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/EditCollectionItemResponse"
+                $ref: '#/components/schemas/EditCollectionItemResponse'
         "400":
           description: Invalid request
         "401":
           description: Not Authorized
         "429":
           description: Too Many Requests
-      security:
-        - APIToken: []
+      x-visibility: Public
+      x-codegen-request-body-name: payload
       x-speakeasy-name-override: updateItem
       x-speakeasy-group: client.collections
   /rest/api/v1/getcollection:
     post:
-      tags:
-        - Collections
+      operationId: getcollection
       summary: Read Collection
       description: Read the details of a Collection given its ID. Does not fetch items in this Collection.
-      operationId: getcollection
-      x-visibility: Preview
-      x-codegen-request-body-name: payload
+      tags:
+        - Collections
+      security:
+        - APIToken: []
       parameters:
-        - $ref: "#/components/parameters/locale"
+        - $ref: '#/components/parameters/locale'
       requestBody:
+        description: GetCollection request
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/GetCollectionRequest"
-        description: GetCollection request
+              $ref: '#/components/schemas/GetCollectionRequest'
         required: true
         x-exportParamName: Request
       responses:
@@ -1429,34 +1476,34 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/GetCollectionResponse"
+                $ref: '#/components/schemas/GetCollectionResponse'
         "400":
           description: Invalid request
         "401":
           description: Not Authorized
         "429":
           description: Too Many Requests
-      security:
-        - APIToken: []
+      x-visibility: Preview
+      x-codegen-request-body-name: payload
       x-speakeasy-name-override: retrieve
       x-speakeasy-group: client.collections
   /rest/api/v1/listcollections:
     post:
-      tags:
-        - Collections
+      operationId: listcollections
       summary: List Collections
       description: List all existing Collections.
-      operationId: listcollections
-      x-visibility: Public
-      x-codegen-request-body-name: payload
+      tags:
+        - Collections
+      security:
+        - APIToken: []
       parameters:
-        - $ref: "#/components/parameters/locale"
+        - $ref: '#/components/parameters/locale'
       requestBody:
+        description: ListCollections request
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/ListCollectionsRequest"
-        description: ListCollections request
+              $ref: '#/components/schemas/ListCollectionsRequest'
         required: true
         x-exportParamName: Request
       responses:
@@ -1465,34 +1512,34 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ListCollectionsResponse"
+                $ref: '#/components/schemas/ListCollectionsResponse'
         "400":
           description: Invalid request
         "401":
           description: Not Authorized
         "429":
           description: Too Many Requests
-      security:
-        - APIToken: []
+      x-visibility: Public
+      x-codegen-request-body-name: payload
       x-speakeasy-name-override: list
       x-speakeasy-group: client.collections
   /rest/api/v1/getdocpermissions:
     post:
-      tags:
-        - Documents
+      operationId: getdocpermissions
       summary: Read document permissions
       description: Read the emails of all users who have access to the given document.
-      operationId: getdocpermissions
-      x-visibility: Preview
-      x-codegen-request-body-name: payload
+      tags:
+        - Documents
+      security:
+        - APIToken: []
       parameters:
-        - $ref: "#/components/parameters/locale"
+        - $ref: '#/components/parameters/locale'
       requestBody:
+        description: Document permissions request
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/GetDocPermissionsRequest"
-        description: Document permissions request
+              $ref: '#/components/schemas/GetDocPermissionsRequest'
         required: true
         x-exportParamName: Request
       responses:
@@ -1501,7 +1548,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/GetDocPermissionsResponse"
+                $ref: '#/components/schemas/GetDocPermissionsResponse'
         "400":
           description: Invalid request
         "401":
@@ -1510,34 +1557,34 @@ paths:
           description: Forbidden
         "429":
           description: Too Many Requests
-      security:
-        - APIToken: []
+      x-visibility: Preview
+      x-codegen-request-body-name: payload
       x-speakeasy-name-override: retrievePermissions
       x-speakeasy-group: client.documents
   /rest/api/v1/getdocuments:
     post:
-      tags:
-        - Documents
+      operationId: getdocuments
       summary: Read documents
       description: Read the documents including metadata (does not include enhanced metadata via `/documentmetadata`) for the given list of Glean Document IDs or URLs specified in the request.
-      operationId: getdocuments
-      x-visibility: Public
-      x-codegen-request-body-name: payload
+      tags:
+        - Documents
+      security:
+        - APIToken: []
       parameters:
-        - $ref: "#/components/parameters/locale"
+        - $ref: '#/components/parameters/locale'
       requestBody:
+        description: Information about documents requested.
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/GetDocumentsRequest"
-        description: Information about documents requested.
+              $ref: '#/components/schemas/GetDocumentsRequest'
       responses:
         "200":
           description: OK
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/GetDocumentsResponse"
+                $ref: '#/components/schemas/GetDocumentsResponse'
         "400":
           description: Invalid request
         "401":
@@ -1546,34 +1593,34 @@ paths:
           description: Documents does not exist, or user cannot access documents.
         "429":
           description: Too Many Requests
-      security:
-        - APIToken: []
+      x-visibility: Public
+      x-codegen-request-body-name: payload
       x-speakeasy-name-override: retrieve
       x-speakeasy-group: client.documents
   /rest/api/v1/getdocumentsbyfacets:
     post:
-      tags:
-        - Documents
+      operationId: getdocumentsbyfacets
       summary: Read documents by facets
       description: Read the documents including metadata (does not include enhanced metadata via `/documentmetadata`) macthing the given facet conditions.
-      operationId: getdocumentsbyfacets
-      x-visibility: Preview
-      x-codegen-request-body-name: payload
+      tags:
+        - Documents
+      security:
+        - APIToken: []
       parameters:
-        - $ref: "#/components/parameters/locale"
+        - $ref: '#/components/parameters/locale'
       requestBody:
+        description: Information about facet conditions for documents to be retrieved.
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/GetDocumentsByFacetsRequest"
-        description: Information about facet conditions for documents to be retrieved.
+              $ref: '#/components/schemas/GetDocumentsByFacetsRequest'
       responses:
         "200":
           description: OK
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/GetDocumentsByFacetsResponse"
+                $ref: '#/components/schemas/GetDocumentsByFacetsResponse'
         "400":
           description: Invalid request
         "401":
@@ -1582,27 +1629,27 @@ paths:
           description: Not Found
         "429":
           description: Too Many Requests
-      security:
-        - APIToken: []
+      x-visibility: Preview
+      x-codegen-request-body-name: payload
       x-speakeasy-name-override: retrieveByFacets
       x-speakeasy-group: client.documents
   /rest/api/v1/insights:
     post:
-      tags:
-        - Insights
+      operationId: insights
       summary: Get insights
       description: Gets the aggregate usage insights data displayed in the Insights Dashboards.
-      operationId: insights
-      x-visibility: Public
-      x-codegen-request-body-name: payload
+      tags:
+        - Insights
+      security:
+        - APIToken: []
       parameters:
-        - $ref: "#/components/parameters/locale"
+        - $ref: '#/components/parameters/locale'
       requestBody:
+        description: Includes request parameters for insights requests.
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/InsightsRequest"
-        description: Includes request parameters for insights requests.
+              $ref: '#/components/schemas/InsightsRequest'
         required: true
         x-exportParamName: InsightsRequest
       responses:
@@ -1611,34 +1658,34 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/InsightsResponse"
+                $ref: '#/components/schemas/InsightsResponse'
         "400":
           description: Invalid request
         "401":
           description: Not Authorized
         "429":
           description: Too Many Requests
-      security:
-        - APIToken: []
+      x-visibility: Public
+      x-codegen-request-body-name: payload
       x-speakeasy-name-override: retrieve
       x-speakeasy-group: client.insights
   /rest/api/v1/messages:
     post:
-      tags:
-        - Messages
+      operationId: messages
       summary: Read messages
       description: Retrieves list of messages from messaging/chat datasources (e.g. Slack, Teams).
-      operationId: messages
-      x-visibility: Preview
-      x-codegen-request-body-name: payload
+      tags:
+        - Messages
+      security:
+        - APIToken: []
       parameters:
-        - $ref: "#/components/parameters/locale"
+        - $ref: '#/components/parameters/locale'
       requestBody:
+        description: Includes request params such as the id for channel/message and direction.
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/MessagesRequest"
-        description: Includes request params such as the id for channel/message and direction.
+              $ref: '#/components/schemas/MessagesRequest'
         required: true
         x-exportParamName: MessagesRequest
       responses:
@@ -1647,34 +1694,34 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/MessagesResponse"
+                $ref: '#/components/schemas/MessagesResponse'
         "400":
           description: Invalid request
         "401":
           description: Not Authorized
         "429":
           description: Too Many Requests
-      security:
-        - APIToken: []
+      x-visibility: Preview
+      x-codegen-request-body-name: payload
       x-speakeasy-name-override: retrieve
       x-speakeasy-group: client.messages
   /rest/api/v1/editpin:
     post:
-      tags:
-        - Pins
+      operationId: editpin
       summary: Update pin
       description: Update an existing user-generated pin.
-      operationId: editpin
-      x-visibility: Public
-      x-codegen-request-body-name: payload
+      tags:
+        - Pins
+      security:
+        - APIToken: []
       parameters:
-        - $ref: "#/components/parameters/locale"
+        - $ref: '#/components/parameters/locale'
       requestBody:
+        description: Edit pins request
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/EditPinRequest"
-        description: Edit pins request
+              $ref: '#/components/schemas/EditPinRequest'
         required: true
         x-exportParamName: Request
       responses:
@@ -1683,34 +1730,34 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/PinDocument"
+                $ref: '#/components/schemas/PinDocument'
         "400":
           description: Invalid request
         "401":
           description: Not Authorized
         "429":
           description: Too Many Requests
-      security:
-        - APIToken: []
+      x-visibility: Public
+      x-codegen-request-body-name: payload
       x-speakeasy-name-override: update
       x-speakeasy-group: client.pins
   /rest/api/v1/getpin:
     post:
-      tags:
-        - Pins
+      operationId: getpin
       summary: Read pin
       description: Read pin details given its ID.
-      operationId: getpin
-      x-visibility: Public
-      x-codegen-request-body-name: payload
+      tags:
+        - Pins
+      security:
+        - APIToken: []
       parameters:
-        - $ref: "#/components/parameters/locale"
+        - $ref: '#/components/parameters/locale'
       requestBody:
+        description: Get pin request
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/GetPinRequest"
-        description: Get pin request
+              $ref: '#/components/schemas/GetPinRequest'
         required: true
         x-exportParamName: Request
       responses:
@@ -1719,34 +1766,34 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/GetPinResponse"
+                $ref: '#/components/schemas/GetPinResponse'
         "400":
           description: Invalid request
         "401":
           description: Not Authorized
         "429":
           description: Too Many Requests
-      security:
-        - APIToken: []
+      x-visibility: Public
+      x-codegen-request-body-name: payload
       x-speakeasy-name-override: retrieve
       x-speakeasy-group: client.pins
   /rest/api/v1/listpins:
     post:
-      tags:
-        - Pins
+      operationId: listpins
       summary: List pins
       description: Lists all pins.
-      operationId: listpins
-      x-visibility: Public
-      x-codegen-request-body-name: payload
+      tags:
+        - Pins
+      security:
+        - APIToken: []
       parameters:
-        - $ref: "#/components/parameters/locale"
+        - $ref: '#/components/parameters/locale'
       requestBody:
+        description: List pins request
         content:
           application/json:
             schema:
               type: object
-        description: List pins request
         required: true
         x-exportParamName: Request
       responses:
@@ -1755,34 +1802,34 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ListPinsResponse"
+                $ref: '#/components/schemas/ListPinsResponse'
         "400":
           description: Invalid request
         "401":
           description: Not Authorized
         "429":
           description: Too Many Requests
-      security:
-        - APIToken: []
+      x-visibility: Public
+      x-codegen-request-body-name: payload
       x-speakeasy-name-override: list
       x-speakeasy-group: client.pins
   /rest/api/v1/pin:
     post:
-      tags:
-        - Pins
+      operationId: pin
       summary: Create pin
       description: Pin a document as a result for a given search query.Pin results that are known to be a good match.
-      operationId: pin
-      x-visibility: Public
-      x-codegen-request-body-name: payload
+      tags:
+        - Pins
+      security:
+        - APIToken: []
       parameters:
-        - $ref: "#/components/parameters/locale"
+        - $ref: '#/components/parameters/locale'
       requestBody:
+        description: Details about the document and query for the pin.
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/PinRequest"
-        description: Details about the document and query for the pin.
+              $ref: '#/components/schemas/PinRequest'
         required: true
         x-exportParamName: PinDocument
       responses:
@@ -1791,34 +1838,34 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/PinDocument"
+                $ref: '#/components/schemas/PinDocument'
         "400":
           description: Invalid request
         "401":
           description: Not Authorized
         "429":
           description: Too Many Requests
-      security:
-        - APIToken: []
+      x-visibility: Public
+      x-codegen-request-body-name: payload
       x-speakeasy-name-override: create
       x-speakeasy-group: client.pins
   /rest/api/v1/unpin:
     post:
-      tags:
-        - Pins
+      operationId: unpin
       summary: Delete pin
       description: Unpin a previously pinned result.
-      operationId: unpin
-      x-visibility: Public
-      x-codegen-request-body-name: payload
+      tags:
+        - Pins
+      security:
+        - APIToken: []
       parameters:
-        - $ref: "#/components/parameters/locale"
+        - $ref: '#/components/parameters/locale'
       requestBody:
+        description: Details about the pin being unpinned.
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/Unpin"
-        description: Details about the pin being unpinned.
+              $ref: '#/components/schemas/Unpin'
         required: true
         x-exportParamName: Unpin
       responses:
@@ -1832,27 +1879,27 @@ paths:
           description: Forbidden from unpinning someone else's pin
         "429":
           description: Too Many Requests
-      security:
-        - APIToken: []
+      x-visibility: Public
+      x-codegen-request-body-name: payload
       x-speakeasy-name-override: remove
       x-speakeasy-group: client.pins
   /rest/api/v1/adminsearch:
     post:
-      tags:
-        - Search
+      operationId: adminsearch
       summary: Search the index (admin)
       description: Retrieves results for search query without respect for permissions. This is available only to privileged users.
-      operationId: adminsearch
-      x-visibility: Preview
-      x-codegen-request-body-name: payload
+      tags:
+        - Search
+      security:
+        - APIToken: []
       parameters:
-        - $ref: "#/components/parameters/locale"
+        - $ref: '#/components/parameters/locale'
       requestBody:
+        description: Admin search request
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/SearchRequest"
-        description: Admin search request
+              $ref: '#/components/schemas/SearchRequest'
         required: true
         x-exportParamName: Request
       responses:
@@ -1861,7 +1908,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/SearchResponse"
+                $ref: '#/components/schemas/SearchResponse'
         "400":
           description: Invalid request
         "401":
@@ -1871,36 +1918,36 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ErrorInfo"
+                $ref: '#/components/schemas/ErrorInfo'
         "422":
           description: Invalid Query
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ErrorInfo"
+                $ref: '#/components/schemas/ErrorInfo'
         "429":
           description: Too Many Requests
-      security:
-        - APIToken: []
+      x-visibility: Preview
+      x-codegen-request-body-name: payload
       x-speakeasy-group: client.search
       x-speakeasy-name-override: queryAsAdmin
   /rest/api/v1/autocomplete:
     post:
-      tags:
-        - Search
+      operationId: autocomplete
       summary: Autocomplete
       description: Retrieve query suggestions, operators and documents for the given partially typed query.
-      operationId: autocomplete
-      x-visibility: Public
-      x-codegen-request-body-name: payload
+      tags:
+        - Search
+      security:
+        - APIToken: []
       parameters:
-        - $ref: "#/components/parameters/locale"
+        - $ref: '#/components/parameters/locale'
       requestBody:
+        description: Autocomplete request
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/AutocompleteRequest"
-        description: Autocomplete request
+              $ref: '#/components/schemas/AutocompleteRequest'
         required: true
         x-exportParamName: Request
       responses:
@@ -1909,34 +1956,34 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/AutocompleteResponse"
+                $ref: '#/components/schemas/AutocompleteResponse'
         "400":
           description: Invalid request
         "401":
           description: Not Authorized
         "429":
           description: Too Many Requests
-      security:
-        - APIToken: []
+      x-visibility: Public
+      x-codegen-request-body-name: payload
       x-speakeasy-group: client.search
       x-speakeasy-name-override: autocomplete
   /rest/api/v1/feed:
     post:
-      tags:
-        - Search
+      operationId: feed
       summary: Feed of documents and events
       description: The personalized feed/home includes different types of contents including suggestions, recents, calendar events and many more.
-      operationId: feed
-      x-visibility: Public
-      x-codegen-request-body-name: payload
+      tags:
+        - Search
+      security:
+        - APIToken: []
       parameters:
-        - $ref: "#/components/parameters/locale"
+        - $ref: '#/components/parameters/locale'
       requestBody:
+        description: Includes request params, client data and more for making user's feed.
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/FeedRequest"
-        description: Includes request params, client data and more for making user's feed.
+              $ref: '#/components/schemas/FeedRequest'
         required: true
         x-exportParamName: FeedRequest
       responses:
@@ -1945,7 +1992,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/FeedResponse"
+                $ref: '#/components/schemas/FeedResponse'
         "400":
           description: Invalid request
         "401":
@@ -1954,27 +2001,27 @@ paths:
           description: Request Timeout
         "429":
           description: Too Many Requests
-      security:
-        - APIToken: []
+      x-visibility: Public
+      x-codegen-request-body-name: payload
       x-speakeasy-name-override: retrieveFeed
       x-speakeasy-group: client.search
   /rest/api/v1/recommendations:
     post:
-      tags:
-        - Search
+      operationId: recommendations
       summary: Recommend documents
       description: Retrieve recommended documents for the given URL or Glean Document ID.
-      operationId: recommendations
-      x-visibility: Preview
-      x-codegen-request-body-name: payload
+      tags:
+        - Search
+      security:
+        - APIToken: []
       parameters:
-        - $ref: "#/components/parameters/locale"
+        - $ref: '#/components/parameters/locale'
       requestBody:
+        description: Recommendations request
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/RecommendationsRequest"
-        description: Recommendations request
+              $ref: '#/components/schemas/RecommendationsRequest'
         required: true
         x-exportParamName: Request
       responses:
@@ -1983,7 +2030,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/RecommendationsResponse"
+                $ref: '#/components/schemas/RecommendationsResponse'
         "202":
           description: Accepted. The Retry-After header has a hint about when the response will be available
         "204":
@@ -1996,27 +2043,27 @@ paths:
           description: Document does not exist or user cannot access document
         "429":
           description: Too Many Requests
-      security:
-        - APIToken: []
+      x-visibility: Preview
+      x-codegen-request-body-name: payload
       x-speakeasy-group: client.search
       x-speakeasy-name-override: recommendations
   /rest/api/v1/search:
     post:
-      tags:
-        - Search
+      operationId: search
       summary: Search
       description: Retrieve results from the index for the given query and filters.
-      operationId: search
-      x-visibility: Public
-      x-codegen-request-body-name: payload
+      tags:
+        - Search
+      security:
+        - APIToken: []
       parameters:
-        - $ref: "#/components/parameters/locale"
+        - $ref: '#/components/parameters/locale'
       requestBody:
+        description: Search request
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/SearchRequest"
-        description: Search request
+              $ref: '#/components/schemas/SearchRequest'
         required: true
         x-exportParamName: Request
       responses:
@@ -2025,7 +2072,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/SearchResponse"
+                $ref: '#/components/schemas/SearchResponse'
         "400":
           description: Invalid request
         "401":
@@ -2035,7 +2082,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ErrorInfo"
+                $ref: '#/components/schemas/ErrorInfo'
         "408":
           description: Request Timeout
         "422":
@@ -2043,30 +2090,30 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ErrorInfo"
+                $ref: '#/components/schemas/ErrorInfo'
         "429":
           description: Too Many Requests
-      security:
-        - APIToken: []
+      x-visibility: Public
+      x-codegen-request-body-name: payload
       x-speakeasy-group: client.search
       x-speakeasy-name-override: query
   /rest/api/v1/listentities:
     post:
-      tags:
-        - Entities
+      operationId: listentities
       summary: List entities
       description: List some set of details for all entities that fit the given criteria and return in the requested order. Does not support negation in filters, assumes relation type EQUALS. There is a limit of 10000 entities that can be retrieved via this endpoint, except when using FULL_DIRECTORY request type for people entities.
-      operationId: listentities
-      x-visibility: Public
-      x-codegen-request-body-name: payload
+      tags:
+        - Entities
+      security:
+        - APIToken: []
       parameters:
-        - $ref: "#/components/parameters/locale"
+        - $ref: '#/components/parameters/locale'
       requestBody:
+        description: List people request
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/ListEntitiesRequest"
-        description: List people request
+              $ref: '#/components/schemas/ListEntitiesRequest'
         required: true
         x-exportParamName: Request
       responses:
@@ -2075,34 +2122,34 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ListEntitiesResponse"
+                $ref: '#/components/schemas/ListEntitiesResponse'
         "400":
           description: Invalid request
         "401":
           description: Not Authorized
         "429":
           description: Too Many Requests
-      security:
-        - APIToken: []
+      x-visibility: Public
+      x-codegen-request-body-name: payload
       x-speakeasy-group: client.entities
       x-speakeasy-name-override: list
   /rest/api/v1/people:
     post:
-      tags:
-        - Entities
+      operationId: people
       summary: Read people
       description: Read people details for the given IDs.
-      operationId: people
-      x-visibility: Public
-      x-codegen-request-body-name: payload
+      tags:
+        - Entities
+      security:
+        - APIToken: []
       parameters:
-        - $ref: "#/components/parameters/locale"
+        - $ref: '#/components/parameters/locale'
       requestBody:
+        description: People request
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/PeopleRequest"
-        description: People request
+              $ref: '#/components/schemas/PeopleRequest'
         required: true
         x-exportParamName: Request
       responses:
@@ -2111,38 +2158,39 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/PeopleResponse"
+                $ref: '#/components/schemas/PeopleResponse'
         "400":
           description: Invalid request
         "401":
           description: Not Authorized
         "429":
           description: Too Many Requests
-      security:
-        - APIToken: []
+      x-visibility: Public
+      x-codegen-request-body-name: payload
       x-speakeasy-name-override: readPeople
       x-speakeasy-group: client.entities
   /rest/api/v1/people/{person_id}/photo:
     get:
-      tags:
-        - Entities
+      operationId: getPersonPhoto
       summary: Get person photo
       description: |
         Returns the profile photo bytes for a person whose photo is stored in Glean (crawled from an identity source or user-uploaded via admin console). Photos hosted externally (e.g. Slack CDN) are not served by this endpoint; callers should follow the photoUrl from /people or /listentities directly. Responses include a Cache-Control header (max-age=3600) to reduce redundant fetches.
-      operationId: getPersonPhoto
-      x-visibility: Public
+      tags:
+        - Entities
+      security:
+        - APIToken: []
       parameters:
         - name: person_id
           in: path
-          required: true
           description: The obfuscated ID of the person whose photo to retrieve.
+          required: true
           schema:
             type: string
         - name: ds
           in: query
-          required: false
           description: |
             Optional datasource override for crawled photos (e.g. AZURE, GDRIVE, OKTA). When omitted, the datasource is derived from the person's stored photo URL or the deployment's primary person datasource.
+          required: false
           schema:
             type: string
       responses:
@@ -2172,25 +2220,24 @@ paths:
             Person not found, person has no photo, or photo is not hosted by Glean (follow photoUrl from /people or /listentities directly).
         "429":
           description: Too Many Requests.
-      security:
-        - APIToken: []
+      x-visibility: Public
   /rest/api/v1/createshortcut:
     post:
-      tags:
-        - Shortcuts
+      operationId: createshortcut
       summary: Create shortcut
       description: Create a user-generated shortcut that contains an alias and destination URL.
-      operationId: createshortcut
-      x-visibility: Public
-      x-codegen-request-body-name: payload
+      tags:
+        - Shortcuts
+      security:
+        - APIToken: []
       parameters:
-        - $ref: "#/components/parameters/locale"
+        - $ref: '#/components/parameters/locale'
       requestBody:
+        description: CreateShortcut request
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/CreateShortcutRequest"
-        description: CreateShortcut request
+              $ref: '#/components/schemas/CreateShortcutRequest'
         required: true
         x-exportParamName: Request
       responses:
@@ -2199,34 +2246,34 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/CreateShortcutResponse"
+                $ref: '#/components/schemas/CreateShortcutResponse'
         "400":
           description: Invalid request
         "401":
           description: Not Authorized
         "429":
           description: Too Many Requests
-      security:
-        - APIToken: []
+      x-visibility: Public
+      x-codegen-request-body-name: payload
       x-speakeasy-name-override: create
       x-speakeasy-group: client.shortcuts
   /rest/api/v1/deleteshortcut:
     post:
-      tags:
-        - Shortcuts
+      operationId: deleteshortcut
       summary: Delete shortcut
       description: Delete an existing user-generated shortcut.
-      operationId: deleteshortcut
-      x-visibility: Public
-      x-codegen-request-body-name: payload
+      tags:
+        - Shortcuts
+      security:
+        - APIToken: []
       parameters:
-        - $ref: "#/components/parameters/locale"
+        - $ref: '#/components/parameters/locale'
       requestBody:
+        description: DeleteShortcut request
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/DeleteShortcutRequest"
-        description: DeleteShortcut request
+              $ref: '#/components/schemas/DeleteShortcutRequest'
         required: true
         x-exportParamName: Request
       responses:
@@ -2238,27 +2285,27 @@ paths:
           description: Not Authorized
         "429":
           description: Too Many Requests
-      security:
-        - APIToken: []
+      x-visibility: Public
+      x-codegen-request-body-name: payload
       x-speakeasy-name-override: delete
       x-speakeasy-group: client.shortcuts
   /rest/api/v1/getshortcut:
     post:
-      tags:
-        - Shortcuts
+      operationId: getshortcut
       summary: Read shortcut
       description: Read a particular shortcut's details given its ID.
-      operationId: getshortcut
-      x-visibility: Public
-      x-codegen-request-body-name: payload
+      tags:
+        - Shortcuts
+      security:
+        - APIToken: []
       parameters:
-        - $ref: "#/components/parameters/locale"
+        - $ref: '#/components/parameters/locale'
       requestBody:
+        description: GetShortcut request
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/GetShortcutRequest"
-        description: GetShortcut request
+              $ref: '#/components/schemas/GetShortcutRequest'
         required: true
         x-exportParamName: Request
       responses:
@@ -2267,34 +2314,34 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/GetShortcutResponse"
+                $ref: '#/components/schemas/GetShortcutResponse'
         "400":
           description: Invalid request
         "401":
           description: Not Authorized
         "429":
           description: Too Many Requests
-      security:
-        - APIToken: []
+      x-visibility: Public
+      x-codegen-request-body-name: payload
       x-speakeasy-group: client.shortcuts
       x-speakeasy-name-override: retrieve
   /rest/api/v1/listshortcuts:
     post:
-      tags:
-        - Shortcuts
+      operationId: listshortcuts
       summary: List shortcuts
       description: List shortcuts editable/owned by the currently authenticated user.
-      operationId: listshortcuts
-      x-visibility: Public
-      x-codegen-request-body-name: payload
+      tags:
+        - Shortcuts
+      security:
+        - APIToken: []
       parameters:
-        - $ref: "#/components/parameters/locale"
+        - $ref: '#/components/parameters/locale'
       requestBody:
+        description: Filters, sorters, paging params required for pagination
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/ListShortcutsPaginatedRequest"
-        description: Filters, sorters, paging params required for pagination
+              $ref: '#/components/schemas/ListShortcutsPaginatedRequest'
         required: true
         x-exportParamName: Request
       responses:
@@ -2303,34 +2350,34 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ListShortcutsPaginatedResponse"
+                $ref: '#/components/schemas/ListShortcutsPaginatedResponse'
         "400":
           description: Invalid request
         "401":
           description: Not Authorized
         "429":
           description: Too Many Requests
-      security:
-        - APIToken: []
+      x-visibility: Public
+      x-codegen-request-body-name: payload
       x-speakeasy-group: client.shortcuts
       x-speakeasy-name-override: list
   /rest/api/v1/updateshortcut:
     post:
-      tags:
-        - Shortcuts
+      operationId: updateshortcut
       summary: Update shortcut
       description: Updates the shortcut with the given ID.
-      operationId: updateshortcut
-      x-visibility: Public
-      x-codegen-request-body-name: payload
+      tags:
+        - Shortcuts
+      security:
+        - APIToken: []
       parameters:
-        - $ref: "#/components/parameters/locale"
+        - $ref: '#/components/parameters/locale'
       requestBody:
+        description: Shortcut content. Id need to be specified for the shortcut.
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/UpdateShortcutRequest"
-        description: Shortcut content. Id need to be specified for the shortcut.
+              $ref: '#/components/schemas/UpdateShortcutRequest'
         required: true
         x-exportParamName: Request
       responses:
@@ -2339,34 +2386,34 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/UpdateShortcutResponse"
+                $ref: '#/components/schemas/UpdateShortcutResponse'
         "400":
           description: Invalid request
         "401":
           description: Not Authorized
         "429":
           description: Too Many Requests
-      security:
-        - APIToken: []
+      x-visibility: Public
+      x-codegen-request-body-name: payload
       x-speakeasy-group: client.shortcuts
       x-speakeasy-name-override: update
   /rest/api/v1/summarize:
     post:
-      tags:
-        - Summarize
+      operationId: summarize
       summary: Summarize documents
       description: Generate an AI summary of the requested documents.
-      operationId: summarize
-      x-visibility: Public
-      x-codegen-request-body-name: payload
+      tags:
+        - Summarize
+      security:
+        - APIToken: []
       parameters:
-        - $ref: "#/components/parameters/locale"
+        - $ref: '#/components/parameters/locale'
       requestBody:
+        description: Includes request params such as the query and specs of the documents to summarize.
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/SummarizeRequest"
-        description: Includes request params such as the query and specs of the documents to summarize.
+              $ref: '#/components/schemas/SummarizeRequest'
         required: true
         x-exportParamName: Request
       responses:
@@ -2375,34 +2422,34 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/SummarizeResponse"
+                $ref: '#/components/schemas/SummarizeResponse'
         "400":
           description: Invalid request
         "401":
           description: Not Authorized
         "429":
           description: Too Many Requests
-      security:
-        - APIToken: []
+      x-visibility: Public
+      x-codegen-request-body-name: payload
       x-speakeasy-name-override: summarize
       x-speakeasy-group: client.documents
   /rest/api/v1/addverificationreminder:
     post:
-      tags:
-        - Verification
+      operationId: addverificationreminder
       summary: Create verification
       description: Creates a verification reminder for the document. Users can create verification reminders from different product surfaces.
-      operationId: addverificationreminder
-      x-visibility: Public
-      x-codegen-request-body-name: payload
+      tags:
+        - Verification
+      security:
+        - APIToken: []
       parameters:
-        - $ref: "#/components/parameters/locale"
+        - $ref: '#/components/parameters/locale'
       requestBody:
+        description: Details about the reminder.
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/ReminderRequest"
-        description: Details about the reminder.
+              $ref: '#/components/schemas/ReminderRequest'
         required: true
         x-exportParamName: ReminderRequest
       responses:
@@ -2411,7 +2458,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Verification"
+                $ref: '#/components/schemas/Verification'
         "400":
           description: Invalid request
         "401":
@@ -2420,61 +2467,61 @@ paths:
           description: Document does not exist, does not support verification or user cannot access document
         "429":
           description: Too Many Requests
-      security:
-        - APIToken: []
+      x-visibility: Public
+      x-codegen-request-body-name: payload
       x-speakeasy-name-override: addReminder
       x-speakeasy-group: client.verification
   /rest/api/v1/listverifications:
     post:
-      tags:
-        - Verification
+      operationId: listverifications
       summary: List verifications
       description: Returns the information to be rendered in verification dashboard. Includes information for each document owned by user regarding their verifications.
-      operationId: listverifications
-      x-visibility: Public
-      x-codegen-request-body-name: payload
+      tags:
+        - Verification
+      security:
+        - APIToken: []
       parameters:
-        - in: query
-          name: count
+        - name: count
+          in: query
           description: Maximum number of documents to return
           required: false
           schema:
             type: integer
-        - $ref: "#/components/parameters/locale"
+        - $ref: '#/components/parameters/locale'
       responses:
         "200":
           description: OK
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/VerificationFeed"
+                $ref: '#/components/schemas/VerificationFeed'
         "400":
           description: Invalid request
         "401":
           description: Not Authorized
         "429":
           description: Too Many Requests
-      security:
-        - APIToken: []
+      x-visibility: Public
+      x-codegen-request-body-name: payload
       x-speakeasy-name-override: list
       x-speakeasy-group: client.verification
   /rest/api/v1/verify:
     post:
-      tags:
-        - Verification
+      operationId: verify
       summary: Update verification
       description: Verify documents to keep the knowledge up to date within customer corpus.
-      operationId: verify
-      x-visibility: Public
-      x-codegen-request-body-name: payload
+      tags:
+        - Verification
+      security:
+        - APIToken: []
       parameters:
-        - $ref: "#/components/parameters/locale"
+        - $ref: '#/components/parameters/locale'
       requestBody:
+        description: Details about the verification request.
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/VerifyRequest"
-        description: Details about the verification request.
+              $ref: '#/components/schemas/VerifyRequest'
         required: true
         x-exportParamName: VerifyRequest
       responses:
@@ -2483,7 +2530,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Verification"
+                $ref: '#/components/schemas/Verification'
         "400":
           description: Invalid request
         "401":
@@ -2492,36 +2539,37 @@ paths:
           description: Document does not exist, does not support verification or user cannot access document
         "429":
           description: Too Many Requests
-      security:
-        - APIToken: []
+      x-visibility: Public
+      x-codegen-request-body-name: payload
       x-speakeasy-name-override: verify
       x-speakeasy-group: client.verification
   /rest/api/v1/tools/list:
     get:
+      summary: List available tools
+      description: Returns a filtered set of available tools based on optional tool name parameters. If no filters are provided, all available tools are returned.
       tags:
         - Tools
         - Tools
-      summary: List available tools
-      description: Returns a filtered set of available tools based on optional tool name parameters. If no filters are provided, all available tools are returned.
-      x-visibility: Preview
+      security:
+        - APIToken: []
       parameters:
-        - in: query
-          name: toolNames
+        - name: toolNames
+          in: query
           description: Optional array of tool names to filter by
           required: false
+          style: form
+          explode: false
           schema:
             type: array
             items:
               type: string
-          style: form
-          explode: false
       responses:
         "200":
           description: Successful operation
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ToolsListResponse"
+                $ref: '#/components/schemas/ToolsListResponse'
         "400":
           description: Bad Request
         "401":
@@ -2530,31 +2578,31 @@ paths:
           description: Not Found
         "429":
           description: Too Many Requests
-      security:
-        - APIToken: []
+      x-visibility: Preview
       x-speakeasy-name-override: list
       x-speakeasy-group: client.tools
   /rest/api/v1/tools/call:
     post:
+      summary: Execute the specified tool
+      description: Execute the specified tool with provided parameters
       tags:
         - Tools
         - Tools
-      summary: Execute the specified tool
-      description: Execute the specified tool with provided parameters
-      x-visibility: Preview
+      security:
+        - APIToken: []
       requestBody:
-        required: true
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/ToolsCallRequest"
+              $ref: '#/components/schemas/ToolsCallRequest'
+        required: true
       responses:
         "200":
           description: Successful operation
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ToolsCallResponse"
+                $ref: '#/components/schemas/ToolsCallResponse'
         "400":
           description: Bad Request
         "401":
@@ -2563,35 +2611,28 @@ paths:
           description: Not Found
         "429":
           description: Too Many Requests
-      security:
-        - APIToken: []
+      x-visibility: Preview
       x-speakeasy-name-override: run
       x-speakeasy-group: client.tools
   /rest/api/v1/actions/{actionPackId}/auth:
-    parameters:
-      - in: path
-        name: actionPackId
-        required: true
-        description: ID of the action pack to query or authorize.
-        schema:
-          type: string
     get:
-      tags:
-        - Tools
+      operationId: getActionAuthStatus
       summary: Get end-user authentication status for an action pack.
       description: |
         Reports whether the calling user is already authenticated against the third-party
         tool backing the specified action pack. Intended for headless / server-driven clients
         that render an "Authorize" prompt when the user has not yet consented to the tool.
-      operationId: getActionAuthStatus
-      x-visibility: Preview
+      tags:
+        - Tools
+      security:
+        - APIToken: []
       responses:
         "200":
           description: Successful operation
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ActionAuthStatusResponse"
+                $ref: '#/components/schemas/ActionAuthStatusResponse'
         "400":
           description: Bad Request
         "401":
@@ -2600,11 +2641,9 @@ paths:
           description: Action pack not found
         "429":
           description: Too Many Requests
-      security:
-        - APIToken: []
+      x-visibility: Preview
     post:
-      tags:
-        - Tools
+      operationId: authorizeAction
       summary: Start the OAuth authorization flow for an action pack.
       description: |
         Starts the third-party OAuth flow for the specified action pack and returns the
@@ -2614,21 +2653,23 @@ paths:
 
         `returnUrl` must match the tenant's configured return URL allowlist; otherwise the
         request is rejected with 400.
-      operationId: authorizeAction
-      x-visibility: Preview
+      tags:
+        - Tools
+      security:
+        - APIToken: []
       requestBody:
-        required: true
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/AuthorizeActionRequest"
+              $ref: '#/components/schemas/AuthorizeActionRequest'
+        required: true
       responses:
         "200":
           description: Successful operation
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/AuthorizeActionResponse"
+                $ref: '#/components/schemas/AuthorizeActionResponse'
         "400":
           description: Invalid request (e.g. returnUrl not in allowlist, unsupported auth type)
         "401":
@@ -2639,8 +2680,14 @@ paths:
           description: Action pack not found
         "429":
           description: Too Many Requests
-      security:
-        - APIToken: []
+      x-visibility: Preview
+    parameters:
+      - name: actionPackId
+        in: path
+        description: ID of the action pack to query or authorize.
+        required: true
+        schema:
+          type: string
   /api/index/v1/indexdocument:
     post:
       summary: Index document
@@ -4454,14 +4501,234 @@ paths:
 components:
   securitySchemes:
     APIToken:
-      scheme: bearer
       type: http
+      scheme: bearer
   schemas:
+    PlatformFilter:
+      type: object
+      required:
+        - field
+        - values
+      description: |
+        A single filter criterion. Multiple values within a filter are OR'd. Filters are AND'd with each other and with any inline query operators.
+      properties:
+        field:
+          type: string
+          description: |
+            The field to filter on. Accepts built-in operator names such as `type`, `owner`, `from`, `author`, `channel`, `status`, `assignee`, `reporter`, `component`, `mentions`, and `collection`, plus custom datasource property names.
+          example: type
+        values:
+          type: array
+          minItems: 1
+          items:
+            type: string
+          description: One or more values to match.
+          example:
+            - spreadsheet
+            - presentation
+        exclude:
+          type: boolean
+          default: false
+          description: Excludes results matching any of the specified values when true.
+    PlatformTimeRange:
+      type: object
+      description: Filter results to those last updated within this range.
+      properties:
+        start:
+          type: string
+          format: date-time
+          description: Inclusive lower bound in ISO 8601 format.
+        end:
+          type: string
+          format: date-time
+          description: Exclusive upper bound in ISO 8601 format.
+    PlatformSearchRequest:
+      type: object
+      additionalProperties: false
+      required:
+        - query
+      properties:
+        query:
+          type: string
+          description: |
+            The search query string. Supports inline operators such as `from:jane type:document app:confluence`. Inline operators are AND'd with structured `filters`.
+          example: quarterly planning 2026
+        page_size:
+          type: integer
+          minimum: 1
+          maximum: 100
+          default: 10
+          description: Number of results to return per page.
+        cursor:
+          type: string
+          nullable: true
+          description: |
+            Opaque pagination token from a previous response's `next_cursor` field. Omit on the first request.
+        datasources:
+          type: array
+          items:
+            type: string
+          description: Restrict results to specific datasources.
+          example:
+            - confluence
+            - google_drive
+        filters:
+          type: array
+          items:
+            $ref: "#/components/schemas/PlatformFilter"
+          description: |
+            Structured filters applied to search results. Multiple values within a filter are OR'd. Multiple filters are AND'd together. Filters are AND'd with any inline operators in `query`. Note that conflicting constraints on the same field (e.g., `type:document` in the query and `type: spreadsheet` in a filter) produce an empty result set.
+        time_range:
+          $ref: "#/components/schemas/PlatformTimeRange"
+    PlatformPerson:
+      type: object
+      nullable: true
+      description: A person associated with the result.
+      properties:
+        name:
+          type: string
+          description: Display name.
+          example: Jane Smith
+        email:
+          type: string
+          format: email
+          description: Email address.
+          example: jane.smith@company.com
+    PlatformResult:
+      type: object
+      required:
+        - url
+        - title
+        - datasource
+      properties:
+        url:
+          type: string
+          format: uri
+          description: Canonical URL of the result.
+          example: https://company.atlassian.net/wiki/spaces/ENG/pages/12345
+        title:
+          type: string
+          description: Result title.
+          example: Q2 2026 Platform Roadmap
+        snippets:
+          type: array
+          items:
+            type: string
+          description: Query-relevant plain-text excerpts from the result body.
+          example:
+            - The platform team will focus on API stability and...
+        datasource:
+          type: string
+          description: The datasource this result originates from.
+          example: confluence
+        document_type:
+          type: string
+          nullable: true
+          description: The document type within the datasource.
+          example: page
+        creator:
+          $ref: "#/components/schemas/PlatformPerson"
+        owner:
+          $ref: "#/components/schemas/PlatformPerson"
+        updated_at:
+          type: string
+          format: date-time
+          nullable: true
+          description: When the result was last modified.
+        created_at:
+          type: string
+          format: date-time
+          nullable: true
+          description: When the result was created.
+    PlatformSearchResponse:
+      type: object
+      required:
+        - results
+        - has_more
+        - next_cursor
+        - request_id
+      properties:
+        results:
+          type: array
+          items:
+            $ref: "#/components/schemas/PlatformResult"
+          description: Ordered list of search results.
+        has_more:
+          type: boolean
+          description: Indicates whether additional pages of results are available.
+        next_cursor:
+          type: string
+          nullable: true
+          description: Opaque token to pass as `cursor` in the next request.
+        request_id:
+          type: string
+          description: Platform-generated request ID for support correlation.
+    PlatformProblemDetail:
+      type: object
+      required:
+        - type
+        - title
+        - status
+        - detail
+        - code
+        - request_id
+      description: |
+        Error response following RFC 9457, extended with `code` and `documentation_url` for machine-readable classification and self-service remediation.
+      properties:
+        type:
+          type: string
+          format: uri
+          description: URI identifying the error type.
+          example: https://developer.glean.com/errors/invalid-cursor
+        title:
+          type: string
+          description: Short, human-readable summary of the error.
+          example: Invalid Pagination Cursor
+        status:
+          type: integer
+          description: HTTP status code mirrored from the response.
+          example: 400
+        detail:
+          type: string
+          description: Human-readable explanation specific to this occurrence.
+          example: |
+            The provided cursor has expired. Start a new search to get a fresh cursor.
+        code:
+          type: string
+          description: Stable machine-readable error code.
+          enum:
+            - invalid_request
+            - missing_required_field
+            - invalid_parameter
+            - invalid_cursor
+            - expired_cursor
+            - invalid_filter
+            - authentication_required
+            - token_expired
+            - insufficient_permissions
+            - resource_not_found
+            - request_timeout
+            - conflict
+            - gone
+            - unprocessable_query
+            - rate_limit_exceeded
+            - internal_error
+            - service_unavailable
+          example: invalid_cursor
+        documentation_url:
+          type: string
+          format: uri
+          description: Direct URL to documentation for this error code.
+          example: https://developer.glean.com/errors/invalid-cursor
+        request_id:
+          type: string
+          description: Platform-generated request ID for support correlation.
+          example: req_7f8a9b0c1d2e
     ActivityEventParams:
       properties:
         bodyContent:
-          description: The HTML content of the page body.
           type: string
+          description: The HTML content of the page body.
         datasourceInstance:
           type: string
           description: The full datasource instance name inferred from the URL of the event
@@ -4472,32 +4739,35 @@ components:
           type: string
           description: The instance only name of the datasource instance, e.g. 1 for jira_1, inferred from the URL of the event
         duration:
-          description: Length in seconds of the activity. For VIEWS, this represents the amount the page was visible in the foreground.
           type: integer
+          description: Length in seconds of the activity. For VIEWS, this represents the amount the page was visible in the foreground.
         query:
+          type: string
           description: The user's search query associated with a SEARCH.
-          type: string
         referrer:
+          type: string
           description: The referring URL of the VIEW or SEARCH.
-          type: string
         title:
-          description: The page title associated with the URL of the event
           type: string
+          description: The page title associated with the URL of the event
         truncated:
-          description: Indicates that the parameters are incomplete and more parameters may be sent with the same action+timestamp+URL in the future. This is used for sending the duration when a `VIEW` is finished.
           type: boolean
+          description: Indicates that the parameters are incomplete and more parameters may be sent with the same action+timestamp+URL in the future. This is used for sending the duration when a `VIEW` is finished.
     ActivityEvent:
-      required:
-        - action
-        - source
-        - timestamp
-        - url
       properties:
         id:
           type: string
           description: Universally unique identifier of the event. To allow for reliable retransmission, only the earliest received event of a given UUID is considered valid by the server and subsequent are ignored.
         action:
           type: string
+          enum:
+            - VIEW
+            - EDIT
+            - SEARCH
+            - COMMENT
+            - CRAWL
+            - HISTORICAL_SEARCH
+            - HISTORICAL_VIEW
           description: The type of activity this represents.
           x-enumDescriptions:
             VIEW: Represents a visit to the given `url`.
@@ -4507,14 +4777,6 @@ components:
             CRAWL: Represents an explicit request to index the given `url` along with associated attributes in this payload.
             HISTORICAL_SEARCH: Represents a search performed at the given `url` as indicated by the user's history.
             HISTORICAL_VIEW: Represents a visit to the given `url` as indicated by the user's history.
-          enum:
-            - VIEW
-            - EDIT
-            - SEARCH
-            - COMMENT
-            - CRAWL
-            - HISTORICAL_SEARCH
-            - HISTORICAL_VIEW
           x-speakeasy-enum-descriptions:
             VIEW: Represents a visit to the given `url`.
             EDIT: Represents an edit of the document represented by the `url`.
@@ -4524,22 +4786,27 @@ components:
             HISTORICAL_SEARCH: Represents a search performed at the given `url` as indicated by the user's history.
             HISTORICAL_VIEW: Represents a visit to the given `url` as indicated by the user's history.
         params:
-          $ref: "#/components/schemas/ActivityEventParams"
+          $ref: '#/components/schemas/ActivityEventParams'
         timestamp:
           type: string
-          description: The ISO 8601 timestamp when the activity began.
           format: date-time
+          description: The ISO 8601 timestamp when the activity began.
         url:
-          description: The URL of the activity.
           type: string
-    Activity:
+          description: The URL of the activity.
       required:
-        - events
+        - action
+        - source
+        - timestamp
+        - url
+    Activity:
       properties:
         events:
           type: array
           items:
-            $ref: "#/components/schemas/ActivityEvent"
+            $ref: '#/components/schemas/ActivityEvent'
+      required:
+        - events
       example:
         events:
           - url: https://example.com/
@@ -4574,11 +4841,11 @@ components:
     User:
       properties:
         userID:
+          type: string
           description: An opaque user ID for the claimed authority (i.e., the actas param, or the origid if actas is not specified).
-          type: string
         origID:
-          description: An opaque user ID for the authenticated user (ignores actas).
           type: string
+          description: An opaque user ID for the authenticated user (ignores actas).
     FeedbackChatExchange:
       properties:
         timestamp:
@@ -4596,13 +4863,13 @@ components:
           description: Search query performed by the agent.
         resultDocuments:
           type: array
-          description: List of documents read by the agent.
           items:
             properties:
               title:
                 type: string
               url:
                 type: string
+          description: List of documents read by the agent.
         response:
           type: string
     ManualFeedbackInfo:
@@ -4613,7 +4880,6 @@ components:
           deprecated: true
         source:
           type: string
-          description: The source associated with the Feedback.event.MANUAL_FEEDBACK event.
           enum:
             - AUTOCOMPLETE
             - CALENDAR
@@ -4637,13 +4903,13 @@ components:
             - SUMMARY
             - TASKS
             - TASK_EXECUTION
+          description: The source associated with the Feedback.event.MANUAL_FEEDBACK event.
         issue:
           type: string
           description: The issue the user indicated in the feedback.
           deprecated: true
         issues:
           type: array
-          description: The issue(s) the user indicated in the feedback.
           items:
             type: string
             enum:
@@ -4662,6 +4928,7 @@ components:
               - RESULTS_HELPFUL
               - RESULTS_POOR_ORDER
               - TOO_MUCH_ONE_KIND
+          description: The issue(s) the user indicated in the feedback.
         imageUrls:
           type: array
           items:
@@ -4692,17 +4959,17 @@ components:
         chatTranscript:
           type: array
           items:
-            $ref: "#/components/schemas/FeedbackChatExchange"
+            $ref: '#/components/schemas/FeedbackChatExchange'
           description: Array of previous request/response exchanges, ordered by oldest to newest.
         numQueriesFromFirstRun:
           type: integer
           description: How many times this query has been run in the past.
         vote:
           type: string
-          description: The vote associated with the Feedback.event.MANUAL_FEEDBACK event.
           enum:
             - UPVOTE
             - DOWNVOTE
+          description: The vote associated with the Feedback.event.MANUAL_FEEDBACK event.
         rating:
           type: integer
           description: A rating associated with the user feedback. The value will be between one and the maximum given by ratingScale, inclusive.
@@ -4722,15 +4989,14 @@ components:
           description: Human-readable name for this implementation (e.g., "Variant A", "GPT-4", "Claude").
         searchParams:
           type: object
-          description: The search/chat parameters used for this implementation.
           additionalProperties:
             type: string
+          description: The search/chat parameters used for this implementation.
         response:
           type: string
           description: The full response generated by this implementation.
         responseMetadata:
           type: object
-          description: Metadata about the response (e.g., latency, token count).
           properties:
             latencyMs:
               type: integer
@@ -4741,6 +5007,7 @@ components:
             modelUsed:
               type: string
               description: The specific model version used.
+          description: Metadata about the response (e.g., latency, token count).
     ManualFeedbackSideBySideInfo:
       properties:
         email:
@@ -4748,19 +5015,19 @@ components:
           description: The email address of the user who submitted the side-by-side feedback.
         source:
           type: string
-          description: The source associated with the side-by-side feedback event.
           enum:
             - LIVE_EVAL
             - CHAT
             - SEARCH
+          description: The source associated with the side-by-side feedback event.
         query:
           type: string
           description: The query or prompt that was evaluated across multiple implementations.
         implementations:
           type: array
-          description: Array of implementations that were compared side-by-side.
           items:
-            $ref: "#/components/schemas/SideBySideImplementation"
+            $ref: '#/components/schemas/SideBySideImplementation'
+          description: Array of implementations that were compared side-by-side.
         evaluationSessionId:
           type: string
           description: Unique identifier for this evaluation session to group related feedback events.
@@ -4769,11 +5036,11 @@ components:
           description: The ID of the implementation this specific feedback event is for.
         vote:
           type: string
-          description: The vote for this specific implementation.
           enum:
             - UPVOTE
             - DOWNVOTE
             - NEUTRAL
+          description: The vote for this specific implementation.
         comments:
           type: string
           description: Specific feedback comments for this implementation.
@@ -4803,16 +5070,12 @@ components:
             - HOMEPAGE
           description: Where the feedback of the workflow originated from
     Feedback:
-      required:
-        - event
-        - trackingTokens
       properties:
         id:
           type: string
           description: Universally unique identifier of the event. To allow for reliable retransmission, only the earliest received event of a given UUID is considered valid by the server and subsequent are ignored.
         category:
           type: string
-          description: The feature category to which the feedback applies. These should be broad product areas such as Announcements, Answers, Search, etc. rather than specific components or UI treatments within those areas.
           enum:
             - ANNOUNCEMENT
             - AUTOCOMPLETE
@@ -4826,46 +5089,14 @@ components:
             - GENERAL
             - PRISM
             - PROMPTS
+          description: The feature category to which the feedback applies. These should be broad product areas such as Announcements, Answers, Search, etc. rather than specific components or UI treatments within those areas.
         trackingTokens:
           type: array
-          description: A list of server-generated trackingTokens to which this event applies.
           items:
             type: string
+          description: A list of server-generated trackingTokens to which this event applies.
         event:
           type: string
-          description: The action the user took within a Glean client with respect to the object referred to by the given `trackingToken`.
-          x-enumDescriptions:
-            CLICK: The object's primary link was clicked with the intent to view its full representation. Depending on the object type, this may imply an external navigation or navigating to a new page or view within the Glean app.
-            CONTAINER_CLICK: A link to the object's parent container (e.g. the folder in which it's located) was clicked.
-            COPY_LINK: The user copied a link to the primary link.
-            CREATE: The user creates a document.
-            DISMISS: The user dismissed the object such that it was hidden from view.
-            DOWNVOTE: The user gave feedback that the object was not useful.
-            EMAIL: The user attempted to send an email.
-            EXECUTE: The user executed the object (e.g. ran a workflow).
-            FILTER: The user applied a filter.
-            FIRST_TOKEN: The first token of a streaming response is received.
-            FOCUS_IN: The user clicked into an interactive element, e.g. the search box.
-            LAST_TOKEN: The final token of a streaming response is received.
-            MANUAL_FEEDBACK: The user submitted textual manual feedback regarding the object.
-            MANUAL_FEEDBACK_SIDE_BY_SIDE: The user submitted comparative feedback for multiple side-by-side implementations.
-            FEEDBACK_TIME_SAVED: The user submitted feedback about time saved by an agent or workflow.
-            MARK_AS_READ: The user explicitly marked the content as read.
-            MESSAGE: The user attempted to send a message using their default messaing app.
-            MIDDLE_CLICK: The user middle clicked the object's primary link with the intent to open its full representation in a new tab.
-            PAGE_BLUR: The user puts a page out of focus but keeps it in the background.
-            PAGE_FOCUS: The user puts a page in focus, meaning it is the first to receive keyboard events.
-            PAGE_LEAVE: The user leaves a page and it is unloaded (by clicking a link, closing the tab/window, etc).
-            PREVIEW: The user clicked the object's inline preview affordance.
-            RIGHT_CLICK: The user right clicked the object's primary link. This may indicate an intent to open it in a new tab or copy it.
-            SECTION_CLICK: The user clicked a link to a subsection of the primary object.
-            SEEN: The user has likely seen the object (e.g. took action to make the object visible within the user's viewport).
-            SELECT: The user explicitly selected something, eg. a chat response variant they prefer.
-            SHARE: The user shared the object with another user.
-            SHOW_MORE: The user clicked the object's show more affordance.
-            UPVOTE: The user gave feedback that the object was useful.
-            VIEW: The object was visible within the user's viewport.
-            VISIBLE: The object was visible within the user's viewport.
           enum:
             - CLICK
             - CONTAINER_CLICK
@@ -4899,6 +5130,39 @@ components:
             - UPVOTE
             - VIEW
             - VISIBLE
+          description: The action the user took within a Glean client with respect to the object referred to by the given `trackingToken`.
+          x-enumDescriptions:
+            CLICK: The object's primary link was clicked with the intent to view its full representation. Depending on the object type, this may imply an external navigation or navigating to a new page or view within the Glean app.
+            CONTAINER_CLICK: A link to the object's parent container (e.g. the folder in which it's located) was clicked.
+            COPY_LINK: The user copied a link to the primary link.
+            CREATE: The user creates a document.
+            DISMISS: The user dismissed the object such that it was hidden from view.
+            DOWNVOTE: The user gave feedback that the object was not useful.
+            EMAIL: The user attempted to send an email.
+            EXECUTE: The user executed the object (e.g. ran a workflow).
+            FILTER: The user applied a filter.
+            FIRST_TOKEN: The first token of a streaming response is received.
+            FOCUS_IN: The user clicked into an interactive element, e.g. the search box.
+            LAST_TOKEN: The final token of a streaming response is received.
+            MANUAL_FEEDBACK: The user submitted textual manual feedback regarding the object.
+            MANUAL_FEEDBACK_SIDE_BY_SIDE: The user submitted comparative feedback for multiple side-by-side implementations.
+            FEEDBACK_TIME_SAVED: The user submitted feedback about time saved by an agent or workflow.
+            MARK_AS_READ: The user explicitly marked the content as read.
+            MESSAGE: The user attempted to send a message using their default messaing app.
+            MIDDLE_CLICK: The user middle clicked the object's primary link with the intent to open its full representation in a new tab.
+            PAGE_BLUR: The user puts a page out of focus but keeps it in the background.
+            PAGE_FOCUS: The user puts a page in focus, meaning it is the first to receive keyboard events.
+            PAGE_LEAVE: The user leaves a page and it is unloaded (by clicking a link, closing the tab/window, etc).
+            PREVIEW: The user clicked the object's inline preview affordance.
+            RIGHT_CLICK: The user right clicked the object's primary link. This may indicate an intent to open it in a new tab or copy it.
+            SECTION_CLICK: The user clicked a link to a subsection of the primary object.
+            SEEN: The user has likely seen the object (e.g. took action to make the object visible within the user's viewport).
+            SELECT: The user explicitly selected something, eg. a chat response variant they prefer.
+            SHARE: The user shared the object with another user.
+            SHOW_MORE: The user clicked the object's show more affordance.
+            UPVOTE: The user gave feedback that the object was useful.
+            VIEW: The object was visible within the user's viewport.
+            VISIBLE: The object was visible within the user's viewport.
           x-speakeasy-enum-descriptions:
             CLICK: The object's primary link was clicked with the intent to view its full representation. Depending on the object type, this may imply an external navigation or navigating to a new page or view within the Glean app.
             CONTAINER_CLICK: A link to the object's parent container (e.g. the folder in which it's located) was clicked.
@@ -4938,65 +5202,67 @@ components:
           type: string
           description: For type MANUAL_FEEDBACK, contains string of user feedback. For autocomplete, partial query string. For feed, string of user feedback in addition to manual feedback signals extracted from all suggested content.
         sessionInfo:
-          $ref: "#/components/schemas/SessionInfo"
+          $ref: '#/components/schemas/SessionInfo'
         timestamp:
           type: string
-          description: The ISO 8601 timestamp when the event occured.
           format: date-time
+          description: The ISO 8601 timestamp when the event occured.
         user:
-          $ref: "#/components/schemas/User"
+          $ref: '#/components/schemas/User'
         pathname:
           type: string
           description: The path the client was at when the feedback event triggered.
         channels:
           type: array
-          description: Where the feedback will be sent, e.g. to Glean, the user's company, or both. If no channels are specified, feedback will go only to Glean.
           items:
             type: string
             enum:
               - COMPANY
               - GLEAN
+          description: Where the feedback will be sent, e.g. to Glean, the user's company, or both. If no channels are specified, feedback will go only to Glean.
         url:
           type: string
           description: The URL the client was at when the feedback event triggered.
         uiTree:
-          description: The UI element tree associated with the event, if any.
+          type: array
           items:
             type: string
-          type: array
+          description: The UI element tree associated with the event, if any.
         uiElement:
           type: string
           description: The UI element associated with the event, if any.
         manualFeedbackInfo:
-          $ref: "#/components/schemas/ManualFeedbackInfo"
+          $ref: '#/components/schemas/ManualFeedbackInfo'
         manualFeedbackSideBySideInfo:
-          $ref: "#/components/schemas/ManualFeedbackSideBySideInfo"
+          $ref: '#/components/schemas/ManualFeedbackSideBySideInfo'
         seenFeedbackInfo:
-          $ref: "#/components/schemas/SeenFeedbackInfo"
+          $ref: '#/components/schemas/SeenFeedbackInfo'
         userViewInfo:
-          $ref: "#/components/schemas/UserViewInfo"
+          $ref: '#/components/schemas/UserViewInfo'
         workflowFeedbackInfo:
-          $ref: "#/components/schemas/WorkflowFeedbackInfo"
+          $ref: '#/components/schemas/WorkflowFeedbackInfo'
         applicationId:
           type: string
           description: The application ID of the client that sent the feedback event.
         agentId:
           type: string
           description: The agent ID of the client that sent the feedback event.
+      required:
+        - event
+        - trackingTokens
       example:
         trackingTokens:
           - trackingTokens
         event: VIEW
     StructuredTextMutableProperties:
-      required:
-        - text
       properties:
         text:
           type: string
           example: From https://en.wikipedia.org/wiki/Diffuse_sky_radiation, the sky is blue because blue light is more strongly scattered than longer-wavelength light.
+      required:
+        - text
     ConnectorType:
       type: string
-      description: The source from which document content was pulled, e.g. an API crawl or browser history
       enum:
         - API_CRAWL
         - BROWSER_CRAWL
@@ -5006,6 +5272,7 @@ components:
         - PUSH_API
         - WEB_CRAWL
         - NATIVE_HISTORY
+      description: The source from which document content was pulled, e.g. an API crawl or browser history
     DocumentContent:
       properties:
         fullTextList:
@@ -5022,16 +5289,16 @@ components:
           type: string
           description: The app or other repository type from which the document was extracted
         connectorType:
-          $ref: "#/components/schemas/ConnectorType"
+          $ref: '#/components/schemas/ConnectorType'
         docType:
           type: string
           description: The datasource-specific type of the document (e.g. for Jira issues, this is the issue type such as Bug or Feature Request).
         content:
-          $ref: "#/components/schemas/DocumentContent"
+          $ref: '#/components/schemas/DocumentContent'
         containerDocument:
-          $ref: "#/components/schemas/Document"
+          $ref: '#/components/schemas/Document'
         parentDocument:
-          $ref: "#/components/schemas/Document"
+          $ref: '#/components/schemas/Document'
         title:
           type: string
           description: The title of the document.
@@ -5039,12 +5306,12 @@ components:
           type: string
           description: A permalink for the document.
         metadata:
-          $ref: "#/components/schemas/DocumentMetadata"
+          $ref: '#/components/schemas/DocumentMetadata'
         sections:
           type: array
-          description: A list of content sub-sections in the document, e.g. text blocks with different headings in a Drive doc or Confluence page.
           items:
-            $ref: "#/components/schemas/DocumentSection"
+            $ref: '#/components/schemas/DocumentSection'
+          description: A list of content sub-sections in the document, e.g. text blocks with different headings in a Drive doc or Confluence page.
     SearchProviderInfo:
       properties:
         name:
@@ -5087,13 +5354,13 @@ components:
             - LT
             - GT
             - NOT_EQUALS
+          example: EQUALS
           x-enumDescriptions:
             EQUALS: The value is equal to the specified value.
             ID_EQUALS: The value is equal to the specified ID.
             LT: The value is less than the specified value.
             GT: The value is greater than the specified value.
             NOT_EQUALS: The value is not equal to the specified value.
-          example: EQUALS
           x-speakeasy-enum-descriptions:
             EQUALS: The value is equal to the specified value.
             ID_EQUALS: The value is equal to the specified ID.
@@ -5102,8 +5369,8 @@ components:
             NOT_EQUALS: The value is not equal to the specified value.
         isNegated:
           type: boolean
-          deprecated: true
           description: DEPRECATED - please use relationType instead
+          deprecated: true
           x-glean-deprecated:
             id: 75a48c79-b36a-4171-a0a0-4af7189da66e
             introduced: "2026-02-05"
@@ -5118,12 +5385,12 @@ components:
         values:
           type: array
           items:
-            $ref: "#/components/schemas/FacetFilterValue"
+            $ref: '#/components/schemas/FacetFilterValue'
           description: Within a single FacetFilter, the values are to be treated like an OR. For example, fieldName type with values [EQUALS Presentation, EQUALS Spreadsheet] means we want to show a document if it's a Presentation OR a Spreadsheet.
         groupName:
           type: string
-          example: Spreadsheet
           description: Indicates the value of a facet, if any, that the given facet is grouped under. This is only used for nested facets, for example, fieldName could be owner and groupName would be Spreadsheet if showing all owners for spreadsheets as a nested facet.
+          example: Spreadsheet
       example:
         fieldName: type
         values:
@@ -5136,7 +5403,7 @@ components:
         filters:
           type: array
           items:
-            $ref: "#/components/schemas/FacetFilter"
+            $ref: '#/components/schemas/FacetFilter'
       description: Within a single FacetFilterSet, the filters are treated as AND. For example, owner Sumeet and type Spreadsheet shows documents that are by Sumeet AND are Spreadsheets.
     FacetBucketFilter:
       properties:
@@ -5147,9 +5414,6 @@ components:
           type: string
           description: The per-term prefix that facet buckets should be filtered on.
     AuthToken:
-      required:
-        - accessToken
-        - datasource
       properties:
         accessToken:
           type: string
@@ -5160,12 +5424,15 @@ components:
         tokenType:
           type: string
         authUser:
-          description: Used by Google to indicate the index of the logged in user. Useful for generating hyperlinks that support multilogin.
           type: string
+          description: Used by Google to indicate the index of the logged in user. Useful for generating hyperlinks that support multilogin.
         expiration:
-          description: Unix timestamp when this token expires (in seconds since epoch UTC).
           type: integer
           format: int64
+          description: Unix timestamp when this token expires (in seconds since epoch UTC).
+      required:
+        - accessToken
+        - datasource
       example:
         accessToken: 123abc
         datasource: gmail
@@ -5173,28 +5440,24 @@ components:
         tokenType: Bearer
         authUser: "1"
     DocumentSpec:
-      x-multiple-discriminators: true
       oneOf:
         - type: object
-          required:
-            - url
           properties:
             url:
               type: string
-              x-discriminator: true
               description: The URL of the document.
-        - type: object
+              x-discriminator: true
           required:
-            - id
+            - url
+        - type: object
           properties:
             id:
               type: string
-              x-discriminator: true
               description: The ID of the document.
-        - type: object
+              x-discriminator: true
           required:
-            - contentId
-            - ugcType
+            - id
+        - type: object
           properties:
             ugcType:
               type: string
@@ -5207,15 +5470,15 @@ components:
               description: The type of the user generated content (UGC datasource).
             contentId:
               type: integer
-              x-discriminator: true
               description: The numeric id for user generated content. Used for ANNOUNCEMENTS, ANSWERS, COLLECTIONS, SHORTCUTS.
+              x-discriminator: true
             docType:
               type: string
               description: The specific type of the user generated content type.
-        - type: object
           required:
+            - contentId
             - ugcType
-            - ugcId
+        - type: object
           properties:
             ugcType:
               type: string
@@ -5229,21 +5492,23 @@ components:
               description: The type of the user generated content (UGC datasource).
             ugcId:
               type: string
-              x-discriminator: true
               description: The string id for user generated content. Used for CHATS.
+              x-discriminator: true
             docType:
               type: string
               description: The specific type of the user generated content type.
+          required:
+            - ugcType
+            - ugcId
+      x-multiple-discriminators: true
     RestrictionFilters:
       properties:
         containerSpecs:
-          description: "Specifications for containers that should be used as part of the restriction (include/exclude). Memberships are recursively defined for a subset of datasources (currently: SharePoint, OneDrive, Google Drive, and Confluence). Please contact the Glean team to enable this for more datasources. Recursive memberships do not apply for Collections."
           type: array
           items:
-            $ref: "#/components/schemas/DocumentSpec"
+            $ref: '#/components/schemas/DocumentSpec'
+          description: 'Specifications for containers that should be used as part of the restriction (include/exclude). Memberships are recursively defined for a subset of datasources (currently: SharePoint, OneDrive, Google Drive, and Confluence). Please contact the Glean team to enable this for more datasources. Recursive memberships do not apply for Collections.'
     SearchRequestOptions:
-      required:
-        - facetBucketSize
       properties:
         datasourceFilter:
           type: string
@@ -5259,15 +5524,15 @@ components:
         facetFilters:
           type: array
           items:
-            $ref: "#/components/schemas/FacetFilter"
+            $ref: '#/components/schemas/FacetFilter'
           description: A list of filters for the query. An AND is assumed between different facetFilters. For example, owner Sumeet and type Spreadsheet shows documents that are by Sumeet AND are Spreadsheets.
         facetFilterSets:
           type: array
           items:
-            $ref: "#/components/schemas/FacetFilterSet"
+            $ref: '#/components/schemas/FacetFilterSet'
           description: A list of facet filter sets that will be OR'ed together. SearchRequestOptions where both facetFilterSets and facetFilters set are considered as bad request. Callers should set only one of these fields.
         facetBucketFilter:
-          $ref: "#/components/schemas/FacetBucketFilter"
+          $ref: '#/components/schemas/FacetBucketFilter'
         facetBucketSize:
           type: integer
           description: The maximum number of FacetBuckets to return in each FacetResult.
@@ -5278,17 +5543,22 @@ components:
           description: Facets for which FacetResults should be fetched and that don't apply to a particular datasource. If specified, these values will replace the standard default facets (last_updated_at, from, etc.). The requested facets will be returned alongside datasource-specific facets if searching a single datasource.
         authTokens:
           type: array
-          description: Auth tokens which may be used for non-indexed, federated results (e.g. Gmail).
           items:
-            $ref: "#/components/schemas/AuthToken"
+            $ref: '#/components/schemas/AuthToken'
+          description: Auth tokens which may be used for non-indexed, federated results (e.g. Gmail).
         fetchAllDatasourceCounts:
           type: boolean
           description: Hints that the QE should return result counts (via the datasource facet result) for all supported datasources, rather than just those specified in the datasource[s]Filter
         responseHints:
           type: array
-          description: Array of hints containing which fields should be populated in the response.
           items:
             type: string
+            enum:
+              - ALL_RESULT_COUNTS
+              - FACET_RESULTS
+              - QUERY_METADATA
+              - RESULTS
+              - SPELLCHECK_METADATA
             description: Hints for the response content.
             x-enumDescriptions:
               ALL_RESULT_COUNTS: Return result counts for each result set which has non-zero results, even when the request itself is limited to a subset.
@@ -5296,18 +5566,13 @@ components:
               QUERY_METADATA: Returns result counts for each result set which has non-zero results, as well as other information about the search such as suggested spelling corrections.
               RESULTS: Return search result documents.
               SPELLCHECK_METADATA: Return metadata pertaining to spellcheck results.
-            enum:
-              - ALL_RESULT_COUNTS
-              - FACET_RESULTS
-              - QUERY_METADATA
-              - RESULTS
-              - SPELLCHECK_METADATA
             x-speakeasy-enum-descriptions:
               ALL_RESULT_COUNTS: Return result counts for each result set which has non-zero results, even when the request itself is limited to a subset.
               FACET_RESULTS: Return only facet results.
               QUERY_METADATA: Returns result counts for each result set which has non-zero results, as well as other information about the search such as suggested spelling corrections.
               RESULTS: Return search result documents.
               SPELLCHECK_METADATA: Return metadata pertaining to spellcheck results.
+          description: Array of hints containing which fields should be populated in the response.
         timezoneOffset:
           type: integer
           description: The offset of the client's timezone in minutes from UTC. e.g. PDT is -420 because it's 7 hours behind UTC.
@@ -5321,11 +5586,13 @@ components:
           type: boolean
           description: Enables expanded content to be returned for LLM usage. The size of content per result returned should be modified using maxSnippetSize. Server may return less or more than what is specified in maxSnippetSize. For more details, see https://developers.glean.com/guides/search/llm-content.
         inclusions:
-          $ref: "#/components/schemas/RestrictionFilters"
+          $ref: '#/components/schemas/RestrictionFilters'
           description: A list of filters which restrict the search results to only the specified content.
         exclusions:
-          $ref: "#/components/schemas/RestrictionFilters"
+          $ref: '#/components/schemas/RestrictionFilters'
           description: A list of filters specifying content to avoid getting search results from. Exclusions take precendence over inclusions and other query parameters, such as search operators and search facets.
+      required:
+        - facetBucketSize
       example:
         datasourceFilter: JIRA
         datasourcesFilter:
@@ -5341,9 +5608,6 @@ components:
               - fieldValues
               - fieldValues
     TextRange:
-      required:
-        - startIndex
-      description: A subsection of a given string to which some special formatting should be applied.
       properties:
         startIndex:
           type: integer
@@ -5362,8 +5626,11 @@ components:
           type: string
           description: The URL associated with the range, if applicable. For example, the linked URL for a LINK range.
         document:
-          $ref: "#/components/schemas/Document"
+          $ref: '#/components/schemas/Document'
           description: A document corresponding to the range, if applicable. For example, the cited document for a CITATION range.
+      required:
+        - startIndex
+      description: A subsection of a given string to which some special formatting should be applied.
     SearchRequestInputDetails:
       properties:
         hasCopyPaste:
@@ -5372,8 +5639,6 @@ components:
       example:
         hasCopyPaste: true
     QuerySuggestion:
-      required:
-        - query
       properties:
         missingTerm:
           type: string
@@ -5382,7 +5647,7 @@ components:
           type: string
           description: The query being suggested (e.g. enforcing the missing term from the original query).
         searchProviderInfo:
-          $ref: "#/components/schemas/SearchProviderInfo"
+          $ref: '#/components/schemas/SearchProviderInfo'
           description: Information about the search provider that generated this suggestion.
         label:
           type: string
@@ -5391,25 +5656,24 @@ components:
           type: string
           description: The datasource associated with the suggestion.
         resultTab:
-          $ref: "#/components/schemas/ResultTab"
+          $ref: '#/components/schemas/ResultTab'
           description: The result tab associated with the suggestion.
         requestOptions:
-          $ref: "#/components/schemas/SearchRequestOptions"
+          $ref: '#/components/schemas/SearchRequestOptions'
         ranges:
           type: array
           items:
-            $ref: "#/components/schemas/TextRange"
+            $ref: '#/components/schemas/TextRange'
           description: The bolded ranges within the query of the QuerySuggestion.
         inputDetails:
-          $ref: "#/components/schemas/SearchRequestInputDetails"
+          $ref: '#/components/schemas/SearchRequestInputDetails'
+      required:
+        - query
       example:
         query: app:github type:pull author:mortimer
         label: Mortimer's PRs
         datasource: github
     Person:
-      required:
-        - name
-        - obfuscatedId
       properties:
         name:
           type: string
@@ -5420,16 +5684,17 @@ components:
         relatedDocuments:
           type: array
           items:
-            $ref: "#/components/schemas/RelatedDocuments"
+            $ref: '#/components/schemas/RelatedDocuments'
           description: A list of documents related to this person.
         metadata:
-          $ref: "#/components/schemas/PersonMetadata"
+          $ref: '#/components/schemas/PersonMetadata'
+      required:
+        - name
+        - obfuscatedId
       example:
         name: George Clooney
         obfuscatedId: abc123
     Company:
-      required:
-        - name
       properties:
         name:
           type: string
@@ -5439,9 +5704,9 @@ components:
           description: Link to internal company company profile.
         websiteUrls:
           type: array
-          description: Link to company's associated websites.
           items:
             type: string
+          description: Link to company's associated websites.
         logoUrl:
           type: string
           description: The URL of the company's logo. Public, Glean-authenticated and Base64 encoded data URLs are all valid (but not third-party-authenticated URLs).
@@ -5478,11 +5743,13 @@ components:
           type: string
           description: User facing description of company.
           example: Financial, software, data, and media company headquartered in Midtown Manhattan, New York City
+      required:
+        - name
     DocumentCounts:
       type: object
-      description: A map of {string, int} pairs representing counts of each document type associated with this customer.
       additionalProperties:
         type: integer
+      description: A map of {string, int} pairs representing counts of each document type associated with this customer.
     CustomDataValue:
       properties:
         displayLabel:
@@ -5491,54 +5758,51 @@ components:
           type: string
         stringListValue:
           type: array
-          description: list of strings for multi-value properties
           items:
             type: string
+          description: list of strings for multi-value properties
         numberValue:
           type: number
         booleanValue:
           type: boolean
     CustomData:
       type: object
-      description: Custom fields specific to individual datasources
       additionalProperties:
-        $ref: "#/components/schemas/CustomDataValue"
+        $ref: '#/components/schemas/CustomDataValue'
+      description: Custom fields specific to individual datasources
     CustomerMetadata:
       properties:
         datasourceId:
           type: string
           description: The user visible id of the salesforce customer account.
         customData:
-          $ref: "#/components/schemas/CustomData"
+          $ref: '#/components/schemas/CustomData'
     Customer:
-      required:
-        - id
-        - company
       properties:
         id:
           type: string
           description: Unique identifier.
         domains:
           type: array
-          description: Link to company's associated website domains.
           items:
             type: string
+          description: Link to company's associated website domains.
         company:
-          $ref: "#/components/schemas/Company"
+          $ref: '#/components/schemas/Company'
         documentCounts:
-          $ref: "#/components/schemas/DocumentCounts"
+          $ref: '#/components/schemas/DocumentCounts'
         poc:
           type: array
-          description: A list of POC for company.
           items:
-            $ref: "#/components/schemas/Person"
+            $ref: '#/components/schemas/Person'
+          description: A list of POC for company.
         metadata:
-          $ref: "#/components/schemas/CustomerMetadata"
+          $ref: '#/components/schemas/CustomerMetadata'
         mergedCustomers:
           type: array
-          description: A list of Customers.
           items:
-            $ref: "#/components/schemas/Customer"
+            $ref: '#/components/schemas/Customer'
+          description: A list of Customers.
         startDate:
           type: string
           format: date
@@ -5551,44 +5815,46 @@ components:
           type: string
           description: User facing (potentially generated) notes about company.
           example: CIO is interested in trying out the product.
-    RelatedObject:
       required:
         - id
+        - company
+    RelatedObject:
       properties:
         id:
           type: string
           description: The ID of the related object
         metadata:
           type: object
-          description: Some metadata of the object which can be displayed, while not having the actual object.
           properties:
             name:
               type: string
               description: Placeholder name of the object, not the relationship.
+          description: Some metadata of the object which can be displayed, while not having the actual object.
+      required:
+        - id
     RelatedObjectEdge:
       properties:
         objects:
           type: array
           items:
-            $ref: "#/components/schemas/RelatedObject"
+            $ref: '#/components/schemas/RelatedObject'
     RelatedObjects:
       properties:
         relatedObjects:
           type: object
-          description: A list of objects related to a source object.
           additionalProperties:
-            $ref: "#/components/schemas/RelatedObjectEdge"
+            $ref: '#/components/schemas/RelatedObjectEdge'
+          description: A list of objects related to a source object.
     ScopeType:
       type: string
-      description: Describes the scope for a ReadPermission, WritePermission, or GrantPermission object
       enum:
         - GLOBAL
         - OWN
+      description: Describes the scope for a ReadPermission, WritePermission, or GrantPermission object
     WritePermission:
-      description: Describes the write permissions levels that a user has for a specific feature
       properties:
         scopeType:
-          $ref: "#/components/schemas/ScopeType"
+          $ref: '#/components/schemas/ScopeType'
         create:
           type: boolean
           description: True if user has create permission for this feature and scope
@@ -5598,33 +5864,31 @@ components:
         delete:
           type: boolean
           description: True if user has delete permission for this feature and scope
+      description: Describes the write permissions levels that a user has for a specific feature
     ObjectPermissions:
       properties:
         write:
-          $ref: "#/components/schemas/WritePermission"
+          $ref: '#/components/schemas/WritePermission'
     PermissionedObject:
       properties:
         permissions:
-          $ref: "#/components/schemas/ObjectPermissions"
+          $ref: '#/components/schemas/ObjectPermissions'
           description: The permissions the current viewer has with respect to a particular object.
     PersonToTeamRelationship:
-      required:
-        - person
       type: object
-      description: Metadata about the relationship of a person to a team.
       properties:
         person:
-          $ref: "#/components/schemas/Person"
+          $ref: '#/components/schemas/Person'
         relationship:
           type: string
-          description: The team member's relationship to the team. This defaults to MEMBER if not set.
-          default: MEMBER
           enum:
             - MEMBER
             - MANAGER
             - LEAD
             - POINT_OF_CONTACT
             - OTHER
+          description: The team member's relationship to the team. This defaults to MEMBER if not set.
+          default: MEMBER
         customRelationshipStr:
           type: string
           description: Displayed name for the relationship if relationship is set to `OTHER`.
@@ -5632,7 +5896,11 @@ components:
           type: string
           format: date-time
           description: The team member's start date
+      required:
+        - person
+      description: Metadata about the relationship of a person to a team.
     TeamEmail:
+      type: object
       properties:
         email:
           type: string
@@ -5640,9 +5908,8 @@ components:
           description: An email address
         type:
           type: string
-          default: OTHER
           description: An enum of `PRIMARY`, `SECONDARY`, `ONCALL`, `OTHER`
-      type: object
+          default: OTHER
       required:
         - email
         - type
@@ -5663,17 +5930,13 @@ components:
     CustomFieldValuePerson:
       properties:
         person:
-          $ref: "#/components/schemas/Person"
+          $ref: '#/components/schemas/Person'
     CustomFieldValue:
       oneOf:
-        - $ref: "#/components/schemas/CustomFieldValueStr"
-        - $ref: "#/components/schemas/CustomFieldValueHyperlink"
-        - $ref: "#/components/schemas/CustomFieldValuePerson"
+        - $ref: '#/components/schemas/CustomFieldValueStr'
+        - $ref: '#/components/schemas/CustomFieldValueHyperlink'
+        - $ref: '#/components/schemas/CustomFieldValuePerson'
     CustomFieldData:
-      required:
-        - label
-        - values
-        - displayable
       properties:
         label:
           type: string
@@ -5681,20 +5944,21 @@ components:
         values:
           type: array
           items:
-            $ref: "#/components/schemas/CustomFieldValue"
+            $ref: '#/components/schemas/CustomFieldValue'
         displayable:
           type: boolean
           description: Determines whether the client should display this custom field
           default: true
-    DatasourceProfile:
       required:
-        - datasource
-        - handle
+        - label
+        - values
+        - displayable
+    DatasourceProfile:
       properties:
         datasource:
           type: string
-          example: github
           description: The datasource the profile is of.
+          example: github
         handle:
           type: string
           description: The display name of the entity in the given datasource.
@@ -5707,14 +5971,14 @@ components:
         isUserGenerated:
           type: boolean
           description: For internal use only. True iff the data source profile was manually added by a user from within Glean (aka not from the original data source)
+      required:
+        - datasource
+        - handle
     Team:
       allOf:
-        - $ref: "#/components/schemas/RelatedObjects"
-        - $ref: "#/components/schemas/PermissionedObject"
+        - $ref: '#/components/schemas/RelatedObjects'
+        - $ref: '#/components/schemas/PermissionedObject'
         - type: object
-          required:
-            - id
-            - name
           properties:
             id:
               type: string
@@ -5745,27 +6009,27 @@ components:
               description: Link to a team page on the internet or your company's intranet
             members:
               type: array
-              description: The members on this team
               items:
-                $ref: "#/components/schemas/PersonToTeamRelationship"
+                $ref: '#/components/schemas/PersonToTeamRelationship'
+              description: The members on this team
             memberCount:
               type: integer
               description: Number of members on this team (recursive; includes all individuals that belong to this team, and all individuals that belong to a subteam within this team)
             emails:
               type: array
-              description: The emails for this team
               items:
-                $ref: "#/components/schemas/TeamEmail"
+                $ref: '#/components/schemas/TeamEmail'
+              description: The emails for this team
             customFields:
               type: array
-              description: Customizable fields for additional team information.
               items:
-                $ref: "#/components/schemas/CustomFieldData"
+                $ref: '#/components/schemas/CustomFieldData'
+              description: Customizable fields for additional team information.
             datasourceProfiles:
               type: array
-              description: The datasource profiles of the team
               items:
-                $ref: "#/components/schemas/DatasourceProfile"
+                $ref: '#/components/schemas/DatasourceProfile'
+              description: The datasource profiles of the team
             datasource:
               type: string
               description: the data source of the team, e.g. GDRIVE
@@ -5778,12 +6042,12 @@ components:
               description: when this team was last updated.
             status:
               type: string
-              description: whether this team is fully processed or there are still unprocessed operations that'll affect it
-              default: PROCESSED
               enum:
                 - PROCESSED
                 - QUEUED_FOR_CREATION
                 - QUEUED_FOR_DELETION
+              description: whether this team is fully processed or there are still unprocessed operations that'll affect it
+              default: PROCESSED
             canBeDeleted:
               type: boolean
               description: can this team be deleted. Some manually ingested teams like GCS_CSV or PUSH_API cannot
@@ -5791,13 +6055,15 @@ components:
             loggingId:
               type: string
               description: The logging id of the team used in scrubbed logs, client analytics, and metrics.
+          required:
+            - id
+            - name
     CustomEntityMetadata:
       properties:
         customData:
-          $ref: "#/components/schemas/CustomData"
+          $ref: '#/components/schemas/CustomData'
     GroupType:
       type: string
-      description: The type of user group
       enum:
         - DEPARTMENT
         - ALL
@@ -5807,13 +6073,11 @@ components:
         - LOCATION
         - REGION
         - EXTERNAL_GROUP
+      description: The type of user group
     Group:
-      required:
-        - type
-        - id
       properties:
         type:
-          $ref: "#/components/schemas/GroupType"
+          $ref: '#/components/schemas/GroupType'
         id:
           type: string
           description: A unique identifier for the group. May be the same as name.
@@ -5826,31 +6090,34 @@ components:
         provisioningId:
           type: string
           description: identifier for greenlist provisioning, aka sciokey
+      required:
+        - type
+        - id
     UserRole:
       type: string
-      description: A user's role with respect to a specific document.
       enum:
         - OWNER
         - VIEWER
         - ANSWER_MODERATOR
         - EDITOR
         - VERIFIER
+      description: A user's role with respect to a specific document.
     UserRoleSpecification:
-      required:
-        - role
       properties:
         sourceDocumentSpec:
-          $ref: "#/components/schemas/DocumentSpec"
+          $ref: '#/components/schemas/DocumentSpec'
           description: The document spec of the object this role originates from. The object this role is included with will usually have the same information as this document spec, but if the role is inherited, then the document spec refers to the parent document that the role came from.
         person:
-          $ref: "#/components/schemas/Person"
+          $ref: '#/components/schemas/Person'
         group:
-          $ref: "#/components/schemas/Group"
+          $ref: '#/components/schemas/Group'
         role:
-          $ref: "#/components/schemas/UserRole"
+          $ref: '#/components/schemas/UserRole'
+      required:
+        - role
     CustomEntity:
       allOf:
-        - $ref: "#/components/schemas/PermissionedObject"
+        - $ref: '#/components/schemas/PermissionedObject'
         - type: object
           properties:
             id:
@@ -5866,12 +6133,12 @@ components:
               type: string
               description: The type of the entity. Interpretation is specific to each datasource
             metadata:
-              $ref: "#/components/schemas/CustomEntityMetadata"
+              $ref: '#/components/schemas/CustomEntityMetadata'
             roles:
               type: array
-              description: A list of user roles for the custom entity explicitly granted by the owner.
               items:
-                $ref: "#/components/schemas/UserRoleSpecification"
+                $ref: '#/components/schemas/UserRoleSpecification'
+              description: A list of user roles for the custom entity explicitly granted by the owner.
     AnswerId:
       properties:
         id:
@@ -5891,9 +6158,9 @@ components:
           example: Why is the sky blue?
         questionVariations:
           type: array
-          description: Additional ways of phrasing this question.
           items:
             type: string
+          description: Additional ways of phrasing this question.
         bodyText:
           type: string
           description: The plain text answer to the question.
@@ -5910,26 +6177,26 @@ components:
           x-speakeasy-deprecation-message: "Deprecated on 2026-02-05, removal scheduled for 2026-10-15: Answer Boards no longer supported"
         audienceFilters:
           type: array
-          description: Filters which restrict who should see the answer. Values are taken from the corresponding filters in people search.
           items:
-            $ref: "#/components/schemas/FacetFilter"
+            $ref: '#/components/schemas/FacetFilter'
+          description: Filters which restrict who should see the answer. Values are taken from the corresponding filters in people search.
         addedRoles:
           type: array
-          description: A list of user roles for the answer added by the owner.
           items:
-            $ref: "#/components/schemas/UserRoleSpecification"
+            $ref: '#/components/schemas/UserRoleSpecification'
+          description: A list of user roles for the answer added by the owner.
         removedRoles:
           type: array
-          description: A list of user roles for the answer removed by the owner.
           items:
-            $ref: "#/components/schemas/UserRoleSpecification"
+            $ref: '#/components/schemas/UserRoleSpecification'
+          description: A list of user roles for the answer removed by the owner.
         roles:
           type: array
-          description: A list of roles for this answer explicitly granted by an owner, editor, or admin.
           items:
-            $ref: "#/components/schemas/UserRoleSpecification"
+            $ref: '#/components/schemas/UserRoleSpecification'
+          description: A list of roles for this answer explicitly granted by an owner, editor, or admin.
         sourceDocumentSpec:
-          $ref: "#/components/schemas/DocumentSpec"
+          $ref: '#/components/schemas/DocumentSpec'
         sourceType:
           type: string
           enum:
@@ -5943,47 +6210,44 @@ components:
           description: An opaque token that represents this particular UGC. To be used for `/feedback` reporting.
     StructuredText:
       allOf:
-        - $ref: "#/components/schemas/StructuredTextMutableProperties"
+        - $ref: '#/components/schemas/StructuredTextMutableProperties'
         - type: object
           properties:
             structuredList:
               type: array
               items:
-                $ref: "#/components/schemas/StructuredTextItem"
+                $ref: '#/components/schemas/StructuredTextItem'
               description: An array of objects each of which contains either a string or a link which optionally corresponds to a document.
     AnswerLike:
       properties:
         user:
-          $ref: "#/components/schemas/Person"
+          $ref: '#/components/schemas/Person'
         createTime:
           type: string
           format: date-time
           description: The time the user liked the answer in ISO format (ISO 8601).
     AnswerLikes:
-      required:
-        - likedBy
-        - likedByUser
-        - numLikes
       properties:
         likedBy:
           type: array
           items:
-            $ref: "#/components/schemas/AnswerLike"
+            $ref: '#/components/schemas/AnswerLike'
         likedByUser:
           type: boolean
           description: Whether the user in context liked the answer.
         numLikes:
           type: integer
           description: The total number of likes for the answer.
-    Reminder:
       required:
-        - assignee
-        - remindAt
+        - likedBy
+        - likedByUser
+        - numLikes
+    Reminder:
       properties:
         assignee:
-          $ref: "#/components/schemas/Person"
+          $ref: '#/components/schemas/Person'
         requestor:
-          $ref: "#/components/schemas/Person"
+          $ref: '#/components/schemas/Person'
         remindAt:
           type: integer
           description: Unix timestamp for when the reminder should trigger (in seconds since epoch UTC).
@@ -5993,6 +6257,9 @@ components:
         reason:
           type: string
           description: An optional free-text reason for the reminder. This is particularly useful when a reminder is used to ask for verification from another user (for example, "Duplicate", "Incomplete", "Incorrect").
+      required:
+        - assignee
+        - remindAt
     TimePoint:
       properties:
         epochSeconds:
@@ -6012,27 +6279,25 @@ components:
           description: DEPRECATED - The number of days from now in the past to define lower boundary of time period.
           deprecated: true
         start:
-          $ref: "#/components/schemas/TimePoint"
+          $ref: '#/components/schemas/TimePoint'
         end:
-          $ref: "#/components/schemas/TimePoint"
+          $ref: '#/components/schemas/TimePoint'
     CountInfo:
-      required:
-        - count
       properties:
         count:
           type: integer
           description: The counter value
         period:
-          $ref: "#/components/schemas/Period"
+          $ref: '#/components/schemas/Period'
         org:
           type: string
           description: The unit of organization over which we did the count aggregation, e.g. org (department) or company
-    VerificationMetadata:
       required:
-        - documentId
+        - count
+    VerificationMetadata:
       properties:
         lastVerifier:
-          $ref: "#/components/schemas/Person"
+          $ref: '#/components/schemas/Person'
         lastVerificationTs:
           type: integer
           description: The unix timestamp of the verification (in seconds since epoch UTC).
@@ -6040,27 +6305,27 @@ components:
           type: integer
           description: The unix timestamp of the verification expiration if applicable (in seconds since epoch UTC).
         document:
-          $ref: "#/components/schemas/Document"
+          $ref: '#/components/schemas/Document'
         reminders:
           type: array
           items:
-            $ref: "#/components/schemas/Reminder"
+            $ref: '#/components/schemas/Reminder'
           description: Info about all outstanding verification reminders for the document if exists.
         lastReminder:
-          $ref: "#/components/schemas/Reminder"
+          $ref: '#/components/schemas/Reminder'
         visitorCount:
           type: array
           items:
-            $ref: "#/components/schemas/CountInfo"
+            $ref: '#/components/schemas/CountInfo'
           description: Number of visitors to the document during included time periods.
         candidateVerifiers:
           type: array
           items:
-            $ref: "#/components/schemas/Person"
+            $ref: '#/components/schemas/Person'
           description: List of potential verifiers for the document e.g. old verifiers and/or users with view/edit permissions.
-    Verification:
       required:
-        - state
+        - documentId
+    Verification:
       properties:
         state:
           type: string
@@ -6070,10 +6335,10 @@ components:
             - DEPRECATED
           description: The verification state for the document.
         metadata:
-          $ref: "#/components/schemas/VerificationMetadata"
-    CollectionBaseMutableProperties:
+          $ref: '#/components/schemas/VerificationMetadata'
       required:
-        - name
+        - state
+    CollectionBaseMutableProperties:
       properties:
         name:
           type: string
@@ -6083,19 +6348,21 @@ components:
           description: A brief summary of the Collection's contents.
         addedRoles:
           type: array
-          description: A list of added user roles for the Collection.
           items:
-            $ref: "#/components/schemas/UserRoleSpecification"
+            $ref: '#/components/schemas/UserRoleSpecification'
+          description: A list of added user roles for the Collection.
         removedRoles:
           type: array
-          description: A list of removed user roles for the Collection.
           items:
-            $ref: "#/components/schemas/UserRoleSpecification"
+            $ref: '#/components/schemas/UserRoleSpecification'
+          description: A list of removed user roles for the Collection.
         audienceFilters:
           type: array
           items:
-            $ref: "#/components/schemas/FacetFilter"
+            $ref: '#/components/schemas/FacetFilter'
           description: Filters which restrict who should see this Collection. Values are taken from the corresponding filters in people search.
+      required:
+        - name
     Thumbnail:
       properties:
         photoId:
@@ -6106,10 +6373,8 @@ components:
           description: Thumbnail URL. This can be user provided image and/or from downloaded images hosted by Glean.
     CollectionMutableProperties:
       allOf:
-        - $ref: "#/components/schemas/CollectionBaseMutableProperties"
+        - $ref: '#/components/schemas/CollectionBaseMutableProperties'
         - type: object
-          required:
-            - name
           properties:
             icon:
               type: string
@@ -6121,10 +6386,12 @@ components:
               type: integer
               description: The parent of this Collection, or 0 if it's a top-level Collection.
             thumbnail:
-              $ref: "#/components/schemas/Thumbnail"
+              $ref: '#/components/schemas/Thumbnail'
             allowedDatasource:
               type: string
               description: The datasource type this Collection can hold.
+          required:
+            - name
     CollectionItemMutableProperties:
       properties:
         name:
@@ -6163,30 +6430,30 @@ components:
           description: For variable shortcuts, contains the URL template; note, `destinationUrl` contains default URL.
         addedRoles:
           type: array
-          description: A list of user roles added for the Shortcut.
           items:
-            $ref: "#/components/schemas/UserRoleSpecification"
+            $ref: '#/components/schemas/UserRoleSpecification'
+          description: A list of user roles added for the Shortcut.
         removedRoles:
           type: array
-          description: A list of user roles removed for the Shortcut.
           items:
-            $ref: "#/components/schemas/UserRoleSpecification"
+            $ref: '#/components/schemas/UserRoleSpecification'
+          description: A list of user roles removed for the Shortcut.
     ShortcutMetadata:
       properties:
         createdBy:
-          $ref: "#/components/schemas/Person"
+          $ref: '#/components/schemas/Person'
         createTime:
           type: string
           format: date-time
           description: The time the shortcut was created in ISO format (ISO 8601).
         updatedBy:
-          $ref: "#/components/schemas/Person"
+          $ref: '#/components/schemas/Person'
         updateTime:
           type: string
           format: date-time
           description: The time the shortcut was updated in ISO format (ISO 8601).
         destinationDocument:
-          $ref: "#/components/schemas/Document"
+          $ref: '#/components/schemas/Document'
           description: Document that corresponds to the destination URL, if applicable.
         intermediateUrl:
           type: string
@@ -6202,13 +6469,11 @@ components:
           description: The URL using which the user can access the edit page of the shortcut.
     Shortcut:
       allOf:
-        - $ref: "#/components/schemas/UserGeneratedContentId"
-        - $ref: "#/components/schemas/ShortcutMutableProperties"
-        - $ref: "#/components/schemas/PermissionedObject"
-        - $ref: "#/components/schemas/ShortcutMetadata"
+        - $ref: '#/components/schemas/UserGeneratedContentId'
+        - $ref: '#/components/schemas/ShortcutMutableProperties'
+        - $ref: '#/components/schemas/PermissionedObject'
+        - $ref: '#/components/schemas/ShortcutMetadata'
         - type: object
-          required:
-            - inputAlias
           properties:
             alias:
               type: string
@@ -6218,18 +6483,17 @@ components:
               description: Title for the Go Link
             roles:
               type: array
-              description: A list of user roles for the Go Link.
               items:
-                $ref: "#/components/schemas/UserRoleSpecification"
+                $ref: '#/components/schemas/UserRoleSpecification'
+              description: A list of user roles for the Go Link.
+          required:
+            - inputAlias
     Collection:
       allOf:
-        - $ref: "#/components/schemas/CollectionMutableProperties"
-        - $ref: "#/components/schemas/PermissionedObject"
-        - $ref: "#/components/schemas/UgcTrackingSignals"
+        - $ref: '#/components/schemas/CollectionMutableProperties'
+        - $ref: '#/components/schemas/PermissionedObject'
+        - $ref: '#/components/schemas/UgcTrackingSignals'
         - type: object
-          required:
-            - id
-            - description
           properties:
             id:
               type: integer
@@ -6241,9 +6505,9 @@ components:
               type: string
               format: date-time
             creator:
-              $ref: "#/components/schemas/Person"
+              $ref: '#/components/schemas/Person'
             updatedBy:
-              $ref: "#/components/schemas/Person"
+              $ref: '#/components/schemas/Person'
             itemCount:
               type: integer
               description: The number of items currently in the Collection. Separated from the actual items so we can grab the count without items.
@@ -6253,10 +6517,10 @@ components:
             items:
               type: array
               items:
-                $ref: "#/components/schemas/CollectionItem"
+                $ref: '#/components/schemas/CollectionItem'
               description: The items in this Collection.
             pinMetadata:
-              $ref: "#/components/schemas/CollectionPinnedMetadata"
+              $ref: '#/components/schemas/CollectionPinnedMetadata'
               description: Metadata having what categories this Collection is pinned to and the eligible categories to pin to
             shortcuts:
               type: array
@@ -6266,20 +6530,20 @@ components:
             children:
               type: array
               items:
-                $ref: "#/components/schemas/Collection"
+                $ref: '#/components/schemas/Collection'
               description: The children Collections of this Collection.
             roles:
               type: array
-              description: A list of user roles for the Collection.
               items:
-                $ref: "#/components/schemas/UserRoleSpecification"
+                $ref: '#/components/schemas/UserRoleSpecification'
+              description: A list of user roles for the Collection.
+          required:
+            - id
+            - description
     CollectionItem:
       allOf:
-        - $ref: "#/components/schemas/CollectionItemMutableProperties"
+        - $ref: '#/components/schemas/CollectionItemMutableProperties'
         - type: object
-          required:
-            - collectionId
-            - itemType
           properties:
             collectionId:
               type: integer
@@ -6294,20 +6558,20 @@ components:
               type: string
               description: Unique identifier for the item within the Collection it belongs to.
             createdBy:
-              $ref: "#/components/schemas/Person"
+              $ref: '#/components/schemas/Person'
               description: The person who added this Collection item.
             createdAt:
               type: string
               format: date-time
               description: Unix timestamp for when the item was first added (in seconds since epoch UTC).
             document:
-              $ref: "#/components/schemas/Document"
+              $ref: '#/components/schemas/Document'
               description: The Document this CollectionItem corresponds to (omitted if item is a non-indexed URL).
             shortcut:
-              $ref: "#/components/schemas/Shortcut"
+              $ref: '#/components/schemas/Shortcut'
               description: The Shortcut this CollectionItem corresponds to (only included if item URL is for a Go Link).
             collection:
-              $ref: "#/components/schemas/Collection"
+              $ref: '#/components/schemas/Collection'
               description: The Collection this CollectionItem corresponds to (only included if item type is COLLECTION).
             itemType:
               type: string
@@ -6316,69 +6580,70 @@ components:
                 - TEXT
                 - URL
                 - COLLECTION
+          required:
+            - collectionId
+            - itemType
     CollectionPinnableCategories:
       type: string
-      description: Categories a Collection can be pinned to.
       enum:
         - COMPANY_RESOURCE
         - DEPARTMENT_RESOURCE
         - TEAM_RESOURCE
+      description: Categories a Collection can be pinned to.
     CollectionPinnableTargets:
       type: string
-      description: What targets can a Collection be pinned to.
       enum:
         - RESOURCE_CARD
         - TEAM_PROFILE_PAGE
+      description: What targets can a Collection be pinned to.
     CollectionPinTarget:
-      required:
-        - category
       properties:
         category:
-          $ref: "#/components/schemas/CollectionPinnableCategories"
+          $ref: '#/components/schemas/CollectionPinnableCategories'
         value:
           type: string
           description: Optional. If category supports values, then the additional value for the category e.g. department name for DEPARTMENT_RESOURCE, team name/id for TEAM_RESOURCE and so on.
         target:
-          $ref: "#/components/schemas/CollectionPinnableTargets"
-    CollectionPinMetadata:
+          $ref: '#/components/schemas/CollectionPinnableTargets'
       required:
-        - id
-        - target
+        - category
+    CollectionPinMetadata:
       properties:
         id:
           type: integer
           description: The ID of the Collection.
         target:
-          $ref: "#/components/schemas/CollectionPinTarget"
+          $ref: '#/components/schemas/CollectionPinTarget'
+      required:
+        - id
+        - target
     CollectionPinnedMetadata:
       properties:
         existingPins:
           type: array
           items:
-            $ref: "#/components/schemas/CollectionPinTarget"
+            $ref: '#/components/schemas/CollectionPinTarget'
           description: List of targets this Collection is pinned to.
         eligiblePins:
           type: array
           items:
-            $ref: "#/components/schemas/CollectionPinMetadata"
+            $ref: '#/components/schemas/CollectionPinMetadata'
           description: List of targets this Collection can be pinned to, excluding the targets this Collection is already pinned to. We also include Collection ID already is pinned to each eligible target, which will be 0 if the target has no pinned Collection.
     Answer:
       allOf:
-        - $ref: "#/components/schemas/AnswerId"
-        - $ref: "#/components/schemas/AnswerDocId"
-        - $ref: "#/components/schemas/AnswerMutableProperties"
-        - $ref: "#/components/schemas/PermissionedObject"
-        - $ref: "#/components/schemas/UgcTrackingSignals"
+        - $ref: '#/components/schemas/AnswerId'
+        - $ref: '#/components/schemas/AnswerDocId'
+        - $ref: '#/components/schemas/AnswerMutableProperties'
+        - $ref: '#/components/schemas/PermissionedObject'
+        - $ref: '#/components/schemas/UgcTrackingSignals'
         - type: object
-          required:
-            - id
           properties:
             combinedAnswerText:
-              $ref: "#/components/schemas/StructuredText"
+              $ref: '#/components/schemas/StructuredText'
             likes:
-              $ref: "#/components/schemas/AnswerLikes"
+              $ref: '#/components/schemas/AnswerLikes'
             author:
-              $ref: "#/components/schemas/Person"
+              $ref: '#/components/schemas/Person'
             createTime:
               type: string
               format: date-time
@@ -6388,21 +6653,22 @@ components:
               format: date-time
               description: The time the answer was last updated in ISO format (ISO 8601).
             updatedBy:
-              $ref: "#/components/schemas/Person"
+              $ref: '#/components/schemas/Person'
             verification:
-              $ref: "#/components/schemas/Verification"
+              $ref: '#/components/schemas/Verification'
             collections:
               type: array
-              description: The collections to which the answer belongs.
               items:
-                $ref: "#/components/schemas/Collection"
+                $ref: '#/components/schemas/Collection'
+              description: The collections to which the answer belongs.
             documentCategory:
               type: string
               description: The document's document_category(.proto).
             sourceDocument:
-              $ref: "#/components/schemas/Document"
+              $ref: '#/components/schemas/Document'
+          required:
+            - id
     FollowupAction:
-      description: A follow-up action that can be invoked by the user after a response. The action parameters are not included and need to be predicted/filled separately.
       properties:
         actionRunId:
           type: string
@@ -6415,9 +6681,9 @@ components:
           description: The ID of the associated action.
         parameters:
           type: object
-          description: Map of assistant predicted parameters and their corresponding values.
           additionalProperties:
             type: string
+          description: Map of assistant predicted parameters and their corresponding values.
         recommendationText:
           type: string
           description: Text to be displayed to the user when recommending the action instance.
@@ -6427,6 +6693,7 @@ components:
         userConfirmationRequired:
           type: boolean
           description: Whether user confirmation is needed before executing this action instance.
+      description: A follow-up action that can be invoked by the user after a response. The action parameters are not included and need to be predicted/filled separately.
     GeneratedQna:
       properties:
         question:
@@ -6441,14 +6708,14 @@ components:
             type: string
           description: List of all follow-up prompts generated for the given query or the generated question.
         followupActions:
-          description: List of follow-up actions generated for the given query or the generated question.
           type: array
           items:
-            $ref: "#/components/schemas/FollowupAction"
+            $ref: '#/components/schemas/FollowupAction'
+          description: List of follow-up actions generated for the given query or the generated question.
         ranges:
           type: array
           items:
-            $ref: "#/components/schemas/TextRange"
+            $ref: '#/components/schemas/TextRange'
           description: Answer subsections to mark with special formatting (citations, bolding etc)
         status:
           type: string
@@ -6469,14 +6736,12 @@ components:
           type: string
           description: An opaque token that represents this particular result in this particular query. To be used for /feedback reporting.
     SearchResult:
-      required:
-        - url
       allOf:
-        - $ref: "#/components/schemas/Result"
+        - $ref: '#/components/schemas/Result'
         - type: object
           properties:
             document:
-              $ref: "#/components/schemas/Document"
+              $ref: '#/components/schemas/Document'
             title:
               type: string
             url:
@@ -6487,60 +6752,62 @@ components:
             snippets:
               type: array
               items:
-                $ref: "#/components/schemas/SearchResultSnippet"
+                $ref: '#/components/schemas/SearchResultSnippet'
               description: Text content from the result document which contains search query terms, if available.
             fullText:
               type: string
               description: The full body text of the result if not already contained in the snippets. Only populated for conversation results (e.g. results from a messaging app such as Slack).
             fullTextList:
               type: array
-              description: The full body text of the result if not already contained in the snippets; each item in the array represents a separate line in the original text. Only populated for conversation results (e.g. results from a messaging app such as Slack).
               items:
                 type: string
+              description: The full body text of the result if not already contained in the snippets; each item in the array represents a separate line in the original text. Only populated for conversation results (e.g. results from a messaging app such as Slack).
             relatedResults:
               type: array
               items:
-                $ref: "#/components/schemas/RelatedDocuments"
+                $ref: '#/components/schemas/RelatedDocuments'
               description: A list of results related to this search result. Eg. for conversation results it contains individual messages from the conversation document which will be shown on SERP.
             clusteredResults:
               type: array
-              description: A list of results that should be displayed as associated with this result.
               items:
-                $ref: "#/components/schemas/SearchResult"
+                $ref: '#/components/schemas/SearchResult'
+              description: A list of results that should be displayed as associated with this result.
             allClusteredResults:
               type: array
-              description: A list of results that should be displayed as associated with this result.
               items:
-                $ref: "#/components/schemas/ClusterGroup"
+                $ref: '#/components/schemas/ClusterGroup'
+              description: A list of results that should be displayed as associated with this result.
             attachmentCount:
               type: integer
               description: The total number of attachments.
             attachments:
               type: array
-              description: A (potentially partial) list of results representing documents attached to the main result document.
               items:
-                $ref: "#/components/schemas/SearchResult"
+                $ref: '#/components/schemas/SearchResult'
+              description: A (potentially partial) list of results representing documents attached to the main result document.
             backlinkResults:
               type: array
-              description: A list of results that should be displayed as backlinks of this result in reverse chronological order.
               items:
-                $ref: "#/components/schemas/SearchResult"
+                $ref: '#/components/schemas/SearchResult'
+              description: A list of results that should be displayed as backlinks of this result in reverse chronological order.
             clusterType:
-              $ref: "#/components/schemas/ClusterTypeEnum"
+              $ref: '#/components/schemas/ClusterTypeEnum'
             mustIncludeSuggestions:
-              $ref: "#/components/schemas/QuerySuggestionList"
+              $ref: '#/components/schemas/QuerySuggestionList'
             querySuggestion:
-              $ref: "#/components/schemas/QuerySuggestion"
+              $ref: '#/components/schemas/QuerySuggestion'
             prominence:
-              $ref: "#/components/schemas/SearchResultProminenceEnum"
+              $ref: '#/components/schemas/SearchResultProminenceEnum'
             attachmentContext:
               type: string
               description: Additional context for the relationship between the result and the document it's attached to.
             pins:
               type: array
-              description: A list of pins associated with this search result.
               items:
-                $ref: "#/components/schemas/PinDocument"
+                $ref: '#/components/schemas/PinDocument'
+              description: A list of pins associated with this search result.
+      required:
+        - url
       example:
         snippets:
           - snippet: snippet
@@ -6570,10 +6837,8 @@ components:
           type: string
           description: Question text that was matched to produce this result.
         questionResult:
-          $ref: "#/components/schemas/SearchResult"
+          $ref: '#/components/schemas/SearchResult'
     CalendarAttendee:
-      required:
-        - person
       properties:
         isOrganizer:
           type: boolean
@@ -6582,12 +6847,12 @@ components:
           type: boolean
           description: Whether or not this attendee is in a group. Needed temporarily at least to support both flat attendees and tree for compatibility.
         person:
-          $ref: "#/components/schemas/Person"
+          $ref: '#/components/schemas/Person'
         groupAttendees:
           type: array
-          description: If this attendee is a group, represents the list of individual attendees in the group.
           items:
-            $ref: "#/components/schemas/CalendarAttendee"
+            $ref: '#/components/schemas/CalendarAttendee'
+          description: If this attendee is a group, represents the list of individual attendees in the group.
         responseStatus:
           type: string
           enum:
@@ -6595,12 +6860,14 @@ components:
             - DECLINED
             - NO_RESPONSE
             - TENTATIVE
+      required:
+        - person
     CalendarAttendees:
       properties:
         people:
           type: array
           items:
-            $ref: "#/components/schemas/CalendarAttendee"
+            $ref: '#/components/schemas/CalendarAttendee'
           description: Full details of some of the attendees of this event
         isLimit:
           type: boolean
@@ -6637,7 +6904,7 @@ components:
           type: string
           format: date-time
         attendees:
-          $ref: "#/components/schemas/CalendarAttendees"
+          $ref: '#/components/schemas/CalendarAttendees'
           description: The attendee list, including their response status
         isCancelled:
           type: boolean
@@ -6655,8 +6922,6 @@ components:
           type: string
           description: The conference provider (e.g., "Microsoft Teams", "Zoom")
     AppResult:
-      required:
-        - datasource
       properties:
         datasource:
           type: string
@@ -6670,6 +6935,8 @@ components:
         iconUrl:
           type: string
           description: If there is available icon URL.
+      required:
+        - datasource
     CodeLine:
       properties:
         lineNumber:
@@ -6679,7 +6946,7 @@ components:
         ranges:
           type: array
           items:
-            $ref: "#/components/schemas/TextRange"
+            $ref: '#/components/schemas/TextRange'
           description: Index ranges depicting matched sections of the line
     Code:
       properties:
@@ -6692,7 +6959,7 @@ components:
         lines:
           type: array
           items:
-            $ref: "#/components/schemas/CodeLine"
+            $ref: '#/components/schemas/CodeLine'
         isLastMatch:
           type: boolean
           description: Last file match for a repo
@@ -6718,11 +6985,10 @@ components:
         suggestions:
           type: array
           items:
-            $ref: "#/components/schemas/QuerySuggestion"
+            $ref: '#/components/schemas/QuerySuggestion'
         person:
-          $ref: "#/components/schemas/Person"
+          $ref: '#/components/schemas/Person'
     IconConfig:
-      description: Defines how to render an icon
       properties:
         generatedBackgroundColorKey:
           type: string
@@ -6756,13 +7022,13 @@ components:
         url:
           type: string
           description: The URL to an image to be displayed if applicable, e.g. the URL for `iconType.URL` icons.
+      description: Defines how to render an icon
       example:
         color: "#343CED"
         key: person_icon
         iconType: GLYPH
         name: user
     ChatMetadata:
-      description: Metadata of a Chat a user had with Glean Assistant. This contains no actual conversational content.
       properties:
         id:
           type: string
@@ -6771,7 +7037,7 @@ components:
           type: integer
           description: Server Unix timestamp of the creation time (in seconds since epoch UTC).
         createdBy:
-          $ref: "#/components/schemas/Person"
+          $ref: '#/components/schemas/Person'
           description: The user who created this Chat.
         updateTime:
           type: integer
@@ -6786,12 +7052,12 @@ components:
           type: string
           description: The display name of the AI App that this Chat is associated to.
         icon:
-          $ref: "#/components/schemas/IconConfig"
+          $ref: '#/components/schemas/IconConfig'
+      description: Metadata of a Chat a user had with Glean Assistant. This contains no actual conversational content.
     RelatedDocuments:
       properties:
         relation:
           type: string
-          description: How this document relates to the including entity.
           enum:
             - ATTACHMENT
             - CANONICAL
@@ -6809,6 +7075,7 @@ components:
             - TICKET
             - TRANSCRIPT
             - WITH
+          description: How this document relates to the including entity.
           x-enum-varnames:
             - ATTACHMENT
             - CANONICAL
@@ -6834,11 +7101,11 @@ components:
           type: string
           description: Which entity in the response that this entity relates to. Relevant when there are multiple entities associated with the response (such as merged customers)
         querySuggestion:
-          $ref: "#/components/schemas/QuerySuggestion"
+          $ref: '#/components/schemas/QuerySuggestion'
         documents:
           type: array
           items:
-            $ref: "#/components/schemas/Document"
+            $ref: '#/components/schemas/Document'
           description: A truncated list of documents with this relation. TO BE DEPRECATED.
           deprecated: true
           x-glean-deprecated:
@@ -6850,7 +7117,7 @@ components:
         results:
           type: array
           items:
-            $ref: "#/components/schemas/SearchResult"
+            $ref: '#/components/schemas/SearchResult'
           description: A truncated list of documents associated with this relation. To be used in favor of `documents` because it contains a trackingToken.
     RelatedQuestion:
       properties:
@@ -6863,19 +7130,18 @@ components:
         ranges:
           type: array
           items:
-            $ref: "#/components/schemas/TextRange"
+            $ref: '#/components/schemas/TextRange'
           description: Subsections of the answer string to which some special formatting should be applied (eg. bold)
     EntityType:
       type: string
-      description: The type of entity.
-      x-include-enum-class-prefix: true
       enum:
         - PERSON
         - PROJECT
         - CUSTOMER
+      description: The type of entity.
+      x-include-enum-class-prefix: true
     Disambiguation:
       type: object
-      description: A disambiguation between multiple entities with the same name
       properties:
         name:
           type: string
@@ -6884,7 +7150,8 @@ components:
           type: string
           description: The unique id of the entity in the knowledge graph
         type:
-          $ref: "#/components/schemas/EntityType"
+          $ref: '#/components/schemas/EntityType'
+      description: A disambiguation between multiple entities with the same name
     SearchResultSnippet:
       properties:
         mimeType:
@@ -6899,15 +7166,15 @@ components:
         ranges:
           type: array
           items:
-            $ref: "#/components/schemas/TextRange"
+            $ref: '#/components/schemas/TextRange'
           description: The bolded ranges within text.
         url:
           type: string
           description: A URL, generated based on availability, that links to the position of the snippet text or to the nearest header above the snippet text.
         snippet:
           type: string
-          deprecated: true
           description: A matching snippet from the document. Query term matches are marked by the unicode characters uE006 and uE007. Use 'text' field instead.
+          deprecated: true
           x-glean-deprecated:
             id: e55ddf30-7c47-43a5-b775-d78f8b29411a
             introduced: "2026-02-05"
@@ -6919,91 +7186,90 @@ components:
         snippet: snippet
         mimeType: mimeType
     StructuredResult:
-      description: A single object that can support any object in the work graph. Only a single object will be populated.
       properties:
         document:
-          $ref: "#/components/schemas/Document"
+          $ref: '#/components/schemas/Document'
         person:
-          $ref: "#/components/schemas/Person"
+          $ref: '#/components/schemas/Person'
         customer:
-          $ref: "#/components/schemas/Customer"
+          $ref: '#/components/schemas/Customer'
         team:
-          $ref: "#/components/schemas/Team"
+          $ref: '#/components/schemas/Team'
         customEntity:
-          $ref: "#/components/schemas/CustomEntity"
+          $ref: '#/components/schemas/CustomEntity'
         answer:
-          $ref: "#/components/schemas/Answer"
+          $ref: '#/components/schemas/Answer'
         generatedQna:
-          $ref: "#/components/schemas/GeneratedQna"
+          $ref: '#/components/schemas/GeneratedQna'
         extractedQnA:
-          $ref: "#/components/schemas/ExtractedQnA"
+          $ref: '#/components/schemas/ExtractedQnA'
         meeting:
-          $ref: "#/components/schemas/Meeting"
+          $ref: '#/components/schemas/Meeting'
         app:
-          $ref: "#/components/schemas/AppResult"
+          $ref: '#/components/schemas/AppResult'
         collection:
-          $ref: "#/components/schemas/Collection"
+          $ref: '#/components/schemas/Collection'
         code:
-          $ref: "#/components/schemas/Code"
+          $ref: '#/components/schemas/Code'
         shortcut:
-          $ref: "#/components/schemas/Shortcut"
+          $ref: '#/components/schemas/Shortcut'
         querySuggestions:
-          $ref: "#/components/schemas/QuerySuggestionList"
+          $ref: '#/components/schemas/QuerySuggestionList'
         chat:
-          $ref: "#/components/schemas/ChatMetadata"
+          $ref: '#/components/schemas/ChatMetadata'
         relatedDocuments:
           type: array
           items:
-            $ref: "#/components/schemas/RelatedDocuments"
+            $ref: '#/components/schemas/RelatedDocuments'
           description: A list of documents related to this structured result.
         relatedQuestion:
-          $ref: "#/components/schemas/RelatedQuestion"
+          $ref: '#/components/schemas/RelatedQuestion'
         disambiguation:
-          $ref: "#/components/schemas/Disambiguation"
+          $ref: '#/components/schemas/Disambiguation'
         snippets:
-          description: Any snippets associated to the populated object.
           type: array
           items:
-            $ref: "#/components/schemas/SearchResultSnippet"
+            $ref: '#/components/schemas/SearchResultSnippet'
+          description: Any snippets associated to the populated object.
         trackingToken:
           type: string
           description: An opaque token that represents this particular result in this particular query. To be used for /feedback reporting.
         prominence:
           type: string
+          enum:
+            - HERO
+            - PROMOTED
+            - STANDARD
           description: The level of visual distinction that should be given to a result.
           x-enumDescriptions:
             HERO: A high-confidence result that should feature prominently on the page.
             PROMOTED: May not be the best result but should be given additional visual distinction.
             STANDARD: Should not be distinct from any other results.
-          enum:
-            - HERO
-            - PROMOTED
-            - STANDARD
           x-speakeasy-enum-descriptions:
             HERO: A high-confidence result that should feature prominently on the page.
             PROMOTED: May not be the best result but should be given additional visual distinction.
             STANDARD: Should not be distinct from any other results.
         source:
           type: string
-          description: Source context for this result. Possible values depend on the result type.
           enum:
             - EXPERT_DETECTION
             - ENTITY_NLQ
             - CALENDAR_EVENT
             - AGENT
+          description: Source context for this result. Possible values depend on the result type.
+      description: A single object that can support any object in the work graph. Only a single object will be populated.
     Result:
       properties:
         structuredResults:
           type: array
-          description: An array of entities in the work graph retrieved via a data request.
           items:
-            $ref: "#/components/schemas/StructuredResult"
+            $ref: '#/components/schemas/StructuredResult'
+          description: An array of entities in the work graph retrieved via a data request.
         trackingToken:
           type: string
           description: An opaque token that represents this particular result in this particular query. To be used for /feedback reporting.
     ClusterTypeEnum:
       type: string
-      description: The reason for inclusion of clusteredResults.
       enum:
         - SIMILAR
         - FRESHNESS
@@ -7016,32 +7282,33 @@ components:
         - SUFFIX
         - AUTHOR_PREFIX
         - AUTHOR_SUFFIX
+      description: The reason for inclusion of clusteredResults.
     ClusterGroup:
-      required:
-        - visibleCountHint
       properties:
         clusteredResults:
           type: array
-          description: A list of results that should be displayed as associated with this result.
           items:
-            $ref: "#/components/schemas/SearchResult"
+            $ref: '#/components/schemas/SearchResult'
+          description: A list of results that should be displayed as associated with this result.
         clusterType:
-          $ref: "#/components/schemas/ClusterTypeEnum"
+          $ref: '#/components/schemas/ClusterTypeEnum'
         visibleCountHint:
           type: integer
           description: The default number of results to display before truncating and showing a "see more" link
+      required:
+        - visibleCountHint
     SearchResultProminenceEnum:
       type: string
+      enum:
+        - HERO
+        - PROMOTED
+        - STANDARD
       description: |
         The level of visual distinction that should be given to a result.
       x-enumDescriptions:
         HERO: A high-confidence result that should feature prominently on the page.
         PROMOTED: May not be the best result but should be given additional visual distinction.
         STANDARD: Should not be distinct from any other results.
-      enum:
-        - HERO
-        - PROMOTED
-        - STANDARD
       x-speakeasy-enum-descriptions:
         HERO: A high-confidence result that should feature prominently on the page.
         PROMOTED: May not be the best result but should be given additional visual distinction.
@@ -7050,20 +7317,18 @@ components:
       properties:
         queries:
           type: array
-          description: The query strings for which the pinned result will show.
           items:
             type: string
+          description: The query strings for which the pinned result will show.
         audienceFilters:
           type: array
-          description: Filters which restrict who should see the pinned document. Values are taken from the corresponding filters in people search.
           items:
-            $ref: "#/components/schemas/FacetFilter"
+            $ref: '#/components/schemas/FacetFilter'
+          description: Filters which restrict who should see the pinned document. Values are taken from the corresponding filters in people search.
     PinDocument:
       allOf:
-        - $ref: "#/components/schemas/PinDocumentMutableProperties"
+        - $ref: '#/components/schemas/PinDocumentMutableProperties'
         - type: object
-          required:
-            - documentId
           properties:
             id:
               type: string
@@ -7073,21 +7338,22 @@ components:
               description: The document which should be a pinned result.
             audienceFilters:
               type: array
-              description: Filters which restrict who should see the pinned document. Values are taken from the corresponding filters in people search.
               items:
-                $ref: "#/components/schemas/FacetFilter"
+                $ref: '#/components/schemas/FacetFilter'
+              description: Filters which restrict who should see the pinned document. Values are taken from the corresponding filters in people search.
             attribution:
-              $ref: "#/components/schemas/Person"
+              $ref: '#/components/schemas/Person'
             updatedBy:
-              $ref: "#/components/schemas/Person"
+              $ref: '#/components/schemas/Person'
             createTime:
               type: string
               format: date-time
             updateTime:
               type: string
               format: date-time
+          required:
+            - documentId
     PersonTeam:
-      description: Use `id` if you index teams via Glean, and use `name` and `externalLink` if you want to use your own team pages
       properties:
         id:
           type: string
@@ -7101,21 +7367,21 @@ components:
           description: Link to a team page on the internet or your company's intranet
         relationship:
           type: string
-          description: The team member's relationship to the team. This defaults to MEMBER if not set.
-          default: MEMBER
           enum:
             - MEMBER
             - MANAGER
             - LEAD
             - POINT_OF_CONTACT
             - OTHER
+          description: The team member's relationship to the team. This defaults to MEMBER if not set.
+          default: MEMBER
         joinDate:
           type: string
           format: date-time
           description: The team member's start date
+      description: Use `id` if you index teams via Glean, and use `name` and `externalLink` if you want to use your own team pages
     StructuredLocation:
       type: object
-      description: Detailed location with information about country, state, city etc.
       properties:
         deskLocation:
           type: string
@@ -7144,10 +7410,8 @@ components:
         countryCode:
           type: string
           description: Alpha-2 or Alpha-3 ISO 3166 country code, e.g. US or USA.
+      description: Detailed location with information about country, state, city etc.
     SocialNetwork:
-      required:
-        - name
-        - profileUrl
       properties:
         name:
           type: string
@@ -7159,11 +7423,10 @@ components:
           type: string
           format: url
           description: Link to profile.
-    PersonDistance:
       required:
         - name
-        - obfuscatedId
-        - distance
+        - profileUrl
+    PersonDistance:
       properties:
         name:
           type: string
@@ -7175,23 +7438,26 @@ components:
           type: number
           format: float
           description: Distance to person, refer to PeopleDistance pipeline on interpretation of the value.
+      required:
+        - name
+        - obfuscatedId
+        - distance
     CommunicationChannel:
       type: string
       enum:
         - COMMUNICATION_CHANNEL_EMAIL
         - COMMUNICATION_CHANNEL_SLACK
     ChannelInviteInfo:
-      description: Information regarding the invite status of a person for a particular channel.
       properties:
         channel:
+          $ref: '#/components/schemas/CommunicationChannel'
           description: Channel through which the invite was sent
-          $ref: "#/components/schemas/CommunicationChannel"
         isAutoInvite:
-          description: Bit that tracks if this invite was automatically sent or user-sent
           type: boolean
+          description: Bit that tracks if this invite was automatically sent or user-sent
         inviter:
+          $ref: '#/components/schemas/Person'
           description: The person that invited this person.
-          $ref: "#/components/schemas/Person"
         inviteTime:
           type: string
           format: date-time
@@ -7200,8 +7466,8 @@ components:
           type: string
           format: date-time
           description: The time this person was reminded in ISO format (ISO 8601) if a reminder was sent.
+      description: Information regarding the invite status of a person for a particular channel.
     InviteInfo:
-      description: Information regarding the invite status of a person.
       properties:
         signUpTime:
           type: string
@@ -7210,12 +7476,12 @@ components:
         invites:
           type: array
           items:
-            $ref: "#/components/schemas/ChannelInviteInfo"
+            $ref: '#/components/schemas/ChannelInviteInfo'
           description: Latest invites received by the user for each channel
         inviter:
-          deprecated: true
+          $ref: '#/components/schemas/Person'
           description: The person that invited this person.
-          $ref: "#/components/schemas/Person"
+          deprecated: true
           x-glean-deprecated:
             id: 1d3cd23f-9085-4378-b466-9bdc2e344a71
             introduced: "2026-02-05"
@@ -7223,10 +7489,10 @@ components:
             removal: "2026-10-15"
           x-speakeasy-deprecation-message: "Deprecated on 2026-02-05, removal scheduled for 2026-10-15: Use ChannelInviteInfo instead"
         inviteTime:
-          deprecated: true
           type: string
           format: date-time
           description: The time this person was invited in ISO format (ISO 8601).
+          deprecated: true
           x-glean-deprecated:
             id: 2dc3f572-cded-483d-af07-fc9fc7fd0ae4
             introduced: "2026-02-05"
@@ -7234,51 +7500,49 @@ components:
             removal: "2026-10-15"
           x-speakeasy-deprecation-message: "Deprecated on 2026-02-05, removal scheduled for 2026-10-15: Use ChannelInviteInfo instead"
         reminderTime:
-          deprecated: true
           type: string
           format: date-time
           description: The time this person was reminded in ISO format (ISO 8601) if a reminder was sent.
+          deprecated: true
           x-glean-deprecated:
             id: d02d58cf-eb90-45d0-ab90-f7a9d707ae3c
             introduced: "2026-02-05"
             message: Use ChannelInviteInfo instead
             removal: "2026-10-15"
           x-speakeasy-deprecation-message: "Deprecated on 2026-02-05, removal scheduled for 2026-10-15: Use ChannelInviteInfo instead"
+      description: Information regarding the invite status of a person.
     ReadPermission:
+      properties:
+        scopeType:
+          $ref: '#/components/schemas/ScopeType'
       description: Describes the read permission level that a user has for a specific feature
-      properties:
-        scopeType:
-          $ref: "#/components/schemas/ScopeType"
     ReadPermissions:
-      description: Describes the read permission levels that a user has for permissioned features. Key must be PermissionedFeatureOrObject
       additionalProperties:
         type: array
+        items:
+          $ref: '#/components/schemas/ReadPermission'
         description: List of read permissions (for different scopes but same feature)
-        items:
-          $ref: "#/components/schemas/ReadPermission"
+      description: Describes the read permission levels that a user has for permissioned features. Key must be PermissionedFeatureOrObject
     WritePermissions:
-      description: Describes the write permissions levels that a user has for permissioned features. Key must be PermissionedFeatureOrObject
       additionalProperties:
         type: array
-        description: List of write permissions (for different scopes but same feature)
         items:
-          $ref: "#/components/schemas/WritePermission"
+          $ref: '#/components/schemas/WritePermission'
+        description: List of write permissions (for different scopes but same feature)
+      description: Describes the write permissions levels that a user has for permissioned features. Key must be PermissionedFeatureOrObject
     GrantPermission:
-      description: Describes the grant permission level that a user has for a specific feature
       properties:
         scopeType:
-          $ref: "#/components/schemas/ScopeType"
+          $ref: '#/components/schemas/ScopeType'
+      description: Describes the grant permission level that a user has for a specific feature
     GrantPermissions:
-      description: Describes the grant permission levels that a user has for permissioned features. Key must be PermissionedFeatureOrObject
       additionalProperties:
         type: array
-        description: List of grant permissions (for different scopes but same feature)
         items:
-          $ref: "#/components/schemas/GrantPermission"
+          $ref: '#/components/schemas/GrantPermission'
+        description: List of grant permissions (for different scopes but same feature)
+      description: Describes the grant permission levels that a user has for permissioned features. Key must be PermissionedFeatureOrObject
     Permissions:
-      description: |-
-        Describes the permissions levels that a user has for permissioned features. When the client sends this, Permissions.read and Permissions.write are the additional permissions granted to a user on top of what they have via their roles.
-        When the server sends this, Permissions.read and Permissions.write are the complete (merged) set of permissions the user has, and Permissions.roles is just for display purposes.
       properties:
         canAdminSearch:
           type: boolean
@@ -7290,23 +7554,23 @@ components:
           type: boolean
           description: TODO--deprecate in favor of the read and write properties. True if the user has access to data loss prevention (DLP) features
         read:
-          $ref: "#/components/schemas/ReadPermissions"
+          $ref: '#/components/schemas/ReadPermissions'
         write:
-          $ref: "#/components/schemas/WritePermissions"
+          $ref: '#/components/schemas/WritePermissions'
         grant:
-          $ref: "#/components/schemas/GrantPermissions"
+          $ref: '#/components/schemas/GrantPermissions'
         role:
           type: string
           description: The roleId of the canonical role a user has. The displayName is equal to the roleId.
         roles:
           type: array
-          description: The roleIds of the roles a user has.
           items:
             type: string
+          description: The roleIds of the roles a user has.
+      description: |-
+        Describes the permissions levels that a user has for permissioned features. When the client sends this, Permissions.read and Permissions.write are the additional permissions granted to a user on top of what they have via their roles.
+        When the server sends this, Permissions.read and Permissions.write are the complete (merged) set of permissions the user has, and Permissions.roles is just for display purposes.
     TimeInterval:
-      required:
-        - start
-        - end
       properties:
         start:
           type: string
@@ -7314,21 +7578,23 @@ components:
         end:
           type: string
           description: The RFC3339 timestamp formatted end time of this event.
+      required:
+        - start
+        - end
     AnonymousEvent:
-      description: A generic, light-weight calendar event.
       type: object
       properties:
         time:
-          $ref: "#/components/schemas/TimeInterval"
+          $ref: '#/components/schemas/TimeInterval'
         eventType:
-          description: The nature of the event, for example "out of office".
           type: string
           enum:
             - DEFAULT
             - OUT_OF_OFFICE
+          description: The nature of the event, for example "out of office".
+      description: A generic, light-weight calendar event.
     Badge:
       type: object
-      description: Displays a user's accomplishment or milestone
       properties:
         key:
           type: string
@@ -7337,10 +7603,11 @@ components:
           type: string
           description: The badge name displayed to users
         iconConfig:
-          $ref: "#/components/schemas/IconConfig"
+          $ref: '#/components/schemas/IconConfig'
         pinned:
           type: boolean
           description: The badge should be shown on the PersonAttribution
+      description: Displays a user's accomplishment or milestone
       example:
         key: deployment_name_new_hire
         displayName: New hire
@@ -7353,17 +7620,17 @@ components:
       properties:
         type:
           type: string
-          x-enumDescriptions:
-            FULL_TIME: The person is a current full-time employee of the company.
-            CONTRACTOR: The person is a current contractor of the company.
-            NON_EMPLOYEE: The person object represents a non-human actor such as a service or admin account.
-            FORMER_EMPLOYEE: The person is a previous employee of the company.
           enum:
             - FULL_TIME
             - CONTRACTOR
             - NON_EMPLOYEE
             - FORMER_EMPLOYEE
           example: FULL_TIME
+          x-enumDescriptions:
+            FULL_TIME: The person is a current full-time employee of the company.
+            CONTRACTOR: The person is a current contractor of the company.
+            NON_EMPLOYEE: The person object represents a non-human actor such as a service or admin account.
+            FORMER_EMPLOYEE: The person is a previous employee of the company.
           x-speakeasy-enum-descriptions:
             FULL_TIME: The person is a current full-time employee of the company.
             CONTRACTOR: The person is a current contractor of the company.
@@ -7385,10 +7652,10 @@ components:
           type: string
           description: An organizational unit where everyone has a similar task, e.g. `Engineering`.
         teams:
-          description: Info about the employee's team(s).
           type: array
           items:
-            $ref: "#/components/schemas/PersonTeam"
+            $ref: '#/components/schemas/PersonTeam'
+          description: Info about the employee's team(s).
         departmentCount:
           type: integer
           description: The number of people in this person's department.
@@ -7397,24 +7664,24 @@ components:
           description: The user's primary email address
         aliasEmails:
           type: array
-          description: Additional email addresses of this user beyond the primary, if any.
           items:
             type: string
+          description: Additional email addresses of this user beyond the primary, if any.
         location:
           type: string
           description: User facing string representing the person's location.
         structuredLocation:
-          $ref: "#/components/schemas/StructuredLocation"
+          $ref: '#/components/schemas/StructuredLocation'
         externalProfileLink:
           type: string
           description: Link to a customer's internal profile page. This is set to '#' when no link is desired.
         manager:
-          $ref: "#/components/schemas/Person"
+          $ref: '#/components/schemas/Person'
         managementChain:
-          description: The chain of reporting in the company as far up as it goes. The last entry is this person's direct manager.
           type: array
           items:
-            $ref: "#/components/schemas/Person"
+            $ref: '#/components/schemas/Person'
+          description: The chain of reporting in the company as far up as it goes. The last entry is this person's direct manager.
         phone:
           type: string
           description: Phone number as a number string.
@@ -7443,11 +7710,11 @@ components:
         reports:
           type: array
           items:
-            $ref: "#/components/schemas/Person"
+            $ref: '#/components/schemas/Person'
         startDate:
           type: string
-          description: The date when the employee started.
           format: date
+          description: The date when the employee started.
         endDate:
           type: string
           format: date
@@ -7468,24 +7735,24 @@ components:
           type: string
           description: The preferred name of the person, or a nickname.
         socialNetwork:
-          description: List of social network profiles.
           type: array
           items:
-            $ref: "#/components/schemas/SocialNetwork"
+            $ref: '#/components/schemas/SocialNetwork'
+          description: List of social network profiles.
         datasourceProfile:
           type: array
-          description: List of profiles this user has in different datasources / tools that they use.
           items:
-            $ref: "#/components/schemas/DatasourceProfile"
+            $ref: '#/components/schemas/DatasourceProfile'
+          description: List of profiles this user has in different datasources / tools that they use.
         querySuggestions:
-          $ref: "#/components/schemas/QuerySuggestionList"
+          $ref: '#/components/schemas/QuerySuggestionList'
         peopleDistance:
           type: array
           items:
-            $ref: "#/components/schemas/PersonDistance"
+            $ref: '#/components/schemas/PersonDistance'
           description: List of people and distances to those people from this person. Optionally with metadata.
         inviteInfo:
-          $ref: "#/components/schemas/InviteInfo"
+          $ref: '#/components/schemas/InviteInfo'
         isSignedUp:
           type: boolean
           description: Whether the user has signed into Glean at least once.
@@ -7494,12 +7761,12 @@ components:
           format: date-time
           description: The last time the user has used the Glean extension in ISO 8601 format.
         permissions:
-          $ref: "#/components/schemas/Permissions"
+          $ref: '#/components/schemas/Permissions'
         customFields:
           type: array
-          description: User customizable fields for additional people information.
           items:
-            $ref: "#/components/schemas/CustomFieldData"
+            $ref: '#/components/schemas/CustomFieldData'
+          description: User customizable fields for additional people information.
         loggingId:
           type: string
           description: The logging id of the person used in scrubbed logs, tracking GA metrics.
@@ -7510,7 +7777,7 @@ components:
         busyEvents:
           type: array
           items:
-            $ref: "#/components/schemas/AnonymousEvent"
+            $ref: '#/components/schemas/AnonymousEvent'
           description: Intervals of busy time for this person, along with the type of event they're busy with.
         profileBoolSettings:
           type: object
@@ -7520,7 +7787,7 @@ components:
         badges:
           type: array
           items:
-            $ref: "#/components/schemas/Badge"
+            $ref: '#/components/schemas/Badge'
           description: The badges that a user has earned over their lifetime.
         isOrgRoot:
           type: boolean
@@ -7535,6 +7802,13 @@ components:
         title: Actor
     DocumentVisibility:
       type: string
+      enum:
+        - PRIVATE
+        - SPECIFIC_PEOPLE_AND_GROUPS
+        - DOMAIN_LINK
+        - DOMAIN_VISIBLE
+        - PUBLIC_LINK
+        - PUBLIC_VISIBLE
       description: The level of visibility of the document as understood by our system.
       x-enumDescriptions:
         PRIVATE: Only one person is able to see the document.
@@ -7543,13 +7817,6 @@ components:
         DOMAIN_VISIBLE: Anyone in the domain can search for the document.
         PUBLIC_LINK: Anyone with the link can see the document.
         PUBLIC_VISIBLE: Anyone on the internet can search for the document.
-      enum:
-        - PRIVATE
-        - SPECIFIC_PEOPLE_AND_GROUPS
-        - DOMAIN_LINK
-        - DOMAIN_VISIBLE
-        - PUBLIC_LINK
-        - PUBLIC_VISIBLE
       x-speakeasy-enum-descriptions:
         PRIVATE: Only one person is able to see the document.
         SPECIFIC_PEOPLE_AND_GROUPS: Only specific people and/or groups can see the document.
@@ -7567,22 +7834,22 @@ components:
         reactors:
           type: array
           items:
-            $ref: "#/components/schemas/Person"
+            $ref: '#/components/schemas/Person'
         reactedByViewer:
           type: boolean
           description: Whether the user in context reacted with this type to the document.
     Share:
-      description: Search endpoint will only fill out numDays ago since that's all we need to display shared badge; docmetadata endpoint will fill out all the fields so that we can display shared badge tooltip
-      required:
-        - numDaysAgo
       properties:
         numDaysAgo:
           type: integer
           description: The number of days that has passed since the share happened
         sharer:
-          $ref: "#/components/schemas/Person"
+          $ref: '#/components/schemas/Person'
         sharingDocument:
-          $ref: "#/components/schemas/Document"
+          $ref: '#/components/schemas/Document'
+      required:
+        - numDaysAgo
+      description: Search endpoint will only fill out numDays ago since that's all we need to display shared badge; docmetadata endpoint will fill out all the fields so that we can display shared badge tooltip
     DocumentInteractions:
       properties:
         numComments:
@@ -7593,10 +7860,10 @@ components:
           description: The count of reactions on the document.
         reactions:
           type: array
-          description: To be deprecated in favor of reacts. A (potentially non-exhaustive) list of reactions for the document.
-          deprecated: true
           items:
             type: string
+          description: To be deprecated in favor of reacts. A (potentially non-exhaustive) list of reactions for the document.
+          deprecated: true
           x-glean-deprecated:
             id: cd754845-6eec-480f-b395-c93478aff563
             introduced: "2026-02-05"
@@ -7606,14 +7873,14 @@ components:
         reacts:
           type: array
           items:
-            $ref: "#/components/schemas/Reaction"
+            $ref: '#/components/schemas/Reaction'
         shares:
           type: array
           items:
-            $ref: "#/components/schemas/Share"
+            $ref: '#/components/schemas/Share'
           description: Describes instances of someone posting a link to this document in one of our indexed datasources.
         visitorCount:
-          $ref: "#/components/schemas/CountInfo"
+          $ref: '#/components/schemas/CountInfo'
     ViewerInfo:
       properties:
         role:
@@ -7637,13 +7904,13 @@ components:
     IndexStatus:
       properties:
         lastCrawledTime:
+          type: string
+          format: date-time
           description: When the document was last crawled
-          type: string
-          format: date-time
         lastIndexedTime:
-          description: When the document was last indexed
           type: string
           format: date-time
+          description: When the document was last indexed
     DocumentMetadata:
       properties:
         datasource:
@@ -7684,21 +7951,21 @@ components:
           type: string
           format: date-time
         author:
-          $ref: "#/components/schemas/Person"
+          $ref: '#/components/schemas/Person'
         owner:
-          $ref: "#/components/schemas/Person"
+          $ref: '#/components/schemas/Person'
         mentionedPeople:
           type: array
           items:
-            $ref: "#/components/schemas/Person"
+            $ref: '#/components/schemas/Person'
           description: A list of people mentioned in the document.
         visibility:
-          $ref: "#/components/schemas/DocumentVisibility"
+          $ref: '#/components/schemas/DocumentVisibility'
         components:
           type: array
-          description: A list of components this result is associated with. Interpretation is specific to each datasource. (e.g. for Jira issues, these are [components](https://confluence.atlassian.com/jirasoftwarecloud/organizing-work-with-components-764478279.html).)
           items:
             type: string
+          description: A list of components this result is associated with. Interpretation is specific to each datasource. (e.g. for Jira issues, these are [components](https://confluence.atlassian.com/jirasoftwarecloud/organizing-work-with-components-764478279.html).)
         status:
           type: string
           description: The status or disposition of the result. Interpretation is specific to each datasource. (e.g. for Jira issues, this is the issue status such as Done, In Progress or Will Not Fix).
@@ -7707,64 +7974,64 @@ components:
           description: The status category of the result. Meant to be more general than status. Interpretation is specific to each datasource.
         pins:
           type: array
-          description: A list of stars associated with this result.  "Pin" is an older name.
           items:
-            $ref: "#/components/schemas/PinDocument"
+            $ref: '#/components/schemas/PinDocument'
+          description: A list of stars associated with this result.  "Pin" is an older name.
         priority:
           type: string
           description: The document priority. Interpretation is datasource specific.
         assignedTo:
-          $ref: "#/components/schemas/Person"
+          $ref: '#/components/schemas/Person'
         updatedBy:
-          $ref: "#/components/schemas/Person"
+          $ref: '#/components/schemas/Person'
         labels:
           type: array
-          description: A list of tags for the document. Interpretation is datasource specific.
           items:
             type: string
+          description: A list of tags for the document. Interpretation is datasource specific.
         collections:
           type: array
-          description: A list of collections that the document belongs to.
           items:
-            $ref: "#/components/schemas/Collection"
+            $ref: '#/components/schemas/Collection'
+          description: A list of collections that the document belongs to.
         datasourceId:
           type: string
           description: The user-visible datasource specific id (e.g. Salesforce case number for example, GitHub PR number).
         interactions:
-          $ref: "#/components/schemas/DocumentInteractions"
+          $ref: '#/components/schemas/DocumentInteractions'
         verification:
-          $ref: "#/components/schemas/Verification"
+          $ref: '#/components/schemas/Verification'
         viewerInfo:
-          $ref: "#/components/schemas/ViewerInfo"
+          $ref: '#/components/schemas/ViewerInfo'
         permissions:
-          $ref: "#/components/schemas/ObjectPermissions"
+          $ref: '#/components/schemas/ObjectPermissions'
         visitCount:
-          $ref: "#/components/schemas/CountInfo"
+          $ref: '#/components/schemas/CountInfo'
         shortcuts:
           type: array
-          description: A list of shortcuts of which destination URL is for the document.
           items:
-            $ref: "#/components/schemas/Shortcut"
+            $ref: '#/components/schemas/Shortcut'
+          description: A list of shortcuts of which destination URL is for the document.
         path:
           type: string
           description: For file datasources like onedrive/github etc this has the path to the file
         customData:
-          $ref: "#/components/schemas/CustomData"
+          $ref: '#/components/schemas/CustomData'
         documentCategory:
           type: string
           description: The document's document_category(.proto).
         contactPerson:
-          $ref: "#/components/schemas/Person"
+          $ref: '#/components/schemas/Person'
         thumbnail:
-          $ref: "#/components/schemas/Thumbnail"
+          $ref: '#/components/schemas/Thumbnail'
           description: A thumbnail image representing this document.
         indexStatus:
-          $ref: "#/components/schemas/IndexStatus"
+          $ref: '#/components/schemas/IndexStatus'
         ancestors:
           type: array
-          description: A list of documents that are ancestors of this document in the hierarchy of the document's datasource, for example parent folders or containers. Ancestors can be of different types and some may not be indexed. Higher level ancestors appear earlier in the list.
           items:
-            $ref: "#/components/schemas/Document"
+            $ref: '#/components/schemas/Document'
+          description: A list of documents that are ancestors of this document in the hierarchy of the document's datasource, for example parent folders or containers. Ancestors can be of different types and some may not be indexed. Higher level ancestors appear earlier in the list.
       example:
         container: container
         parentId: JIRA_EN-1337
@@ -7798,14 +8065,14 @@ components:
           type: string
           example: https://en.wikipedia.org/wiki/Diffuse_sky_radiation
         document:
-          deprecated: true
+          $ref: '#/components/schemas/Document'
           description: Deprecated. To be gradually migrated to structuredResult.
-          $ref: "#/components/schemas/Document"
+          deprecated: true
         text:
           type: string
           example: Because its wavelengths are shorter, blue light is more strongly scattered than the longer-wavelength lights, red or green. Hence the result that when looking at the sky away from the direct incident sunlight, the human eye perceives the sky to be blue.
         structuredResult:
-          $ref: "#/components/schemas/StructuredResult"
+          $ref: '#/components/schemas/StructuredResult'
     AnnouncementMutableProperties:
       properties:
         startTime:
@@ -7820,20 +8087,20 @@ components:
           type: string
           description: The headline of the announcement.
         body:
-          $ref: "#/components/schemas/StructuredText"
+          $ref: '#/components/schemas/StructuredText'
         emoji:
           type: string
           description: An emoji used to indicate the nature of the announcement.
         thumbnail:
-          $ref: "#/components/schemas/Thumbnail"
+          $ref: '#/components/schemas/Thumbnail'
         banner:
-          $ref: "#/components/schemas/Thumbnail"
+          $ref: '#/components/schemas/Thumbnail'
           description: Optional variant of thumbnail cropped for header background.
         audienceFilters:
           type: array
-          description: Filters which restrict who should see the announcement. Values are taken from the corresponding filters in people search.
           items:
-            $ref: "#/components/schemas/FacetFilter"
+            $ref: '#/components/schemas/FacetFilter'
+          description: Filters which restrict who should see the announcement. Values are taken from the corresponding filters in people search.
         sourceDocumentId:
           type: string
           description: The Glean Document ID of the source document this Announcement was created from (e.g. Slack thread).
@@ -7860,7 +8127,7 @@ components:
           description: URL for viewing the announcement. It will be set to document URL for announcements from other datasources e.g. simpplr. Can only be written when channel="SOCIAL_FEED".
     CreateAnnouncementRequest:
       allOf:
-        - $ref: "#/components/schemas/AnnouncementMutableProperties"
+        - $ref: '#/components/schemas/AnnouncementMutableProperties'
         - type: object
           required:
             - title
@@ -7875,17 +8142,17 @@ components:
         draftId: 342
     Announcement:
       allOf:
-        - $ref: "#/components/schemas/AnnouncementMutableProperties"
-        - $ref: "#/components/schemas/DraftProperties"
-        - $ref: "#/components/schemas/PermissionedObject"
-        - $ref: "#/components/schemas/UgcTrackingSignals"
+        - $ref: '#/components/schemas/AnnouncementMutableProperties'
+        - $ref: '#/components/schemas/DraftProperties'
+        - $ref: '#/components/schemas/PermissionedObject'
+        - $ref: '#/components/schemas/UgcTrackingSignals'
         - type: object
           properties:
             id:
               type: integer
               description: The opaque id of the announcement.
             author:
-              $ref: "#/components/schemas/Person"
+              $ref: '#/components/schemas/Person'
             createTimestamp:
               type: integer
               description: Server Unix timestamp of the creation time (in seconds since epoch UTC).
@@ -7893,7 +8160,7 @@ components:
               type: integer
               description: Server Unix timestamp of the last update time (in seconds since epoch UTC).
             updatedBy:
-              $ref: "#/components/schemas/Person"
+              $ref: '#/components/schemas/Person'
             viewerInfo:
               type: object
               properties:
@@ -7904,31 +8171,31 @@ components:
                   type: boolean
                   description: Whether the viewer has read the announcement.
             sourceDocument:
-              $ref: "#/components/schemas/Document"
+              $ref: '#/components/schemas/Document'
               description: The source document if the announcement is created from one.
             isPublished:
               type: boolean
               description: Whether or not the announcement is published.
     DeleteAnnouncementRequest:
-      required:
-        - id
       properties:
         id:
           type: integer
           description: The opaque id of the announcement to be deleted.
+      required:
+        - id
     UpdateAnnouncementRequest:
       allOf:
-        - $ref: "#/components/schemas/AnnouncementMutableProperties"
+        - $ref: '#/components/schemas/AnnouncementMutableProperties'
         - type: object
+          properties:
+            id:
+              type: integer
+              description: The opaque id of the announcement.
           required:
             - id
             - title
             - startTime
             - endTime
-          properties:
-            id:
-              type: integer
-              description: The opaque id of the announcement.
     AddedCollections:
       properties:
         addedCollections:
@@ -7938,22 +8205,22 @@ components:
           description: IDs of Collections to which a document is added.
     AnswerCreationData:
       allOf:
-        - $ref: "#/components/schemas/AnswerMutableProperties"
-        - $ref: "#/components/schemas/AddedCollections"
+        - $ref: '#/components/schemas/AnswerMutableProperties'
+        - $ref: '#/components/schemas/AddedCollections'
         - type: object
           properties:
             combinedAnswerText:
-              $ref: "#/components/schemas/StructuredTextMutableProperties"
+              $ref: '#/components/schemas/StructuredTextMutableProperties'
     CreateAnswerRequest:
-      required:
-        - data
       properties:
         data:
-          $ref: "#/components/schemas/AnswerCreationData"
+          $ref: '#/components/schemas/AnswerCreationData'
+      required:
+        - data
     DeleteAnswerRequest:
       allOf:
-        - $ref: "#/components/schemas/AnswerId"
-        - $ref: "#/components/schemas/AnswerDocId"
+        - $ref: '#/components/schemas/AnswerId'
+        - $ref: '#/components/schemas/AnswerDocId'
         - type: object
           required:
             - id
@@ -7966,27 +8233,25 @@ components:
           description: IDs of Collections from which a document is removed.
     EditAnswerRequest:
       allOf:
-        - $ref: "#/components/schemas/AnswerId"
-        - $ref: "#/components/schemas/AnswerDocId"
-        - $ref: "#/components/schemas/AnswerMutableProperties"
-        - $ref: "#/components/schemas/AddedCollections"
-        - $ref: "#/components/schemas/RemovedCollections"
+        - $ref: '#/components/schemas/AnswerId'
+        - $ref: '#/components/schemas/AnswerDocId'
+        - $ref: '#/components/schemas/AnswerMutableProperties'
+        - $ref: '#/components/schemas/AddedCollections'
+        - $ref: '#/components/schemas/RemovedCollections'
         - type: object
-          required:
-            - id
           properties:
             combinedAnswerText:
-              $ref: "#/components/schemas/StructuredTextMutableProperties"
+              $ref: '#/components/schemas/StructuredTextMutableProperties'
+          required:
+            - id
     GetAnswerRequest:
       allOf:
-        - $ref: "#/components/schemas/AnswerId"
-        - $ref: "#/components/schemas/AnswerDocId"
+        - $ref: '#/components/schemas/AnswerId'
+        - $ref: '#/components/schemas/AnswerDocId'
     AnswerResult:
-      required:
-        - answer
       properties:
         answer:
-          $ref: "#/components/schemas/Answer"
+          $ref: '#/components/schemas/Answer'
         trackingToken:
           type: string
           description: Use `answer.trackingToken` instead.
@@ -7997,6 +8262,8 @@ components:
             message: Use `answer.trackingToken` instead.
             removal: "2027-01-15"
           x-speakeasy-deprecation-message: "Deprecated on 2026-05-07, removal scheduled for 2027-01-15: Use `answer.trackingToken` instead."
+      required:
+        - answer
     GetAnswerError:
       properties:
         errorType:
@@ -8005,37 +8272,37 @@ components:
             - NO_PERMISSION
             - INVALID_ID
         answerAuthor:
-          $ref: "#/components/schemas/Person"
+          $ref: '#/components/schemas/Person'
     GetAnswerResponse:
       properties:
         answerResult:
-          $ref: "#/components/schemas/AnswerResult"
+          $ref: '#/components/schemas/AnswerResult'
         error:
-          $ref: "#/components/schemas/GetAnswerError"
+          $ref: '#/components/schemas/GetAnswerError'
     ListAnswersRequest:
       properties:
         boardId:
           type: integer
           description: The Answer Board Id to list answers on.
     ListAnswersResponse:
-      required:
-        - answers
-        - answerResults
       properties:
         answerResults:
           type: array
           items:
-            $ref: "#/components/schemas/AnswerResult"
+            $ref: '#/components/schemas/AnswerResult'
           description: List of answers with tracking tokens.
+      required:
+        - answers
+        - answerResults
     AuthStatus:
       type: string
-      description: The per-user authorization status for a datasource.
       enum:
         - DISABLED
         - AWAITING_AUTH
         - AUTHORIZED
         - STALE_OAUTH
         - SEG_MIGRATION
+      description: The per-user authorization status for a datasource.
       x-enum-varnames:
         - AUTH_STATUS_DISABLED
         - AUTH_STATUS_AWAITING_AUTH
@@ -8043,8 +8310,6 @@ components:
         - AUTH_STATUS_STALE_OAUTH
         - AUTH_STATUS_SEG_MIGRATION
     UnauthorizedDatasourceInstance:
-      description: |
-        A datasource instance that could not return results for this request because the user has not completed or has expired per-user OAuth.
       properties:
         datasourceInstance:
           type: string
@@ -8056,48 +8321,56 @@ components:
           description: Human-readable name of the datasource instance for display.
           example: Slack
         authStatus:
-          $ref: "#/components/schemas/AuthStatus"
+          $ref: '#/components/schemas/AuthStatus'
         authUrlRelativePath:
           type: string
           description: |
             Relative path to initiate or resume OAuth for the current user and instance, including a one-time authentication token as a query parameter. Clients should prepend their configured Glean backend base URL.
+      description: |
+        A datasource instance that could not return results for this request because the user has not completed or has expired per-user OAuth.
     CheckDatasourceAuthResponse:
-      required:
-        - unauthorizedDatasourceInstances
       properties:
         unauthorizedDatasourceInstances:
           type: array
+          items:
+            $ref: '#/components/schemas/UnauthorizedDatasourceInstance'
           description: |
             Datasource instances that require per-user OAuth authorization. Empty when all datasources are authorized.
-          items:
-            $ref: "#/components/schemas/UnauthorizedDatasourceInstance"
-    CreateAuthTokenResponse:
       required:
-        - token
-        - expirationTime
+        - unauthorizedDatasourceInstances
+    CreateAuthTokenResponse:
       properties:
         token:
           type: string
           description: An authentication token that can be passed to any endpoint via Bearer Authentication
         expirationTime:
-          description: Unix timestamp for when this token expires (in seconds since epoch UTC).
           type: integer
           format: int64
+          description: Unix timestamp for when this token expires (in seconds since epoch UTC).
+      required:
+        - token
+        - expirationTime
     ToolSets:
       type: object
-      description: The types of tools that the agent is allowed to use. Only works with FAST and ADVANCED `agent` values
       properties:
         enableWebSearch:
           type: boolean
-          description: "Whether the agent is allowed to use web search (default: true)."
+          description: 'Whether the agent is allowed to use web search (default: true).'
         enableCompanyTools:
           type: boolean
-          description: "Whether the agent is allowed to search internal company resources (default: true)."
+          description: 'Whether the agent is allowed to search internal company resources (default: true).'
+      description: The types of tools that the agent is allowed to use. Only works with FAST and ADVANCED `agent` values
     AgentConfig:
-      description: Describes the agent that executes the request.
       properties:
         agent:
           type: string
+          enum:
+            - DEFAULT
+            - GPT
+            - UNIVERSAL
+            - FAST
+            - ADVANCED
+            - AUTO
           description: Name of the agent.
           x-enumDescriptions:
             DEFAULT: Integrates with your company's knowledge. This will soon be deprecated in favor of the FAST and ADVANCED `agent` values
@@ -8106,13 +8379,6 @@ components:
             FAST: Uses an agent powered by the agentic engine that responds faster but may have lower quality results. Requires the agentic engine to be enabled in the deployment.
             ADVANCED: Uses an agent powered by the agentic engine that thinks for longer and potentially makes more LLM calls to return higher quality results. Requires the agentic engine to be enabled in the deployment.
             AUTO: Uses an agent powered by the agentic engine that routes between reasoning efforts based on the question and context.
-          enum:
-            - DEFAULT
-            - GPT
-            - UNIVERSAL
-            - FAST
-            - ADVANCED
-            - AUTO
           x-speakeasy-enum-descriptions:
             DEFAULT: Integrates with your company's knowledge. This will soon be deprecated in favor of the FAST and ADVANCED `agent` values
             GPT: Communicates directly with the LLM. This will soon be deprecated in favor of the FAST and ADVANCED `agent` values
@@ -8121,36 +8387,35 @@ components:
             ADVANCED: Uses an agent powered by the agentic engine that thinks for longer and potentially makes more LLM calls to return higher quality results. Requires the agentic engine to be enabled in the deployment.
             AUTO: Uses an agent powered by the agentic engine that routes between reasoning efforts based on the question and context.
         toolSets:
-          $ref: "#/components/schemas/ToolSets"
+          $ref: '#/components/schemas/ToolSets'
         mode:
           type: string
+          enum:
+            - DEFAULT
+            - QUICK
           description: Top level modes to run GleanChat in.
           x-enumDescriptions:
             DEFAULT: Used if no mode supplied.
             QUICK: Deprecated.
-          enum:
-            - DEFAULT
-            - QUICK
           x-speakeasy-enum-descriptions:
             DEFAULT: Used if no mode supplied.
             QUICK: Deprecated.
         useImageGeneration:
           type: boolean
           description: Whether the agent should create an image.
+      description: Describes the agent that executes the request.
     ChatFileStatus:
       type: string
-      description: Current status of the file.
-      x-include-enum-class-prefix: true
       enum:
         - PROCESSING
         - PROCESSED
         - PARTIALLY_PROCESSED
         - FAILED
         - DELETED
+      description: Current status of the file.
+      x-include-enum-class-prefix: true
     ChatFileFailureReason:
       type: string
-      description: Reason for failed status.
-      x-include-enum-class-prefix: true
       enum:
         - PARSE_FAILED
         - AV_SCAN_FAILED
@@ -8163,12 +8428,13 @@ components:
         - URL_FETCH_FAILED
         - EMPTY_CONTENT
         - AUTH_REQUIRED
+      description: Reason for failed status.
+      x-include-enum-class-prefix: true
     ChatFileMetadata:
       type: object
-      description: Metadata of a file uploaded by a user for Chat.
       properties:
         status:
-          $ref: "#/components/schemas/ChatFileStatus"
+          $ref: '#/components/schemas/ChatFileStatus'
         uploadTime:
           type: integer
           format: int64
@@ -8178,13 +8444,13 @@ components:
           format: int64
           description: Size of the processed file in bytes.
         failureReason:
-          $ref: "#/components/schemas/ChatFileFailureReason"
+          $ref: '#/components/schemas/ChatFileFailureReason'
         mimeType:
-          description: MIME type of the file.
           type: string
+          description: MIME type of the file.
+      description: Metadata of a file uploaded by a user for Chat.
     ChatFile:
       type: object
-      description: Structure for file uploaded by a user for Chat.
       properties:
         id:
           type: string
@@ -8199,38 +8465,39 @@ components:
           description: Name of the uploaded file.
           example: sample.pdf
         metadata:
-          $ref: "#/components/schemas/ChatFileMetadata"
+          $ref: '#/components/schemas/ChatFileMetadata'
+      description: Structure for file uploaded by a user for Chat.
     ReferenceRange:
-      description: Each text range from the response can correspond to an array of snippets from the citation source.
       properties:
         textRange:
-          $ref: "#/components/schemas/TextRange"
+          $ref: '#/components/schemas/TextRange'
         snippets:
           type: array
           items:
-            $ref: "#/components/schemas/SearchResultSnippet"
+            $ref: '#/components/schemas/SearchResultSnippet'
+      description: Each text range from the response can correspond to an array of snippets from the citation source.
     ChatMessageCitation:
-      description: Information about the source for a ChatMessage.
       properties:
         trackingToken:
           type: string
           description: An opaque token that represents this particular result in this particular ChatMessage. To be used for /feedback reporting.
         sourceDocument:
-          $ref: "#/components/schemas/Document"
+          $ref: '#/components/schemas/Document'
         sourceFile:
-          $ref: "#/components/schemas/ChatFile"
+          $ref: '#/components/schemas/ChatFile'
         sourcePerson:
-          $ref: "#/components/schemas/Person"
+          $ref: '#/components/schemas/Person'
         sourceCustomEntity:
-          $ref: "#/components/schemas/CustomEntity"
+          $ref: '#/components/schemas/CustomEntity'
         referenceRanges:
-          description: Each reference range and its corresponding snippets
           type: array
           items:
-            $ref: "#/components/schemas/ReferenceRange"
+            $ref: '#/components/schemas/ReferenceRange'
+          description: Each reference range and its corresponding snippets
+      description: Information about the source for a ChatMessage.
     displayName:
-      description: Human understandable name of the tool. Max 50 characters.
       type: string
+      description: Human understandable name of the tool. Max 50 characters.
     logoUrl:
       type: string
       description: URL used to fetch the logo.
@@ -8242,9 +8509,6 @@ components:
         - Email
         - Chat message
     PersonObject:
-      required:
-        - name
-        - obfuscatedId
       properties:
         name:
           type: string
@@ -8252,8 +8516,10 @@ components:
         obfuscatedId:
           type: string
           description: An opaque identifier that can be used to request metadata for a Person.
+      required:
+        - name
+        - obfuscatedId
     AuthConfig:
-      description: Config for tool's authentication method.
       type: object
       properties:
         isOnPrem:
@@ -8285,11 +8551,11 @@ components:
           description: The type of grant type being used.
         status:
           type: string
-          description: Auth status of the tool.
           enum:
             - AWAITING_AUTH
             - AUTHORIZED
             - AUTH_DISABLED
+          description: Auth status of the tool.
         client_url:
           type: string
           format: url
@@ -8323,46 +8589,41 @@ components:
           type: string
           format: date-time
           description: The time the tool was last authorized in ISO format (ISO 8601).
+      description: Config for tool's authentication method.
     ToolMetadata:
-      description: The manifest for a tool that can be used to augment Glean Assistant.
-      required:
-        - type
-        - name
-        - displayName
-        - displayDescription
       properties:
         type:
-          description: The type of tool.
           type: string
           enum:
             - RETRIEVAL
             - ACTION
+          description: The type of tool.
         name:
-          description: Unique identifier for the tool. Name should be understandable by the LLM, and will be used to invoke a tool.
           type: string
+          description: Unique identifier for the tool. Name should be understandable by the LLM, and will be used to invoke a tool.
         displayName:
-          $ref: "#/components/schemas/displayName"
+          $ref: '#/components/schemas/displayName'
         toolId:
           type: string
           description: An opaque id which is unique identifier for the tool.
         displayDescription:
-          description: Description of the tool meant for a human.
           type: string
+          description: Description of the tool meant for a human.
         logoUrl:
-          $ref: "#/components/schemas/logoUrl"
+          $ref: '#/components/schemas/logoUrl'
         objectName:
-          $ref: "#/components/schemas/objectName"
+          $ref: '#/components/schemas/objectName'
         knowledgeType:
           type: string
-          description: Indicates the kind of knowledge a tool would access or modify.
           enum:
             - NEUTRAL_KNOWLEDGE
             - COMPANY_KNOWLEDGE
             - WORLD_KNOWLEDGE
+          description: Indicates the kind of knowledge a tool would access or modify.
         createdBy:
-          $ref: "#/components/schemas/PersonObject"
+          $ref: '#/components/schemas/PersonObject'
         lastUpdatedBy:
-          $ref: "#/components/schemas/PersonObject"
+          $ref: '#/components/schemas/PersonObject'
         createdAt:
           type: string
           format: date-time
@@ -8373,11 +8634,11 @@ components:
           description: The time the tool was last updated in ISO format (ISO 8601)
         writeActionType:
           type: string
-          description: Valid only for write actions. Represents the type of write action. REDIRECT - The client renders the URL which contains information for carrying out the action. EXECUTION - Send a request to an external server and execute the action. MCP - Send a tools/call request to an MCP server to execute the action.
           enum:
             - REDIRECT
             - EXECUTION
             - MCP
+          description: Valid only for write actions. Represents the type of write action. REDIRECT - The client renders the URL which contains information for carrying out the action. EXECUTION - Send a request to an external server and execute the action. MCP - Send a tools/call request to an MCP server to execute the action.
         authType:
           type: string
           enum:
@@ -8394,20 +8655,25 @@ components:
             'OAUTH_USER' uses individual user tokens for external API calls.
             'DWD' refers to domain wide delegation.
         auth:
+          $ref: '#/components/schemas/AuthConfig'
           deprecated: true
-          $ref: "#/components/schemas/AuthConfig"
         permissions:
+          $ref: '#/components/schemas/ObjectPermissions'
           deprecated: true
-          $ref: "#/components/schemas/ObjectPermissions"
         usageInstructions:
-          description: Usage instructions for the LLM to use this action.
           type: string
+          description: Usage instructions for the LLM to use this action.
         isSetupFinished:
           type: boolean
           description: Whether this action has been fully configured and validated.
+      required:
+        - type
+        - name
+        - displayName
+        - displayDescription
+      description: The manifest for a tool that can be used to augment Glean Assistant.
     PossibleValue:
       type: object
-      description: Possible value of a specific parameter
       properties:
         value:
           type: string
@@ -8415,17 +8681,18 @@ components:
         label:
           type: string
           description: User-friendly label associated with the value
+      description: Possible value of a specific parameter
     WriteActionParameter:
       type: object
       properties:
         type:
           type: string
-          description: The type of the value (e.g., integer, string, boolean, etc.)
           enum:
             - UNKNOWN
             - INTEGER
             - STRING
             - BOOLEAN
+          description: The type of the value (e.g., integer, string, boolean, etc.)
         displayName:
           type: string
           description: Human readable display name for the key.
@@ -8441,54 +8708,53 @@ components:
         possibleValues:
           type: array
           items:
-            $ref: "#/components/schemas/PossibleValue"
+            $ref: '#/components/schemas/PossibleValue'
           description: Possible values that the parameter can take.
     ToolInfo:
       type: object
       properties:
         metadata:
-          $ref: "#/components/schemas/ToolMetadata"
+          $ref: '#/components/schemas/ToolMetadata'
         parameters:
           type: object
-          description: Parameters supported by the tool.
           additionalProperties:
-            $ref: "#/components/schemas/WriteActionParameter"
+            $ref: '#/components/schemas/WriteActionParameter'
+          description: Parameters supported by the tool.
     ChatMessageFragment:
-      description: Represents a part of a ChatMessage that originates from a single action/tool. It is designed to support rich data formats beyond simple text, allowing for a more dynamic and interactive chat experience. Each fragment can include various types of content, such as text, search queries, action information, and more. Also, each ChatMessageFragment should only have one of structuredResults, querySuggestion, writeAction, followupAction, agentRecommendation, followupRoutingSuggestion or file.
       allOf:
-        - $ref: "#/components/schemas/Result"
+        - $ref: '#/components/schemas/Result'
         - type: object
           properties:
             text:
               type: string
             querySuggestion:
+              $ref: '#/components/schemas/QuerySuggestion'
               description: The search queries issued while responding.
-              $ref: "#/components/schemas/QuerySuggestion"
             file:
+              $ref: '#/components/schemas/ChatFile'
               description: Files referenced in the message fragment. This is used to construct rich-text messages with file references.
-              $ref: "#/components/schemas/ChatFile"
             action:
+              $ref: '#/components/schemas/ToolInfo'
               description: Basic information about an action. This can be used to construct rich-text messages with action references.
-              $ref: "#/components/schemas/ToolInfo"
             citation:
+              $ref: '#/components/schemas/ChatMessageCitation'
               description: Inline citation.
-              $ref: "#/components/schemas/ChatMessageCitation"
+      description: Represents a part of a ChatMessage that originates from a single action/tool. It is designed to support rich data formats beyond simple text, allowing for a more dynamic and interactive chat experience. Each fragment can include various types of content, such as text, search queries, action information, and more. Also, each ChatMessageFragment should only have one of structuredResults, querySuggestion, writeAction, followupAction, agentRecommendation, followupRoutingSuggestion or file.
     ChatMessage:
-      description: A message that is rendered as one coherent unit with one given sender.
       properties:
         agentConfig:
-          $ref: "#/components/schemas/AgentConfig"
+          $ref: '#/components/schemas/AgentConfig'
           description: Describes the agent config that generated this message. Populated on responses and not required on requests.
         author:
-          default: USER
           enum:
             - USER
             - GLEAN_AI
+          default: USER
         citations:
           type: array
           items:
-            $ref: "#/components/schemas/ChatMessageCitation"
-          description: "Deprecated: Use inline citations via ChatMessageFragment.citation instead. For detailed reference information, use ChatMessageCitation.referenceRanges. This field is still populated for backward compatibility."
+            $ref: '#/components/schemas/ChatMessageCitation'
+          description: 'Deprecated: Use inline citations via ChatMessageFragment.citation instead. For detailed reference information, use ChatMessageCitation.referenceRanges. This field is still populated for backward compatibility.'
           deprecated: true
           x-glean-deprecated:
             id: 6446f85e-c90e-4c00-9717-796f9db3dc61
@@ -8503,9 +8769,9 @@ components:
           description: IDs of files uploaded in the message that are referenced to generate the answer.
         fragments:
           type: array
-          description: A list of rich data used to represent the response or formulate a request. These are linearly stitched together to support richer data formats beyond simple text.
           items:
-            $ref: "#/components/schemas/ChatMessageFragment"
+            $ref: '#/components/schemas/ChatMessageFragment'
+          description: A list of rich data used to represent the response or formulate a request. These are linearly stitched together to support richer data formats beyond simple text.
         ts:
           type: string
           description: Response timestamp of the message.
@@ -8517,24 +8783,6 @@ components:
           description: Opaque tracking token generated server-side.
         messageType:
           type: string
-          default: CONTENT
-          description: Semantically groups content of a certain type. It can be used for purposes such as differential UI treatment. USER authored messages should be of type CONTENT and do not need `messageType` specified.
-          x-enumDescriptions:
-            UPDATE: An intermediate state message for progress updates.
-            CONTENT: A user query or response message.
-            CONTEXT: A message providing context in addition to the user query.
-            CONTROL: Control signal for message streaming.
-            CONTROL_START: Control signal indicating the start of a message stream.
-            CONTROL_FINISH: Control signal indicating the end of a message stream.
-            CONTROL_CANCEL: Control signal indicating the message stream was cancelled.
-            CONTROL_RETRY: Indicates the message streaming needed to be retried.
-            CONTROL_UNKNOWN: Fallback control signal for unrecognized control types.
-            DEBUG: A debug message. Strictly used internally.
-            DEBUG_EXTERNAL: A debug message to be used while debugging Action creation.
-            ERROR: A message that describes an error while processing the request.
-            HEADING: A heading message used to distinguish different sections of the holistic response.
-            WARNING: A warning message to be shown to the user.
-            SERVER_TOOL: A message used to for server-side tool auth/use, for request and response.
           enum:
             - UPDATE
             - CONTENT
@@ -8551,6 +8799,24 @@ components:
             - HEADING
             - WARNING
             - SERVER_TOOL
+          description: Semantically groups content of a certain type. It can be used for purposes such as differential UI treatment. USER authored messages should be of type CONTENT and do not need `messageType` specified.
+          default: CONTENT
+          x-enumDescriptions:
+            UPDATE: An intermediate state message for progress updates.
+            CONTENT: A user query or response message.
+            CONTEXT: A message providing context in addition to the user query.
+            CONTROL: Control signal for message streaming.
+            CONTROL_START: Control signal indicating the start of a message stream.
+            CONTROL_FINISH: Control signal indicating the end of a message stream.
+            CONTROL_CANCEL: Control signal indicating the message stream was cancelled.
+            CONTROL_RETRY: Indicates the message streaming needed to be retried.
+            CONTROL_UNKNOWN: Fallback control signal for unrecognized control types.
+            DEBUG: A debug message. Strictly used internally.
+            DEBUG_EXTERNAL: A debug message to be used while debugging Action creation.
+            ERROR: A message that describes an error while processing the request.
+            HEADING: A heading message used to distinguish different sections of the holistic response.
+            WARNING: A warning message to be shown to the user.
+            SERVER_TOOL: A message used to for server-side tool auth/use, for request and response.
           x-speakeasy-enum-descriptions:
             UPDATE: An intermediate state message for progress updates.
             CONTENT: A user query or response message.
@@ -8568,22 +8834,20 @@ components:
             WARNING: A warning message to be shown to the user.
             SERVER_TOOL: A message used to for server-side tool auth/use, for request and response.
         hasMoreFragments:
-          deprecated: true
           type: boolean
           description: Signals there are additional response fragments incoming.
+          deprecated: true
+      description: A message that is rendered as one coherent unit with one given sender.
     ChatRequestBase:
-      required:
-        - messages
-      description: The minimal set of fields that form a chat request.
       properties:
         messages:
           type: array
-          description: A list of chat messages, from most recent to least recent. At least one message must specify a USER author.
           items:
-            $ref: "#/components/schemas/ChatMessage"
+            $ref: '#/components/schemas/ChatMessage'
+          description: A list of chat messages, from most recent to least recent. At least one message must specify a USER author.
         sessionInfo:
+          $ref: '#/components/schemas/SessionInfo'
           description: Optional object for tracking the session used by the client and for debugging purposes.
-          $ref: "#/components/schemas/SessionInfo"
         saveChat:
           type: boolean
           description: Save the current interaction as a Chat for the user to access and potentially continue later.
@@ -8591,31 +8855,34 @@ components:
           type: string
           description: The id of the Chat that context should be retrieved from and messages added to. An empty id starts a new Chat, and the Chat is saved if saveChat is true.
         agentConfig:
-          $ref: "#/components/schemas/AgentConfig"
+          $ref: '#/components/schemas/AgentConfig'
           description: Describes the agent that will execute the request.
+      required:
+        - messages
+      description: The minimal set of fields that form a chat request.
     ChatRestrictionFilters:
       allOf:
-        - $ref: "#/components/schemas/RestrictionFilters"
+        - $ref: '#/components/schemas/RestrictionFilters'
         - type: object
           properties:
             documentSpecs:
               type: array
               items:
-                $ref: "#/components/schemas/DocumentSpec"
+                $ref: '#/components/schemas/DocumentSpec'
             datasourceInstances:
               type: array
               items:
                 type: string
     ChatRequest:
       allOf:
-        - $ref: "#/components/schemas/ChatRequestBase"
+        - $ref: '#/components/schemas/ChatRequestBase'
         - type: object
           properties:
             inclusions:
-              $ref: "#/components/schemas/ChatRestrictionFilters"
+              $ref: '#/components/schemas/ChatRestrictionFilters'
               description: A list of filters which only allows chat to access certain content.
             exclusions:
-              $ref: "#/components/schemas/ChatRestrictionFilters"
+              $ref: '#/components/schemas/ChatRestrictionFilters'
               description: A list of filters which disallows chat from accessing certain content. If content is in both inclusions and exclusions, it'll be excluded.
             timeoutMillis:
               type: integer
@@ -8631,17 +8898,16 @@ components:
               type: boolean
               description: If set, response lines will be streamed one-by-one as they become available. Each will be a ChatResponse, formatted as JSON, and separated by a new line. If false, the entire response will be returned at once. Note that if this is set and the model being used does not support streaming, the model's response will not be streamed, but other messages from the endpoint still will be.
     ChatResponse:
-      description: A single response from the /chat backend.
       properties:
         messages:
           type: array
           items:
-            $ref: "#/components/schemas/ChatMessage"
+            $ref: '#/components/schemas/ChatMessage'
         chatId:
           type: string
           description: The id of the associated Chat the messages belong to, if one exists.
         chat:
-          $ref: "#/components/schemas/ChatMetadata"
+          $ref: '#/components/schemas/ChatMetadata'
         followUpPrompts:
           type: array
           items:
@@ -8655,53 +8921,54 @@ components:
         chatSessionTrackingToken:
           type: string
           description: A token that is used to track the session.
+      description: A single response from the /chat backend.
     DeleteChatsRequest:
-      required:
-        - ids
       properties:
         ids:
           type: array
           items:
             type: string
           description: A non-empty list of ids of the Chats to be deleted.
-    GetChatRequest:
       required:
-        - id
+        - ids
+    GetChatRequest:
       properties:
         id:
           type: string
           description: The id of the Chat to be retrieved.
+      required:
+        - id
     Chat:
-      description: A historical representation of a series of chat messages a user had with Glean Assistant.
       allOf:
-        - $ref: "#/components/schemas/ChatMetadata"
-        - $ref: "#/components/schemas/PermissionedObject"
+        - $ref: '#/components/schemas/ChatMetadata'
+        - $ref: '#/components/schemas/PermissionedObject'
       properties:
         messages:
           type: array
           items:
-            $ref: "#/components/schemas/ChatMessage"
+            $ref: '#/components/schemas/ChatMessage'
           description: The chat messages within a Chat.
         roles:
           type: array
           items:
-            $ref: "#/components/schemas/UserRoleSpecification"
+            $ref: '#/components/schemas/UserRoleSpecification'
           description: A list of roles for this Chat.
+      description: A historical representation of a series of chat messages a user had with Glean Assistant.
     ChatResult:
       properties:
         chat:
-          $ref: "#/components/schemas/Chat"
+          $ref: '#/components/schemas/Chat'
         trackingToken:
           type: string
           description: An opaque token that represents this particular Chat. To be used for `/feedback` reporting.
     GetChatResponse:
       properties:
         chatResult:
-          $ref: "#/components/schemas/ChatResult"
+          $ref: '#/components/schemas/ChatResult'
     ChatMetadataResult:
       properties:
         chat:
-          $ref: "#/components/schemas/ChatMetadata"
+          $ref: '#/components/schemas/ChatMetadata'
         trackingToken:
           type: string
           description: An opaque token that represents this particular Chat. To be used for `/feedback` reporting.
@@ -8710,26 +8977,24 @@ components:
         chatResults:
           type: array
           items:
-            $ref: "#/components/schemas/ChatMetadataResult"
+            $ref: '#/components/schemas/ChatMetadataResult'
           x-includeEmpty: true
         cursor:
           type: string
           description: An opaque cursor for fetching the next page of results. If empty, there are no more results.
     GetChatApplicationRequest:
-      required:
-        - id
       properties:
         id:
           type: string
           description: The id of the Chat application to be retrieved.
+      required:
+        - id
     ChatApplicationDetails: {}
     GetChatApplicationResponse:
       properties:
         application:
-          $ref: "#/components/schemas/ChatApplicationDetails"
+          $ref: '#/components/schemas/ChatApplicationDetails'
     UploadChatFilesRequest:
-      required:
-        - files
       properties:
         files:
           type: array
@@ -8737,45 +9002,42 @@ components:
             type: string
             format: binary
           description: Raw files to be uploaded for chat in binary format.
+      required:
+        - files
     UploadChatFilesResponse:
       properties:
         files:
           type: array
           items:
-            $ref: "#/components/schemas/ChatFile"
+            $ref: '#/components/schemas/ChatFile'
           description: Files uploaded for chat.
     GetChatFilesRequest:
-      required:
-        - fileIds
       properties:
         fileIds:
           type: array
           items:
             type: string
           description: IDs of files to fetch.
+      required:
+        - fileIds
     GetChatFilesResponse:
       properties:
         files:
-          description: A map of file IDs to ChatFile structs.
           type: object
           additionalProperties:
-            $ref: "#/components/schemas/ChatFile"
+            $ref: '#/components/schemas/ChatFile'
+          description: A map of file IDs to ChatFile structs.
     DeleteChatFilesRequest:
-      required:
-        - fileIds
       properties:
         fileIds:
           type: array
           items:
             type: string
           description: IDs of files to delete.
-    Agent:
-      title: Agent
-      type: object
       required:
-        - agent_id
-        - name
-        - capabilities
+        - fileIds
+    Agent:
+      type: object
       properties:
         agent_id:
           type: string
@@ -8798,12 +9060,6 @@ components:
           description: The agent metadata. Currently not implemented.
         capabilities:
           type: object
-          title: Agent Capabilities
-          description: |-
-            Describes features that the agent supports. example: {
-              "ap.io.messages": true,
-              "ap.io.streaming": true
-            }
           properties:
             ap.io.messages:
               type: boolean
@@ -8813,14 +9069,25 @@ components:
               type: boolean
               title: Streaming
               description: Whether the agent supports streaming output. If true, you you can stream agent ouput. All agents currently support streaming.
+          title: Agent Capabilities
           additionalProperties: true
+          description: |-
+            Describes features that the agent supports. example: {
+              "ap.io.messages": true,
+              "ap.io.streaming": true
+            }
+      title: Agent
+      required:
+        - agent_id
+        - name
+        - capabilities
     ErrorResponse:
       type: object
-      description: Error response returned for failed requests
       properties:
         message:
           type: string
           description: Client-facing error message describing what went wrong
+      description: Error response returned for failed requests
     WorkflowDraftableProperties:
       properties:
         name:
@@ -8829,11 +9096,11 @@ components:
     WorkflowMutableProperties:
       type: object
       allOf:
-        - $ref: "#/components/schemas/WorkflowDraftableProperties"
+        - $ref: '#/components/schemas/WorkflowDraftableProperties'
         - type: object
     EditWorkflowRequest:
       allOf:
-        - $ref: "#/components/schemas/WorkflowMutableProperties"
+        - $ref: '#/components/schemas/WorkflowMutableProperties'
         - type: object
           properties:
             id:
@@ -8841,10 +9108,6 @@ components:
               description: The workflow ID we want to update.
     ActionSummary:
       type: object
-      description: Represents a minimal summary of an action.
-      required:
-        - tool_id
-        - display_name
       properties:
         tool_id:
           type: string
@@ -8877,7 +9140,12 @@ components:
             Neutral knowledge:
               - Native tools that don't access or modify content via APIs (e.g., file analyst, think)
               - Platform read or write tools (creator has to determine their knowledge implications)
+      required:
+        - tool_id
+        - display_name
+      description: Represents a minimal summary of an action.
     AgentSchemas:
+      type: object
       properties:
         agent_id:
           type: string
@@ -8899,16 +9167,15 @@ components:
           description: The schema for the agent output. In JSON Schema format.
         tools:
           type: array
+          items:
+            $ref: '#/components/schemas/ActionSummary'
           title: Tools
           description: List of tools that the agent can invoke. Only included when include_tools query parameter is set to true.
-          items:
-            $ref: "#/components/schemas/ActionSummary"
-      type: object
+      title: AgentSchemas
       required:
         - agent_id
         - input_schema
         - output_schema
-      title: AgentSchemas
       description: Defines the structure and properties of an agent.
     SearchAgentsRequest:
       type: object
@@ -8919,12 +9186,12 @@ components:
           example: HR Policy Agent
     SearchAgentsResponse:
       type: object
-      title: Response Search Agents
       properties:
         agents:
           type: array
           items:
-            $ref: "#/components/schemas/Agent"
+            $ref: '#/components/schemas/Agent'
+      title: Response Search Agents
     ContentType:
       type: string
       enum:
@@ -8938,8 +9205,6 @@ components:
           description: The role of the message.
           example: USER
         content:
-          title: Content
-          description: The content of the message.
           type: array
           items:
             type: object
@@ -8947,16 +9212,15 @@ components:
               text:
                 type: string
               type:
-                $ref: "#/components/schemas/ContentType"
+                $ref: '#/components/schemas/ContentType'
+            title: MessageTextBlock
             required:
               - text
               - type
-            title: MessageTextBlock
+          title: Content
+          description: The content of the message.
     AgentRunCreate:
-      description: "Payload for creating a run. **Important**: If the agent uses an input form trigger, the `input` field is required and must include all fields defined in the form schema. Even fields marked as optional in the UI must be included in the request—use an empty string (`\"\"`) for optional fields without values. Omitting required form fields will result in a 500 error."
       type: object
-      required:
-        - agent_id
       properties:
         agent_id:
           type: string
@@ -8965,49 +9229,52 @@ components:
         input:
           type: object
           title: Input
-          description: The input to the agent. Required when the agent uses an input form trigger.
           additionalProperties: true
+          description: The input to the agent. Required when the agent uses an input form trigger.
         messages:
           type: array
           items:
-            $ref: "#/components/schemas/Message"
+            $ref: '#/components/schemas/Message'
           title: Messages
           description: The messages to pass an input to the agent.
         metadata:
           type: object
           title: Metadata
-          description: The metadata to pass to the agent.
           additionalProperties: true
+          description: The metadata to pass to the agent.
+      required:
+        - agent_id
+      description: 'Payload for creating a run. **Important**: If the agent uses an input form trigger, the `input` field is required and must include all fields defined in the form schema. Even fields marked as optional in the UI must be included in the request—use an empty string (`""`) for optional fields without values. Omitting required form fields will result in a 500 error.'
     AgentExecutionStatus:
-      description: The status of the run. One of 'error', 'success'.
       type: string
+      title: AgentExecutionStatus
       enum:
         - error
         - success
-      title: AgentExecutionStatus
+      description: The status of the run. One of 'error', 'success'.
     AgentRun:
       allOf:
-        - $ref: "#/components/schemas/AgentRunCreate"
+        - $ref: '#/components/schemas/AgentRunCreate'
         - type: object
           properties:
             status:
-              $ref: "#/components/schemas/AgentExecutionStatus"
+              $ref: '#/components/schemas/AgentExecutionStatus'
     AgentRunWaitResponse:
       type: object
       properties:
         run:
-          $ref: "#/components/schemas/AgentRun"
+          $ref: '#/components/schemas/AgentRun'
           title: Run
           description: The run information.
         messages:
           type: array
           items:
-            $ref: "#/components/schemas/Message"
+            $ref: '#/components/schemas/Message'
           title: Messages
           description: The messages returned by the run.
     CollectionItemDescriptor:
       allOf:
-        - $ref: "#/components/schemas/CollectionItemMutableProperties"
+        - $ref: '#/components/schemas/CollectionItemMutableProperties'
       properties:
         url:
           type: string
@@ -9025,8 +9292,6 @@ components:
             - TEXT
             - URL
     AddCollectionItemsRequest:
-      required:
-        - collectionId
       properties:
         collectionId:
           type: number
@@ -9034,8 +9299,10 @@ components:
         addedCollectionItemDescriptors:
           type: array
           items:
-            $ref: "#/components/schemas/CollectionItemDescriptor"
+            $ref: '#/components/schemas/CollectionItemDescriptor'
           description: The CollectionItemDescriptors of the items being added.
+      required:
+        - collectionId
     AddCollectionItemsError:
       properties:
         errorType:
@@ -9046,21 +9313,19 @@ components:
     AddCollectionItemsResponse:
       properties:
         collection:
-          $ref: "#/components/schemas/Collection"
+          $ref: '#/components/schemas/Collection'
           description: The modified Collection. Only CollectionItemMutableProperties are set for each item.
         error:
-          $ref: "#/components/schemas/AddCollectionItemsError"
+          $ref: '#/components/schemas/AddCollectionItemsError'
     CreateCollectionRequest:
       allOf:
-        - $ref: "#/components/schemas/CollectionMutableProperties"
+        - $ref: '#/components/schemas/CollectionMutableProperties'
         - type: object
           properties:
             newNextItemId:
               type: string
               description: The (optional) ItemId of the next CollectionItem in sequence. If omitted, will be added to the end of the Collection. Only used if parentId is specified.
     CollectionError:
-      required:
-        - errorCode
       properties:
         errorCode:
           type: string
@@ -9073,6 +9338,8 @@ components:
             - WIDTH_VIOLATION
             - NO_PERMISSIONS
             - CORRUPT_ITEM
+      required:
+        - errorCode
     CreateCollectionResponse:
       allOf:
         - type: object
@@ -9083,12 +9350,10 @@ components:
                 - error
           properties:
             collection:
-              $ref: "#/components/schemas/Collection"
+              $ref: '#/components/schemas/Collection'
             error:
-              $ref: "#/components/schemas/CollectionError"
+              $ref: '#/components/schemas/CollectionError'
     DeleteCollectionRequest:
-      required:
-        - ids
       properties:
         ids:
           type: array
@@ -9098,10 +9363,9 @@ components:
         allowedDatasource:
           type: string
           description: The datasource allowed in the Collection to be deleted.
-    DeleteCollectionItemRequest:
       required:
-        - collectionId
-        - itemId
+        - ids
+    DeleteCollectionItemRequest:
       properties:
         collectionId:
           type: number
@@ -9112,37 +9376,37 @@ components:
         documentId:
           type: string
           description: The (optional) Glean Document ID of the CollectionItem to remove from this Collection if this is an indexed document.
+      required:
+        - collectionId
+        - itemId
     DeleteCollectionItemResponse:
       properties:
         collection:
-          $ref: "#/components/schemas/Collection"
+          $ref: '#/components/schemas/Collection'
           description: The modified Collection. Only CollectionItemMutableProperties are set for each item.
     EditCollectionRequest:
       allOf:
-        - $ref: "#/components/schemas/CollectionMutableProperties"
+        - $ref: '#/components/schemas/CollectionMutableProperties'
         - type: object
-          required:
-            - id
           properties:
             id:
               type: integer
               description: The ID of the Collection to modify.
+          required:
+            - id
     EditCollectionResponse:
       allOf:
-        - $ref: "#/components/schemas/Collection"
-        - $ref: "#/components/schemas/CollectionError"
+        - $ref: '#/components/schemas/Collection'
+        - $ref: '#/components/schemas/CollectionError'
         - type: object
           properties:
             collection:
-              $ref: "#/components/schemas/Collection"
+              $ref: '#/components/schemas/Collection'
             error:
-              $ref: "#/components/schemas/CollectionError"
+              $ref: '#/components/schemas/CollectionError'
     EditCollectionItemRequest:
-      required:
-        - collectionId
-        - itemId
       allOf:
-        - $ref: "#/components/schemas/CollectionItemMutableProperties"
+        - $ref: '#/components/schemas/CollectionItemMutableProperties'
         - type: object
       properties:
         collectionId:
@@ -9151,14 +9415,15 @@ components:
         itemId:
           type: string
           description: The ID of the CollectionItem to edit.
+      required:
+        - collectionId
+        - itemId
     EditCollectionItemResponse:
       properties:
         collection:
-          $ref: "#/components/schemas/Collection"
+          $ref: '#/components/schemas/Collection'
           description: The modified Collection. Only CollectionItemMutableProperties are set for each item.
     GetCollectionRequest:
-      required:
-        - id
       properties:
         id:
           type: integer
@@ -9172,14 +9437,16 @@ components:
         allowedDatasource:
           type: string
           description: The datasource allowed in the Collection returned.
+      required:
+        - id
     GetCollectionResponse:
       properties:
         collection:
-          $ref: "#/components/schemas/Collection"
+          $ref: '#/components/schemas/Collection'
         rootCollection:
-          $ref: "#/components/schemas/Collection"
+          $ref: '#/components/schemas/Collection'
         error:
-          $ref: "#/components/schemas/CollectionError"
+          $ref: '#/components/schemas/CollectionError'
         trackingToken:
           type: string
           description: Use `collection.trackingToken` instead.
@@ -9204,14 +9471,14 @@ components:
             The datasource type this Collection can hold.
             ANSWERS - for Collections representing answer boards
     ListCollectionsResponse:
-      required:
-        - collections
       properties:
         collections:
           type: array
           items:
-            $ref: "#/components/schemas/Collection"
+            $ref: '#/components/schemas/Collection'
           description: List of all Collections, no Collection items are fetched.
+      required:
+        - collections
     GetDocPermissionsRequest:
       type: object
       properties:
@@ -9227,16 +9494,13 @@ components:
             type: string
           description: A list of emails of users who have access to the document. If the document is visible to all Glean users, a list with only a single value of 'VISIBLE_TO_ALL'.
     GetDocumentsRequest:
-      required:
-        - documentSpecs
       properties:
         documentSpecs:
           type: array
           items:
-            $ref: "#/components/schemas/DocumentSpec"
+            $ref: '#/components/schemas/DocumentSpec'
           description: The specification for the documents to be retrieved.
         includeFields:
-          description: List of Document fields to return (that aren't returned by default)
           type: array
           items:
             type: string
@@ -9246,28 +9510,29 @@ components:
               - RECENT_SHARES
               - DOCUMENT_CONTENT
               - CUSTOM_METADATA
+          description: List of Document fields to return (that aren't returned by default)
+      required:
+        - documentSpecs
     DocumentOrError:
-      x-omit-error-on-success: true
       oneOf:
-        - $ref: "#/components/schemas/Document"
+        - $ref: '#/components/schemas/Document'
         - type: object
-          required:
-            - error
           properties:
             error:
               type: string
               description: The text for error, reason.
               x-is-error-field: true
+          required:
+            - error
+      x-omit-error-on-success: true
     GetDocumentsResponse:
       properties:
         documents:
           type: object
           additionalProperties:
-            $ref: "#/components/schemas/DocumentOrError"
+            $ref: '#/components/schemas/DocumentOrError'
           description: The document details or the error if document is not found.
     GetDocumentsByFacetsRequest:
-      required:
-        - filterSets
       properties:
         datasourcesFilter:
           type: array
@@ -9277,17 +9542,19 @@ components:
         filterSets:
           type: array
           items:
-            $ref: "#/components/schemas/FacetFilterSet"
+            $ref: '#/components/schemas/FacetFilterSet'
           description: A list of facet filter sets that will be OR'ed together. An AND is assumed between different filters in each set.
         cursor:
           type: string
           description: Pagination cursor. A previously received opaque token representing the position in the overall results at which to start.
+      required:
+        - filterSets
     GetDocumentsByFacetsResponse:
       properties:
         documents:
           type: array
           items:
-            $ref: "#/components/schemas/Document"
+            $ref: '#/components/schemas/Document'
           description: The document details, ordered by score.
         hasMoreResults:
           type: boolean
@@ -9308,7 +9575,7 @@ components:
             type: string
           description: Manager emails whose teams should be filtered for. Empty array means no filtering.
         dayRange:
-          $ref: "#/components/schemas/Period"
+          $ref: '#/components/schemas/Period'
           description: Time period for which Insights are requested.
     InsightsAssistantRequest:
       properties:
@@ -9323,7 +9590,7 @@ components:
             type: string
           description: Manager emails whose teams should be filtered for. Empty array means no filtering.
         dayRange:
-          $ref: "#/components/schemas/Period"
+          $ref: '#/components/schemas/Period'
           description: Time period for which Insights are requested.
     AgentsInsightsV2Request:
       properties:
@@ -9343,7 +9610,7 @@ components:
             type: string
           description: Manager emails whose teams should be filtered for. Empty array means no filtering.
         dayRange:
-          $ref: "#/components/schemas/Period"
+          $ref: '#/components/schemas/Period'
           description: Time period for which Insights are requested.
     McpBreakdownInsightsRequest:
       properties:
@@ -9363,7 +9630,7 @@ components:
             type: string
           description: Manager emails whose teams should be filtered for. Empty array means no filtering.
         dayRange:
-          $ref: "#/components/schemas/Period"
+          $ref: '#/components/schemas/Period'
           description: Time period for which Insights are requested.
         breakdownType:
           type: string
@@ -9391,29 +9658,26 @@ components:
     InsightsRequest:
       properties:
         overviewRequest:
-          $ref: "#/components/schemas/InsightsOverviewRequest"
-          x-visibility: Public
+          $ref: '#/components/schemas/InsightsOverviewRequest'
           description: If specified, will return data for the Overview section of the Insights Dashboard.
+          x-visibility: Public
         assistantRequest:
-          $ref: "#/components/schemas/InsightsAssistantRequest"
-          x-visibility: Public
+          $ref: '#/components/schemas/InsightsAssistantRequest'
           description: If specified, will return data for the Assistant section of the Insights Dashboard.
-        agentsRequest:
-          $ref: "#/components/schemas/AgentsInsightsV2Request"
           x-visibility: Public
+        agentsRequest:
+          $ref: '#/components/schemas/AgentsInsightsV2Request'
           description: If specified, will return data for the Agents section of the Insights Dashboard.
+          x-visibility: Public
         mcpBreakdownRequest:
-          $ref: "#/components/schemas/McpBreakdownInsightsRequest"
+          $ref: '#/components/schemas/McpBreakdownInsightsRequest'
         disablePerUserInsights:
           type: boolean
           description: If true, suppresses the generation of per-user Insights in the response. Default is false.
     UserActivityInsight:
-      required:
-        - user
-        - activity
       properties:
         user:
-          $ref: "#/components/schemas/Person"
+          $ref: '#/components/schemas/Person'
         activity:
           type: string
           enum:
@@ -9424,9 +9688,12 @@ components:
           type: integer
           description: Unix timestamp of the last activity (in seconds since epoch UTC).
         activityCount:
-          $ref: "#/components/schemas/CountInfo"
+          $ref: '#/components/schemas/CountInfo'
         activeDayCount:
-          $ref: "#/components/schemas/CountInfo"
+          $ref: '#/components/schemas/CountInfo'
+      required:
+        - user
+        - activity
     GleanAssistInsightsResponse:
       properties:
         lastLogTimestamp:
@@ -9435,7 +9702,7 @@ components:
         activityInsights:
           type: array
           items:
-            $ref: "#/components/schemas/UserActivityInsight"
+            $ref: '#/components/schemas/UserActivityInsight'
           description: Insights for all active users with respect to set of actions.
         totalActiveUsers:
           type: integer
@@ -9460,7 +9727,7 @@ components:
           description: Number of current Weekly Active Users.
     InsightsSearchSummary:
       allOf:
-        - $ref: "#/components/schemas/CurrentActiveUsers"
+        - $ref: '#/components/schemas/CurrentActiveUsers'
         - type: object
           properties:
             numSearches:
@@ -9471,7 +9738,7 @@ components:
               description: Total number of distinct users who searched over the specified time period.
     InsightsChatSummary:
       allOf:
-        - $ref: "#/components/schemas/CurrentActiveUsers"
+        - $ref: '#/components/schemas/CurrentActiveUsers'
         - type: object
           properties:
             numChats:
@@ -9482,7 +9749,7 @@ components:
               description: Total number of distinct users who used Chat over the specified time period.
     InsightsDepartmentsSummary:
       allOf:
-        - $ref: "#/components/schemas/CurrentActiveUsers"
+        - $ref: '#/components/schemas/CurrentActiveUsers'
         - type: object
           properties:
             departments:
@@ -9497,25 +9764,23 @@ components:
               type: integer
               description: Number of current signed up employees in the specified departments, according to the Org Chart.
             searchSummary:
-              $ref: "#/components/schemas/InsightsSearchSummary"
+              $ref: '#/components/schemas/InsightsSearchSummary'
             chatSummary:
-              $ref: "#/components/schemas/InsightsChatSummary"
+              $ref: '#/components/schemas/InsightsChatSummary'
             searchActiveUsers:
-              $ref: "#/components/schemas/CurrentActiveUsers"
+              $ref: '#/components/schemas/CurrentActiveUsers'
               description: Search-specific active user counts for the specified departments.
             assistantActiveUsers:
-              $ref: "#/components/schemas/CurrentActiveUsers"
+              $ref: '#/components/schemas/CurrentActiveUsers'
               description: Assistant-specific active user counts for the specified departments.
             agentsActiveUsers:
-              $ref: "#/components/schemas/CurrentActiveUsers"
+              $ref: '#/components/schemas/CurrentActiveUsers'
               description: Agents-specific active user counts for the specified departments.
             extensionSummary:
-              $ref: "#/components/schemas/CurrentActiveUsers"
+              $ref: '#/components/schemas/CurrentActiveUsers'
             ugcSummary:
-              $ref: "#/components/schemas/CurrentActiveUsers"
+              $ref: '#/components/schemas/CurrentActiveUsers'
     LabeledCountInfo:
-      required:
-        - label
       properties:
         label:
           type: string
@@ -9523,12 +9788,14 @@ components:
         countInfo:
           type: array
           items:
-            $ref: "#/components/schemas/CountInfo"
+            $ref: '#/components/schemas/CountInfo'
           description: List of data points for counts for a given date period.
+      required:
+        - label
     PerUserInsight:
       properties:
         person:
-          $ref: "#/components/schemas/Person"
+          $ref: '#/components/schemas/Person'
         numSearches:
           type: integer
           description: Total number of searches by this user over the specified time period.
@@ -9555,7 +9822,7 @@ components:
           description: Total number of agent runs for this user over the specified time period.
     InsightsOverviewResponse:
       allOf:
-        - $ref: "#/components/schemas/InsightsDepartmentsSummary"
+        - $ref: '#/components/schemas/InsightsDepartmentsSummary'
         - type: object
           properties:
             lastUpdatedTs:
@@ -9566,35 +9833,35 @@ components:
               format: float
               description: Search session satisfaction rate, over the specified time period in the specified departments.
             monthlyActiveUserTimeseries:
-              $ref: "#/components/schemas/LabeledCountInfo"
+              $ref: '#/components/schemas/LabeledCountInfo'
             weeklyActiveUserTimeseries:
-              $ref: "#/components/schemas/LabeledCountInfo"
+              $ref: '#/components/schemas/LabeledCountInfo'
             dailyActiveUserTimeseries:
-              $ref: "#/components/schemas/LabeledCountInfo"
+              $ref: '#/components/schemas/LabeledCountInfo'
             searchMonthlyActiveUserTimeseries:
-              $ref: "#/components/schemas/LabeledCountInfo"
+              $ref: '#/components/schemas/LabeledCountInfo'
             searchWeeklyActiveUserTimeseries:
-              $ref: "#/components/schemas/LabeledCountInfo"
+              $ref: '#/components/schemas/LabeledCountInfo'
             searchDailyActiveUserTimeseries:
-              $ref: "#/components/schemas/LabeledCountInfo"
+              $ref: '#/components/schemas/LabeledCountInfo'
             assistantMonthlyActiveUserTimeseries:
-              $ref: "#/components/schemas/LabeledCountInfo"
+              $ref: '#/components/schemas/LabeledCountInfo'
             assistantWeeklyActiveUserTimeseries:
-              $ref: "#/components/schemas/LabeledCountInfo"
+              $ref: '#/components/schemas/LabeledCountInfo'
             assistantDailyActiveUserTimeseries:
-              $ref: "#/components/schemas/LabeledCountInfo"
+              $ref: '#/components/schemas/LabeledCountInfo'
             agentsMonthlyActiveUserTimeseries:
-              $ref: "#/components/schemas/LabeledCountInfo"
+              $ref: '#/components/schemas/LabeledCountInfo'
             agentsWeeklyActiveUserTimeseries:
-              $ref: "#/components/schemas/LabeledCountInfo"
+              $ref: '#/components/schemas/LabeledCountInfo'
             agentsDailyActiveUserTimeseries:
-              $ref: "#/components/schemas/LabeledCountInfo"
+              $ref: '#/components/schemas/LabeledCountInfo'
             searchesTimeseries:
-              $ref: "#/components/schemas/LabeledCountInfo"
+              $ref: '#/components/schemas/LabeledCountInfo'
             assistantInteractionsTimeseries:
-              $ref: "#/components/schemas/LabeledCountInfo"
+              $ref: '#/components/schemas/LabeledCountInfo'
             agentRunsTimeseries:
-              $ref: "#/components/schemas/LabeledCountInfo"
+              $ref: '#/components/schemas/LabeledCountInfo'
             searchDatasourceCounts:
               type: object
               additionalProperties:
@@ -9608,12 +9875,12 @@ components:
             perUserInsights:
               type: array
               items:
-                $ref: "#/components/schemas/PerUserInsight"
+                $ref: '#/components/schemas/PerUserInsight'
               description: Per-user insights, over the specified time period in the specified departments. All current users in the organization who have signed into Glean at least once are included.
     PerUserAssistantInsight:
       properties:
         person:
-          $ref: "#/components/schemas/Person"
+          $ref: '#/components/schemas/Person'
         numChatMessages:
           type: integer
           description: Total number of chat messages sent by this user over the specified time period.
@@ -9631,37 +9898,37 @@ components:
           description: Total number of days this user was active on the Assistant over the specified time period.
     AssistantInsightsResponse:
       allOf:
-        - $ref: "#/components/schemas/CurrentActiveUsers"
+        - $ref: '#/components/schemas/CurrentActiveUsers'
         - type: object
           properties:
             lastUpdatedTs:
               type: integer
               description: Unix timestamp of the last update for the insights data in the response.
             monthlyActiveUserTimeseries:
-              $ref: "#/components/schemas/LabeledCountInfo"
+              $ref: '#/components/schemas/LabeledCountInfo'
             weeklyActiveUserTimeseries:
-              $ref: "#/components/schemas/LabeledCountInfo"
+              $ref: '#/components/schemas/LabeledCountInfo'
             dailyActiveUserTimeseries:
-              $ref: "#/components/schemas/LabeledCountInfo"
+              $ref: '#/components/schemas/LabeledCountInfo'
             totalSignups:
               type: integer
               description: Number of current signed up employees in the specified departments, according to the Org Chart.
             chatMessagesTimeseries:
-              $ref: "#/components/schemas/LabeledCountInfo"
+              $ref: '#/components/schemas/LabeledCountInfo'
             summarizationsTimeseries:
-              $ref: "#/components/schemas/LabeledCountInfo"
+              $ref: '#/components/schemas/LabeledCountInfo'
             aiAnswersTimeseries:
-              $ref: "#/components/schemas/LabeledCountInfo"
+              $ref: '#/components/schemas/LabeledCountInfo'
             gleanbotInteractionsTimeseries:
-              $ref: "#/components/schemas/LabeledCountInfo"
+              $ref: '#/components/schemas/LabeledCountInfo'
             perUserInsights:
               type: array
               items:
-                $ref: "#/components/schemas/PerUserAssistantInsight"
+                $ref: '#/components/schemas/PerUserAssistantInsight'
             upvotesTimeseries:
-              $ref: "#/components/schemas/LabeledCountInfo"
+              $ref: '#/components/schemas/LabeledCountInfo'
             downvotesTimeseries:
-              $ref: "#/components/schemas/LabeledCountInfo"
+              $ref: '#/components/schemas/LabeledCountInfo'
     PerAgentInsight:
       properties:
         agentId:
@@ -9671,7 +9938,7 @@ components:
           type: string
           description: Agent name
         icon:
-          $ref: "#/components/schemas/IconConfig"
+          $ref: '#/components/schemas/IconConfig'
           description: Agent icon configuration
         isDeleted:
           type: boolean
@@ -9689,7 +9956,7 @@ components:
           type: integer
           description: Total number of downvotes for this agent over the specified time period.
         owner:
-          $ref: "#/components/schemas/Person"
+          $ref: '#/components/schemas/Person'
           description: |
             The creator/owner of the agent. Absent if agent is deleted or owner is unknown.
     AgentUseCaseInsight:
@@ -9714,7 +9981,7 @@ components:
           type: string
           description: Name of the most-used agent for this use case.
         topAgentIcon:
-          $ref: "#/components/schemas/IconConfig"
+          $ref: '#/components/schemas/IconConfig'
           description: Icon of the most-used agent for this use case.
         topAgentIsDeleted:
           type: boolean
@@ -9741,7 +10008,7 @@ components:
           type: string
           description: Name of the agent to be shown in the agent column in this department over the specified time period.
         icon:
-          $ref: "#/components/schemas/IconConfig"
+          $ref: '#/components/schemas/IconConfig'
           description: Agent icon configuration
         isDeleted:
           type: boolean
@@ -9749,7 +10016,7 @@ components:
     AgentUsersInsight:
       properties:
         person:
-          $ref: "#/components/schemas/Person"
+          $ref: '#/components/schemas/Person'
         departmentName:
           type: string
           description: Department name
@@ -9775,7 +10042,7 @@ components:
           type: string
           description: Agent name
         icon:
-          $ref: "#/components/schemas/IconConfig"
+          $ref: '#/components/schemas/IconConfig'
           description: Agent icon configuration
         isDeleted:
           type: boolean
@@ -9792,56 +10059,56 @@ components:
           description: Total number of users who provided feedback on time saved for this agent over the specified time period.
     AgentsInsightsV2Response:
       allOf:
-        - $ref: "#/components/schemas/CurrentActiveUsers"
+        - $ref: '#/components/schemas/CurrentActiveUsers'
         - type: object
           properties:
             monthlyActiveUserTimeseries:
-              $ref: "#/components/schemas/LabeledCountInfo"
+              $ref: '#/components/schemas/LabeledCountInfo'
             weeklyActiveUserTimeseries:
-              $ref: "#/components/schemas/LabeledCountInfo"
+              $ref: '#/components/schemas/LabeledCountInfo'
             dailyActiveUserTimeseries:
-              $ref: "#/components/schemas/LabeledCountInfo"
+              $ref: '#/components/schemas/LabeledCountInfo'
             sharedAgentsCount:
               type: integer
               description: Total number of shared agents.
             topAgentsInsights:
               type: array
               items:
-                $ref: "#/components/schemas/PerAgentInsight"
+                $ref: '#/components/schemas/PerAgentInsight'
             topUseCasesInsights:
               type: array
               items:
-                $ref: "#/components/schemas/AgentUseCaseInsight"
+                $ref: '#/components/schemas/AgentUseCaseInsight'
             agentsUsageByDepartmentInsights:
               type: array
               items:
-                $ref: "#/components/schemas/AgentsUsageByDepartmentInsight"
+                $ref: '#/components/schemas/AgentsUsageByDepartmentInsight'
             agentUsersInsights:
               type: array
               items:
-                $ref: "#/components/schemas/AgentUsersInsight"
+                $ref: '#/components/schemas/AgentUsersInsight'
             agentsTimeSavedInsights:
               type: array
               items:
-                $ref: "#/components/schemas/AgentsTimeSavedInsight"
+                $ref: '#/components/schemas/AgentsTimeSavedInsight'
               description: Insights for agents time saved over the specified time period.
             dailyAgentRunsTimeseries:
-              $ref: "#/components/schemas/LabeledCountInfo"
+              $ref: '#/components/schemas/LabeledCountInfo'
             successfulRunsTimeseries:
-              $ref: "#/components/schemas/LabeledCountInfo"
+              $ref: '#/components/schemas/LabeledCountInfo'
             failedRunsTimeseries:
-              $ref: "#/components/schemas/LabeledCountInfo"
+              $ref: '#/components/schemas/LabeledCountInfo'
             pausedRunsTimeseries:
-              $ref: "#/components/schemas/LabeledCountInfo"
+              $ref: '#/components/schemas/LabeledCountInfo'
             upvotesTimeseries:
-              $ref: "#/components/schemas/LabeledCountInfo"
+              $ref: '#/components/schemas/LabeledCountInfo'
             downvotesTimeseries:
-              $ref: "#/components/schemas/LabeledCountInfo"
+              $ref: '#/components/schemas/LabeledCountInfo'
     InsightsResponse:
       properties:
         gleanAssist:
+          $ref: '#/components/schemas/GleanAssistInsightsResponse'
           deprecated: true
-          $ref: "#/components/schemas/GleanAssistInsightsResponse"
           x-glean-deprecated:
             id: 15850758-4d95-4d98-8d57-39c50663a796
             introduced: "2026-02-05"
@@ -9849,16 +10116,12 @@ components:
             removal: "2026-10-15"
           x-speakeasy-deprecation-message: "Deprecated on 2026-02-05, removal scheduled for 2026-10-15: Field is deprecated"
         overviewResponse:
-          $ref: "#/components/schemas/InsightsOverviewResponse"
+          $ref: '#/components/schemas/InsightsOverviewResponse'
         assistantResponse:
-          $ref: "#/components/schemas/AssistantInsightsResponse"
+          $ref: '#/components/schemas/AssistantInsightsResponse'
         agentsResponse:
-          $ref: "#/components/schemas/AgentsInsightsV2Response"
+          $ref: '#/components/schemas/AgentsInsightsV2Response'
     MessagesRequest:
-      required:
-        - id
-        - idType
-        - datasource
       properties:
         idType:
           type: string
@@ -9898,19 +10161,23 @@ components:
         datasourceInstanceDisplayName:
           type: string
           description: The datasource instance display name from which the document was extracted. This is used for appinstance facet filter for datasources that support multiple instances.
+      required:
+        - id
+        - idType
+        - datasource
     InvalidOperatorValueError:
       properties:
         key:
+          type: string
           description: The operator key that has an invalid value.
-          type: string
         value:
-          description: The invalid operator value.
           type: string
+          description: The invalid operator value.
     ErrorMessage:
       properties:
         source:
-          description: The datasource this message relates to.
           type: string
+          description: The datasource this message relates to.
         errorMessage:
           type: string
     ErrorInfo:
@@ -9923,13 +10190,13 @@ components:
           description: Indicates the outlook results could not be fetched due to bad token.
         invalidOperators:
           type: array
-          description: Indicates results could not be fetched due to invalid operators in the query.
           items:
-            $ref: "#/components/schemas/InvalidOperatorValueError"
+            $ref: '#/components/schemas/InvalidOperatorValueError'
+          description: Indicates results could not be fetched due to invalid operators in the query.
         errorMessages:
           type: array
           items:
-            $ref: "#/components/schemas/ErrorMessage"
+            $ref: '#/components/schemas/ErrorMessage'
         federatedSearchRateLimitError:
           type: boolean
           description: Indicates the federated search results could not be fetched due to rate limiting.
@@ -9940,19 +10207,19 @@ components:
           type: string
           description: A token that should be passed for additional requests related to this request (such as more results requests).
         sessionInfo:
-          $ref: "#/components/schemas/SessionInfo"
+          $ref: '#/components/schemas/SessionInfo'
         results:
           type: array
           items:
-            $ref: "#/components/schemas/SearchResult"
+            $ref: '#/components/schemas/SearchResult'
         structuredResults:
           type: array
           items:
-            $ref: "#/components/schemas/StructuredResult"
+            $ref: '#/components/schemas/StructuredResult'
         generatedQnaResult:
-          $ref: "#/components/schemas/GeneratedQna"
+          $ref: '#/components/schemas/GeneratedQna'
         errorInfo:
-          $ref: "#/components/schemas/ErrorInfo"
+          $ref: '#/components/schemas/ErrorInfo'
         requestID:
           type: string
           description: A platform-generated request ID to correlate backend logs.
@@ -9970,8 +10237,6 @@ components:
             format: int64
           description: List of experiment ids for the corresponding request.
     SearchWarning:
-      required:
-        - warningType
       properties:
         warningType:
           type: string
@@ -9995,6 +10260,8 @@ components:
           items:
             type: string
           description: A list of query terms that were ignored when generating search results, if any. For example, terms containing invalid filters such as "updated:invalid_date" will be ignored.
+      required:
+        - warningType
     SearchResponseMetadata:
       properties:
         rewrittenQuery:
@@ -10010,16 +10277,16 @@ components:
         searchedQueryRanges:
           type: array
           items:
-            $ref: "#/components/schemas/TextRange"
+            $ref: '#/components/schemas/TextRange'
           description: The bolded ranges within the searched query.
         originalQuery:
           type: string
           description: The query text sent by the client in the request.
         querySuggestion:
-          $ref: "#/components/schemas/QuerySuggestion"
+          $ref: '#/components/schemas/QuerySuggestion'
           description: An alternative query to the one provided that may give better results, e.g. a spelling suggestion.
         additionalQuerySuggestions:
-          $ref: "#/components/schemas/QuerySuggestionList"
+          $ref: '#/components/schemas/QuerySuggestionList'
           description: Other alternative queries that may provide better or more specific results than the original query.
         negatedTerms:
           type: array
@@ -10033,7 +10300,7 @@ components:
           type: boolean
           description: No results were found for the original query. The usage of this bit in conjunction with modifiedQueryWasUsed will dictate whether the full page replacement is 0-result or few-result based.
         searchWarning:
-          $ref: "#/components/schemas/SearchWarning"
+          $ref: '#/components/schemas/SearchWarning'
         triggeredExpertDetection:
           type: boolean
           description: Whether the query triggered expert detection results in the People tab.
@@ -10044,17 +10311,17 @@ components:
       properties:
         stringValue:
           type: string
-          example: engineering
           description: The value that should be set in the FacetFilter when applying this filter to a search request.
+          example: engineering
         integerValue:
           type: integer
           example: 5
         displayLabel:
           type: string
-          example: engineering
           description: An optional user-friendly label to display in place of the facet value.
+          example: engineering
         iconConfig:
-          $ref: "#/components/schemas/IconConfig"
+          $ref: '#/components/schemas/IconConfig'
     FacetBucket:
       properties:
         count:
@@ -10063,14 +10330,14 @@ components:
           example: 1
         datasource:
           type: string
-          example: jira
           description: The datasource the value belongs to. This will be used by the all tab to show types across all datasources.
+          example: jira
         percentage:
           type: integer
           description: Estimated percentage of results in this facet.
           example: 5
         value:
-          $ref: "#/components/schemas/FacetValue"
+          $ref: '#/components/schemas/FacetValue'
     FacetResult:
       properties:
         sourceName:
@@ -10083,9 +10350,9 @@ components:
           example: SelectMultiple
         buckets:
           type: array
-          description: A list of unique buckets that exist within this result set.
           items:
-            $ref: "#/components/schemas/FacetBucket"
+            $ref: '#/components/schemas/FacetBucket'
+          description: A list of unique buckets that exist within this result set.
         hasMoreBuckets:
           type: boolean
           description: Returns true if more buckets exist than those returned. Additional buckets can be retrieve by requesting again with a higher facetBucketSize.
@@ -10100,24 +10367,24 @@ components:
           type: string
           description: Textual description of the results. Can be shown at the top of SERP, e.g. 'People who write about this topic' for experts in people tab.
         iconConfig:
-          $ref: "#/components/schemas/IconConfig"
+          $ref: '#/components/schemas/IconConfig'
           description: The config for the icon that's displayed with this description
     SearchResponse:
       allOf:
-        - $ref: "#/components/schemas/ResultsResponse"
-        - $ref: "#/components/schemas/BackendExperimentsContext"
+        - $ref: '#/components/schemas/ResultsResponse'
+        - $ref: '#/components/schemas/BackendExperimentsContext'
         - type: object
           properties:
             metadata:
-              $ref: "#/components/schemas/SearchResponseMetadata"
+              $ref: '#/components/schemas/SearchResponseMetadata'
             facetResults:
               type: array
               items:
-                $ref: "#/components/schemas/FacetResult"
+                $ref: '#/components/schemas/FacetResult'
             resultTabs:
               type: array
               items:
-                $ref: "#/components/schemas/ResultTab"
+                $ref: '#/components/schemas/ResultTab'
               description: All result tabs available for the current query. Populated if QUERY_METADATA is specified in the request.
             resultTabIds:
               type: array
@@ -10125,11 +10392,11 @@ components:
                 type: string
               description: The unique IDs of the result tabs to which this response belongs.
             resultsDescription:
-              $ref: "#/components/schemas/ResultsDescription"
+              $ref: '#/components/schemas/ResultsDescription'
             rewrittenFacetFilters:
               type: array
               items:
-                $ref: "#/components/schemas/FacetFilter"
+                $ref: '#/components/schemas/FacetFilter'
               description: The actual applied facet filters based on the operators and facetFilters in the query. Useful for mapping typed operators to visual facets.
             cursor:
               type: string
@@ -10219,19 +10486,19 @@ components:
               - fieldValues
               - fieldValues
     MessagesResponse:
-      required:
-        - hasMore
       properties:
         hasMore:
           type: boolean
           description: Whether there are more results for client to continue requesting.
         searchResponse:
-          $ref: "#/components/schemas/SearchResponse"
+          $ref: '#/components/schemas/SearchResponse'
         rootMessage:
-          $ref: "#/components/schemas/SearchResult"
+          $ref: '#/components/schemas/SearchResult'
+      required:
+        - hasMore
     EditPinRequest:
       allOf:
-        - $ref: "#/components/schemas/PinDocumentMutableProperties"
+        - $ref: '#/components/schemas/PinDocumentMutableProperties'
         - type: object
           properties:
             id:
@@ -10245,19 +10512,19 @@ components:
     GetPinResponse:
       properties:
         pin:
-          $ref: "#/components/schemas/PinDocument"
+          $ref: '#/components/schemas/PinDocument'
     ListPinsResponse:
-      required:
-        - pins
       properties:
         pins:
           type: array
           items:
-            $ref: "#/components/schemas/PinDocument"
+            $ref: '#/components/schemas/PinDocument'
           description: List of pinned documents.
+      required:
+        - pins
     PinRequest:
       allOf:
-        - $ref: "#/components/schemas/PinDocumentMutableProperties"
+        - $ref: '#/components/schemas/PinDocumentMutableProperties'
         - type: object
           properties:
             documentId:
@@ -10272,29 +10539,27 @@ components:
       properties:
         timestamp:
           type: string
-          description: The ISO 8601 timestamp associated with the client request.
           format: date-time
+          description: The ISO 8601 timestamp associated with the client request.
         trackingToken:
           type: string
           description: A previously received trackingToken for a search associated with the same query. Useful for more requests and requests for other tabs.
         sessionInfo:
-          $ref: "#/components/schemas/SessionInfo"
+          $ref: '#/components/schemas/SessionInfo'
         sourceDocument:
-          $ref: "#/components/schemas/Document"
+          $ref: '#/components/schemas/Document'
           description: The document from which the ResultsRequest is issued, if any.
         pageSize:
           type: integer
-          example: 100
           description: Hint to the server about how many results to send back. Server may return less or more. Structured results and clustered results don't count towards pageSize.
+          example: 100
         maxSnippetSize:
           type: integer
           description: Hint to the server about how many characters long a snippet may be. Server may return less or more.
           example: 400
     SearchRequest:
-      required:
-        - query
       allOf:
-        - $ref: "#/components/schemas/ResultsRequest"
+        - $ref: '#/components/schemas/ResultsRequest'
         - type: object
           properties:
             query:
@@ -10310,9 +10575,9 @@ components:
                 type: string
               description: The unique IDs of the result tabs for which to fetch results. This will have precedence over datasource filters if both are specified and in conflict.
             inputDetails:
-              $ref: "#/components/schemas/SearchRequestInputDetails"
+              $ref: '#/components/schemas/SearchRequestInputDetails'
             requestOptions:
-              $ref: "#/components/schemas/SearchRequestOptions"
+              $ref: '#/components/schemas/SearchRequestOptions'
             timeoutMillis:
               type: integer
               description: Timeout in milliseconds for the request. A `408` error will be returned if handling the request takes longer.
@@ -10320,6 +10585,8 @@ components:
             disableSpellcheck:
               type: boolean
               description: Whether or not to disable spellcheck.
+      required:
+        - query
       example:
         trackingToken: trackingToken
         query: vacation policy
@@ -10342,7 +10609,7 @@ components:
         trackingToken:
           type: string
         sessionInfo:
-          $ref: "#/components/schemas/SessionInfo"
+          $ref: '#/components/schemas/SessionInfo'
         query:
           type: string
           description: Partially typed query.
@@ -10357,7 +10624,6 @@ components:
           description: Filter to only return results relevant to the given datasource.
         resultTypes:
           type: array
-          description: Filter to only return results of the given type(s). All types may be returned if omitted.
           items:
             type: string
             enum:
@@ -10375,6 +10641,7 @@ components:
               - OPERATOR_VALUE
               - QUICKLINK
               - SUGGESTION
+          description: Filter to only return results of the given type(s). All types may be returned if omitted.
         resultSize:
           type: integer
           description: |
@@ -10382,9 +10649,9 @@ components:
           example: 10
         authTokens:
           type: array
-          description: Auth tokens which may be used for federated results.
           items:
-            $ref: "#/components/schemas/AuthToken"
+            $ref: '#/components/schemas/AuthToken'
+          description: Auth tokens which may be used for federated results.
       example:
         trackingToken: trackingToken
         query: what is a que
@@ -10397,8 +10664,6 @@ components:
         docType:
           type: string
     OperatorMetadata:
-      required:
-        - name
       properties:
         name:
           type: string
@@ -10417,13 +10682,15 @@ components:
         scopes:
           type: array
           items:
-            $ref: "#/components/schemas/OperatorScope"
+            $ref: '#/components/schemas/OperatorScope'
         value:
           type: string
           description: Raw/canonical value of the operator. Only applies when result is an operator value.
         displayValue:
           type: string
           description: Human readable value of the operator that can be shown to the user. Only applies when result is an operator value.
+      required:
+        - name
       example:
         name: Last Updated
         operatorType: DATE
@@ -10432,7 +10699,6 @@ components:
             docType: Document
           - datasource: ZENDESK
     Quicklink:
-      description: An action for a specific datasource that will show up in autocomplete and app card, e.g. "Create new issue" for jira.
       properties:
         name:
           type: string
@@ -10444,14 +10710,13 @@ components:
           type: string
           description: The URL of the action.
         iconConfig:
-          $ref: "#/components/schemas/IconConfig"
+          $ref: '#/components/schemas/IconConfig'
           description: The config for the icon for this quicklink
         id:
           type: string
           description: Unique identifier of this quicklink
         scopes:
           type: array
-          description: The scopes for which this quicklink is applicable
           items:
             type: string
             enum:
@@ -10460,10 +10725,9 @@ components:
               - AUTOCOMPLETE_FUZZY_MATCH
               - AUTOCOMPLETE_ZERO_QUERY
               - NEW_TAB_PAGE
+          description: The scopes for which this quicklink is applicable
+      description: An action for a specific datasource that will show up in autocomplete and app card, e.g. "Create new issue" for jira.
     AutocompleteResult:
-      required:
-        - result
-        - result_type
       properties:
         result:
           type: string
@@ -10493,23 +10757,26 @@ components:
           type: number
           description: Higher indicates a more confident match.
         operatorMetadata:
-          $ref: "#/components/schemas/OperatorMetadata"
+          $ref: '#/components/schemas/OperatorMetadata'
         quicklink:
-          $ref: "#/components/schemas/Quicklink"
+          $ref: '#/components/schemas/Quicklink'
         document:
-          $ref: "#/components/schemas/Document"
+          $ref: '#/components/schemas/Document'
         url:
           type: string
         structuredResult:
-          $ref: "#/components/schemas/StructuredResult"
+          $ref: '#/components/schemas/StructuredResult'
         trackingToken:
           type: string
           description: A token to be passed in /feedback events associated with this autocomplete result.
         ranges:
           type: array
           items:
-            $ref: "#/components/schemas/TextRange"
+            $ref: '#/components/schemas/TextRange'
           description: Subsections of the result string to which some special formatting should be applied (eg. bold)
+      required:
+        - result
+        - result_type
       example:
         result: sample result
         resultType: DOCUMENT
@@ -10520,7 +10787,6 @@ components:
           - datasource: confluence
           - objectType: page
     AutocompleteResultGroup:
-      description: A subsection of the results list from which distinct sections should be created.
       properties:
         startIndex:
           type: integer
@@ -10531,27 +10797,28 @@ components:
         title:
           type: string
           description: The title of the result group to be displayed. Empty means no title.
+      description: A subsection of the results list from which distinct sections should be created.
     AutocompleteResponse:
       allOf:
-        - $ref: "#/components/schemas/BackendExperimentsContext"
+        - $ref: '#/components/schemas/BackendExperimentsContext'
         - type: object
           properties:
             trackingToken:
               type: string
               description: An opaque token that represents this particular set of autocomplete results. To be used for /feedback reporting.
             sessionInfo:
-              $ref: "#/components/schemas/SessionInfo"
+              $ref: '#/components/schemas/SessionInfo'
             results:
               type: array
               items:
-                $ref: "#/components/schemas/AutocompleteResult"
+                $ref: '#/components/schemas/AutocompleteResult'
             groups:
               type: array
               items:
-                $ref: "#/components/schemas/AutocompleteResultGroup"
+                $ref: '#/components/schemas/AutocompleteResultGroup'
               description: Subsections of the results list from which distinct sections should be created.
             errorInfo:
-              $ref: "#/components/schemas/ErrorInfo"
+              $ref: '#/components/schemas/ErrorInfo'
             backendTimeMillis:
               type: integer
               format: int64
@@ -10565,8 +10832,6 @@ components:
           type: string
           description: The Chat Application ID this feed request should be scoped to. Empty means there is no Chat Application ID..
     FeedRequestOptions:
-      required:
-        - resultSize
       properties:
         resultSize:
           type: integer
@@ -10588,10 +10853,10 @@ components:
             type: string
           description: Datasources for which content should be included. Empty is for all.
         chatZeroStateSuggestionOptions:
-          $ref: "#/components/schemas/ChatZeroStateSuggestionOptions"
-    FeedRequest:
+          $ref: '#/components/schemas/ChatZeroStateSuggestionOptions'
       required:
-        - refreshType
+        - resultSize
+    FeedRequest:
       properties:
         categories:
           type: array
@@ -10640,13 +10905,15 @@ components:
               - OOO_PLANNER
           description: Categories of content requested. An allowlist gives flexibility to request content separately or together.
         requestOptions:
-          $ref: "#/components/schemas/FeedRequestOptions"
+          $ref: '#/components/schemas/FeedRequestOptions'
         timeoutMillis:
           type: integer
           description: Timeout in milliseconds for the request. A `408` error will be returned if handling the request takes longer.
           example: 5000
         sessionInfo:
-          $ref: "#/components/schemas/SessionInfo"
+          $ref: '#/components/schemas/SessionInfo'
+      required:
+        - refreshType
     DisplayableListFormat:
       properties:
         format:
@@ -10656,15 +10923,12 @@ components:
           description: defines how to render this particular displayable list card
     DisplayableListItemUIConfig:
       type: object
-      description: UI configurations for each item of the list
       properties:
         showNewIndicator:
           type: boolean
           description: show a "New" pill next to the item
+      description: UI configurations for each item of the list
     ConferenceData:
-      required:
-        - provider
-        - uri
       properties:
         provider:
           type: string
@@ -10680,14 +10944,16 @@ components:
             - NATIVE_CONFERENCE
             - LOCATION
             - DESCRIPTION
+      required:
+        - provider
+        - uri
     EventClassificationName:
-      description: The name for a generated classification of an event.
       type: string
       enum:
         - External Event
+      description: The name for a generated classification of an event.
     EventStrategyName:
       type: string
-      description: The name of method used to surface relevant data for a given calendar event.
       enum:
         - customerCard
         - news
@@ -10698,17 +10964,17 @@ components:
         - relevantDocuments
         - chatFollowUps
         - conversations
+      description: The name of method used to surface relevant data for a given calendar event.
     EventClassification:
-      description: A generated classification of a given event.
       properties:
         name:
-          $ref: "#/components/schemas/EventClassificationName"
+          $ref: '#/components/schemas/EventClassificationName'
         strategies:
           type: array
           items:
-            $ref: "#/components/schemas/EventStrategyName"
+            $ref: '#/components/schemas/EventStrategyName'
+      description: A generated classification of a given event.
     StructuredLink:
-      description: The display configuration for a link.
       properties:
         name:
           type: string
@@ -10717,47 +10983,45 @@ components:
           type: string
           description: The URL for the link.
         iconConfig:
-          $ref: "#/components/schemas/IconConfig"
+          $ref: '#/components/schemas/IconConfig'
+      description: The display configuration for a link.
     GeneratedAttachmentContent:
-      description: Content that has been generated or extrapolated from the documents present in the document field.
       properties:
         displayHeader:
+          type: string
           description: The header describing the generated content.
-          type: string
         text:
-          description: The content that has been generated.
           type: string
+          description: The content that has been generated.
+      description: Content that has been generated or extrapolated from the documents present in the document field.
       example:
         displayHeader: Action Items
         content: You said you'd send over the design document after the meeting.
     GeneratedAttachment:
-      description: These are attachments that aren't natively present on the event, and have been smartly suggested.
       properties:
         strategyName:
-          $ref: "#/components/schemas/EventStrategyName"
+          $ref: '#/components/schemas/EventStrategyName'
         documents:
           type: array
           items:
-            $ref: "#/components/schemas/Document"
+            $ref: '#/components/schemas/Document'
         person:
-          $ref: "#/components/schemas/Person"
+          $ref: '#/components/schemas/Person'
         customer:
-          $ref: "#/components/schemas/Customer"
+          $ref: '#/components/schemas/Customer'
         externalLinks:
-          description: A list of links to external sources outside of Glean.
           type: array
           items:
-            $ref: "#/components/schemas/StructuredLink"
+            $ref: '#/components/schemas/StructuredLink'
+          description: A list of links to external sources outside of Glean.
         content:
           type: array
           items:
-            $ref: "#/components/schemas/GeneratedAttachmentContent"
+            $ref: '#/components/schemas/GeneratedAttachmentContent'
+      description: These are attachments that aren't natively present on the event, and have been smartly suggested.
     CalendarEvent:
-      required:
-        - id
-        - url
       allOf:
-        - $ref: "#/components/schemas/AnonymousEvent"
+        - $ref: '#/components/schemas/AnonymousEvent'
         - type: object
           properties:
             id:
@@ -10767,12 +11031,12 @@ components:
               type: string
               description: A permalink for this calendar event
             attendees:
-              $ref: "#/components/schemas/CalendarAttendees"
+              $ref: '#/components/schemas/CalendarAttendees'
             location:
               type: string
               description: The location that this event is taking place at.
             conferenceData:
-              $ref: "#/components/schemas/ConferenceData"
+              $ref: '#/components/schemas/ConferenceData'
             description:
               type: string
               description: The HTML description of the event.
@@ -10788,35 +11052,38 @@ components:
             classifications:
               type: array
               items:
-                $ref: "#/components/schemas/EventClassification"
+                $ref: '#/components/schemas/EventClassification'
             generatedAttachments:
               type: array
               items:
-                $ref: "#/components/schemas/GeneratedAttachment"
+                $ref: '#/components/schemas/GeneratedAttachment'
+      required:
+        - id
+        - url
     SectionType:
       type: string
+      enum:
+        - CHANNEL
+        - MENTIONS
+        - TOPIC
       description: Type of the section. This defines how the section should be interpreted and rendered in the digest.
       x-enumDescriptions:
         CHANNEL: A standard section for channel-based digests (e.g. from Slack, Teams).
         MENTIONS: A dedicated section that surfaces user mentions (actionable, informative, or all).
         TOPIC: A section driven by a generic topic, not tied to any specific channel or instance.
-      enum:
-        - CHANNEL
-        - MENTIONS
-        - TOPIC
       x-speakeasy-enum-descriptions:
         CHANNEL: A standard section for channel-based digests (e.g. from Slack, Teams).
         MENTIONS: A dedicated section that surfaces user mentions (actionable, informative, or all).
         TOPIC: A section driven by a generic topic, not tied to any specific channel or instance.
     UpdateType:
       type: string
+      enum:
+        - ACTIONABLE
+        - INFORMATIVE
       description: Optional type classification for the update.
       x-enumDescriptions:
         ACTIONABLE: Updates that require user attention or action
         INFORMATIVE: Updates that are purely informational
-      enum:
-        - ACTIONABLE
-        - INFORMATIVE
       x-speakeasy-enum-descriptions:
         ACTIONABLE: Updates that require user attention or action
         INFORMATIVE: Updates that are purely informational
@@ -10825,9 +11092,9 @@ components:
       properties:
         urls:
           type: array
-          description: List of URLs for similar updates that are grouped together and rendered as a single update.
           items:
             type: string
+          description: List of URLs for similar updates that are grouped together and rendered as a single update.
         url:
           type: string
           description: URL link to the content or document.
@@ -10841,19 +11108,15 @@ components:
           type: string
           description: Brief summary or description of the update content.
         type:
-          $ref: "#/components/schemas/UpdateType"
+          $ref: '#/components/schemas/UpdateType'
     DigestSection:
       type: object
-      required:
-        - id
-        - type
-        - updates
       properties:
         id:
           type: string
           description: Unique identifier for the digest section.
         type:
-          $ref: "#/components/schemas/SectionType"
+          $ref: '#/components/schemas/SectionType'
         displayName:
           type: string
           description: Human-readable name for the digest section.
@@ -10874,8 +11137,12 @@ components:
         updates:
           type: array
           items:
-            $ref: "#/components/schemas/DigestUpdate"
+            $ref: '#/components/schemas/DigestUpdate'
           description: List of updates within this digest section.
+      required:
+        - id
+        - type
+        - updates
     Digest:
       type: object
       properties:
@@ -10893,7 +11160,7 @@ components:
         sections:
           type: array
           items:
-            $ref: "#/components/schemas/DigestSection"
+            $ref: '#/components/schemas/DigestSection'
           description: Array of digest sections from which the podcast was created.
     ChatSuggestion:
       properties:
@@ -10904,8 +11171,6 @@ components:
           type: string
           description: Targeted Glean Chat feature for the suggestion.
     PromptTemplateMutableProperties:
-      required:
-        - template
       properties:
         name:
           type: string
@@ -10917,31 +11182,33 @@ components:
           type: string
           description: The Application Id the prompt template should be created under. Empty for default assistant.
         inclusions:
-          $ref: "#/components/schemas/ChatRestrictionFilters"
+          $ref: '#/components/schemas/ChatRestrictionFilters'
           description: A list of filters which only allows the prompt template to access certain content.
         addedRoles:
           type: array
-          description: A list of added user roles for the Workflow.
           items:
-            $ref: "#/components/schemas/UserRoleSpecification"
+            $ref: '#/components/schemas/UserRoleSpecification'
+          description: A list of added user roles for the Workflow.
         removedRoles:
           type: array
-          description: A list of removed user roles for the Workflow.
           items:
-            $ref: "#/components/schemas/UserRoleSpecification"
+            $ref: '#/components/schemas/UserRoleSpecification'
+          description: A list of removed user roles for the Workflow.
+      required:
+        - template
     AttributionProperties: {}
     PromptTemplate:
       allOf:
-        - $ref: "#/components/schemas/PromptTemplateMutableProperties"
-        - $ref: "#/components/schemas/PermissionedObject"
-        - $ref: "#/components/schemas/AttributionProperties"
+        - $ref: '#/components/schemas/PromptTemplateMutableProperties'
+        - $ref: '#/components/schemas/PermissionedObject'
+        - $ref: '#/components/schemas/AttributionProperties'
         - type: object
           properties:
             id:
               type: string
               description: Opaque id for this prompt template
             author:
-              $ref: "#/components/schemas/Person"
+              $ref: '#/components/schemas/Person'
             createTimestamp:
               type: integer
               description: Server Unix timestamp of the creation time.
@@ -10949,12 +11216,12 @@ components:
               type: integer
               description: Server Unix timestamp of the last update time.
             lastUpdatedBy:
-              $ref: "#/components/schemas/Person"
+              $ref: '#/components/schemas/Person'
             roles:
               type: array
-              description: A list of roles for this prompt template explicitly granted.
               items:
-                $ref: "#/components/schemas/UserRoleSpecification"
+                $ref: '#/components/schemas/UserRoleSpecification'
+              description: A list of roles for this prompt template explicitly granted.
     UgcType:
       enum:
         - AGENT_TYPE
@@ -10980,36 +11247,36 @@ components:
       type: object
       properties:
         ugcType:
-          $ref: "#/components/schemas/UgcType"
+          $ref: '#/components/schemas/UgcType'
         id:
           type: string
           description: Opaque id of the UGC.
         count:
           type: integer
-          x-includeEmpty: true
           description: Number of users this object has been favorited by.
+          x-includeEmpty: true
         favoritedByUser:
           type: boolean
-          x-includeEmpty: true
           description: If the requesting user has favorited this object.
+          x-includeEmpty: true
     PromptTemplateResult:
       properties:
         promptTemplate:
-          $ref: "#/components/schemas/PromptTemplate"
+          $ref: '#/components/schemas/PromptTemplate'
         trackingToken:
           type: string
           description: An opaque token that represents this prompt template
         favoriteInfo:
-          $ref: "#/components/schemas/FavoriteInfo"
+          $ref: '#/components/schemas/FavoriteInfo'
         runCount:
-          $ref: "#/components/schemas/CountInfo"
+          $ref: '#/components/schemas/CountInfo'
           description: This tracks how many times this prompt template was run. If user runs a prompt template after modifying the original one, it still counts as a run for the original template.
     WorkflowMetadata:
       allOf:
         - type: object
           properties:
             author:
-              $ref: "#/components/schemas/Person"
+              $ref: '#/components/schemas/Person'
             createTimestamp:
               type: integer
               description: Server Unix timestamp of the creation time.
@@ -11020,19 +11287,19 @@ components:
               type: integer
               description: Server Unix timestamp of the last time the draft was saved.
             lastDraftSavedBy:
+              $ref: '#/components/schemas/Person'
               description: The person who last saved the draft.
-              $ref: "#/components/schemas/Person"
             lastDraftGitAuthorId:
               type: string
               description: ID of the VCS user (e.g. GitHub username) who last saved the draft. Set only by the draft save path via the external Git integration API.
             lastUpdatedBy:
-              $ref: "#/components/schemas/Person"
+              $ref: '#/components/schemas/Person'
     Workflow:
       allOf:
-        - $ref: "#/components/schemas/PermissionedObject"
-        - $ref: "#/components/schemas/WorkflowMutableProperties"
-        - $ref: "#/components/schemas/WorkflowMetadata"
-        - $ref: "#/components/schemas/AttributionProperties"
+        - $ref: '#/components/schemas/PermissionedObject'
+        - $ref: '#/components/schemas/WorkflowMutableProperties'
+        - $ref: '#/components/schemas/WorkflowMetadata'
+        - $ref: '#/components/schemas/AttributionProperties'
         - type: object
           properties:
             id:
@@ -11040,15 +11307,15 @@ components:
               description: The ID of the workflow.
     WorkflowResult:
       type: object
-      required:
-        - workflow
       properties:
         workflow:
-          $ref: "#/components/schemas/Workflow"
+          $ref: '#/components/schemas/Workflow'
+      required:
+        - workflow
     UserActivity:
       properties:
         actor:
-          $ref: "#/components/schemas/Person"
+          $ref: '#/components/schemas/Person'
         timestamp:
           type: integer
           description: Unix timestamp of the activity (in seconds since epoch UTC).
@@ -11071,10 +11338,8 @@ components:
             - VIEW
           description: The action for the activity
         aggregateVisitCount:
-          $ref: "#/components/schemas/CountInfo"
+          $ref: '#/components/schemas/CountInfo'
     FeedEntry:
-      required:
-        - title
       properties:
         entryId:
           type: string
@@ -11083,16 +11348,16 @@ components:
           type: string
           description: Title for the result. Can be document title, event title and so on.
         thumbnail:
-          $ref: "#/components/schemas/Thumbnail"
+          $ref: '#/components/schemas/Thumbnail'
         createdBy:
-          $ref: "#/components/schemas/Person"
+          $ref: '#/components/schemas/Person'
         uiConfig:
           allOf:
-            - $ref: "#/components/schemas/DisplayableListFormat"
+            - $ref: '#/components/schemas/DisplayableListFormat'
             - type: object
               properties:
                 additionalFlags:
-                  $ref: "#/components/schemas/DisplayableListItemUIConfig"
+                  $ref: '#/components/schemas/DisplayableListItemUIConfig'
         justificationType:
           type: string
           enum:
@@ -11160,38 +11425,37 @@ components:
           type: string
           description: View URL for the entry if based on links that are not documents in Glean.
         document:
-          $ref: "#/components/schemas/Document"
+          $ref: '#/components/schemas/Document'
         event:
-          $ref: "#/components/schemas/CalendarEvent"
+          $ref: '#/components/schemas/CalendarEvent'
         announcement:
-          $ref: "#/components/schemas/Announcement"
+          $ref: '#/components/schemas/Announcement'
         digest:
-          $ref: "#/components/schemas/Digest"
+          $ref: '#/components/schemas/Digest'
         collection:
-          $ref: "#/components/schemas/Collection"
+          $ref: '#/components/schemas/Collection'
         collectionItem:
-          $ref: "#/components/schemas/CollectionItem"
+          $ref: '#/components/schemas/CollectionItem'
         person:
-          $ref: "#/components/schemas/Person"
+          $ref: '#/components/schemas/Person'
         app:
-          $ref: "#/components/schemas/AppResult"
+          $ref: '#/components/schemas/AppResult'
         chatSuggestion:
-          $ref: "#/components/schemas/ChatSuggestion"
+          $ref: '#/components/schemas/ChatSuggestion'
         promptTemplate:
-          $ref: "#/components/schemas/PromptTemplateResult"
+          $ref: '#/components/schemas/PromptTemplateResult'
         workflow:
-          $ref: "#/components/schemas/WorkflowResult"
+          $ref: '#/components/schemas/WorkflowResult'
         activities:
           type: array
           items:
-            $ref: "#/components/schemas/UserActivity"
+            $ref: '#/components/schemas/UserActivity'
           description: List of activity where each activity has user, action, timestamp.
         documentVisitorCount:
-          $ref: "#/components/schemas/CountInfo"
-    FeedResult:
+          $ref: '#/components/schemas/CountInfo'
       required:
-        - category
-        - primaryEntry
+        - title
+    FeedResult:
       properties:
         category:
           type: string
@@ -11238,20 +11502,21 @@ components:
             - OOO_PLANNER
           description: Category of the result, one of the requested categories in incoming request.
         primaryEntry:
-          $ref: "#/components/schemas/FeedEntry"
+          $ref: '#/components/schemas/FeedEntry'
         secondaryEntries:
           type: array
           items:
-            $ref: "#/components/schemas/FeedEntry"
+            $ref: '#/components/schemas/FeedEntry'
           description: Secondary entries for the result e.g. suggested docs for the calendar, carousel.
         rank:
           type: integer
           description: Rank of the result. Rank is suggested by server. Client side rank may differ.
-    FeedResponse:
       required:
-        - serverTimestamp
+        - category
+        - primaryEntry
+    FeedResponse:
       allOf:
-        - $ref: "#/components/schemas/BackendExperimentsContext"
+        - $ref: '#/components/schemas/BackendExperimentsContext'
         - type: object
           properties:
             trackingToken:
@@ -11263,17 +11528,19 @@ components:
             results:
               type: array
               items:
-                $ref: "#/components/schemas/FeedResult"
+                $ref: '#/components/schemas/FeedResult'
             facetResults:
               type: object
               additionalProperties:
                 type: array
                 items:
-                  $ref: "#/components/schemas/FacetResult"
+                  $ref: '#/components/schemas/FacetResult'
               description: Map from category to the list of facets that can be used to filter the entry's content.
             mentionsTimeWindowInHours:
               type: integer
               description: The time window (in hours) used for generating user mentions.
+      required:
+        - serverTimestamp
     RecommendationsRequestOptions:
       properties:
         datasourceFilter:
@@ -11287,30 +11554,30 @@ components:
         facetFilterSets:
           type: array
           items:
-            $ref: "#/components/schemas/FacetFilterSet"
+            $ref: '#/components/schemas/FacetFilterSet'
           description: A list of facet filter sets that will be OR'ed together.
         context:
-          $ref: "#/components/schemas/Document"
+          $ref: '#/components/schemas/Document'
           description: Content for either a new or unindexed document, or additional content for an indexed document, which may be used to generate recommendations.
         resultProminence:
-          description: The types of prominence wanted in results returned. Default is any type.
           type: array
           items:
-            $ref: "#/components/schemas/SearchResultProminenceEnum"
+            $ref: '#/components/schemas/SearchResultProminenceEnum'
+          description: The types of prominence wanted in results returned. Default is any type.
     RecommendationsRequest:
       allOf:
-        - $ref: "#/components/schemas/ResultsRequest"
+        - $ref: '#/components/schemas/ResultsRequest'
         - type: object
           properties:
             recommendationDocumentSpec:
-              $ref: "#/components/schemas/DocumentSpec"
+              $ref: '#/components/schemas/DocumentSpec'
               description: Retrieve recommendations for this document. Glean Document ID is preferred over URL.
             requestOptions:
-              $ref: "#/components/schemas/RecommendationsRequestOptions"
+              $ref: '#/components/schemas/RecommendationsRequestOptions'
               description: Options for adjusting the request for recommendations.
     RecommendationsResponse:
       allOf:
-        - $ref: "#/components/schemas/ResultsResponse"
+        - $ref: '#/components/schemas/ResultsResponse'
     SortOptions:
       type: object
       properties:
@@ -11327,19 +11594,19 @@ components:
         filter:
           type: array
           items:
-            $ref: "#/components/schemas/FacetFilter"
+            $ref: '#/components/schemas/FacetFilter'
         sort:
-          description: Use EntitiesSortOrder enum for SortOptions.sortBy
           type: array
           items:
-            $ref: "#/components/schemas/SortOptions"
+            $ref: '#/components/schemas/SortOptions'
+          description: Use EntitiesSortOrder enum for SortOptions.sortBy
         entityType:
           type: string
-          default: PEOPLE
           enum:
             - PEOPLE
             - TEAMS
             - CUSTOM_ENTITIES
+          default: PEOPLE
         datasource:
           type: string
           description: The datasource associated with the entity type, most commonly used with CUSTOM_ENTITIES
@@ -11347,7 +11614,6 @@ components:
           type: string
           description: A query string to search for entities that each entity in the response must conform to. An empty query does not filter any entities.
         includeFields:
-          description: List of entity fields to return (that aren't returned by default)
           type: array
           items:
             type: string
@@ -11361,10 +11627,11 @@ components:
               - LAST_EXTENSION_USE
               - MANAGEMENT_DETAILS
               - UNPROCESSED_TEAMS
+          description: List of entity fields to return (that aren't returned by default)
         pageSize:
           type: integer
-          example: 100
           description: Hint to the server about how many results to send back. Server may return less.
+          example: 100
         cursor:
           type: string
           description: Pagination cursor. A previously received opaque token representing the position in the overall results at which to start.
@@ -11373,20 +11640,19 @@ components:
           description: A string denoting the search surface from which the endpoint is called.
         requestType:
           type: string
-          default: STANDARD
-          description: The type of request being made.
-          x-enumDescriptions:
-            STANDARD: Used by default for all requests and satisfies all standard use cases for list requests. Limited to 10000 entities.
-            FULL_DIRECTORY: Used exclusively to return a comprehensive list of all people entities in the organization, typically for audit like purposes. The recommended approach is to sort by FIRST_NAME or LAST_NAME, and use pagination for large organizations.
           enum:
             - STANDARD
             - FULL_DIRECTORY
+          description: The type of request being made.
+          default: STANDARD
+          x-enumDescriptions:
+            STANDARD: Used by default for all requests and satisfies all standard use cases for list requests. Limited to 10000 entities.
+            FULL_DIRECTORY: Used exclusively to return a comprehensive list of all people entities in the organization, typically for audit like purposes. The recommended approach is to sort by FIRST_NAME or LAST_NAME, and use pagination for large organizations.
           x-speakeasy-enum-descriptions:
             STANDARD: Used by default for all requests and satisfies all standard use cases for list requests. Limited to 10000 entities.
             FULL_DIRECTORY: Used exclusively to return a comprehensive list of all people entities in the organization, typically for audit like purposes. The recommended approach is to sort by FIRST_NAME or LAST_NAME, and use pagination for large organizations.
     EntitiesSortOrder:
       type: string
-      description: Different ways of sorting entities
       enum:
         - ENTITY_NAME
         - FIRST_NAME
@@ -11395,25 +11661,26 @@ components:
         - START_DATE
         - TEAM_SIZE
         - RELEVANCE
+      description: Different ways of sorting entities
     ListEntitiesResponse:
       type: object
       properties:
         results:
           type: array
           items:
-            $ref: "#/components/schemas/Person"
+            $ref: '#/components/schemas/Person'
         teamResults:
           type: array
           items:
-            $ref: "#/components/schemas/Team"
+            $ref: '#/components/schemas/Team'
         customEntityResults:
           type: array
           items:
-            $ref: "#/components/schemas/CustomEntity"
+            $ref: '#/components/schemas/CustomEntity'
         facetResults:
           type: array
           items:
-            $ref: "#/components/schemas/FacetResult"
+            $ref: '#/components/schemas/FacetResult'
         cursor:
           type: string
           description: Pagination cursor. A previously received opaque token representing the position in the overall results at which to start.
@@ -11425,14 +11692,14 @@ components:
           description: Whether or not more entities can be fetched.
         sortOptions:
           type: array
-          description: Sort options from EntitiesSortOrder supported for this response. Default is empty list.
           items:
-            $ref: "#/components/schemas/EntitiesSortOrder"
+            $ref: '#/components/schemas/EntitiesSortOrder'
+          description: Sort options from EntitiesSortOrder supported for this response. Default is empty list.
         customFacetNames:
           type: array
-          description: list of Person attributes that are custom setup by deployment
           items:
             type: string
+          description: list of Person attributes that are custom setup by deployment
     PeopleRequest:
       type: object
       properties:
@@ -11450,7 +11717,6 @@ components:
             type: string
           description: The email IDs to retrieve. The result is the deduplicated union of emailIds and obfuscatedIds.
         includeFields:
-          description: List of PersonMetadata fields to return (that aren't returned by default)
           type: array
           items:
             type: string
@@ -11465,17 +11731,18 @@ components:
               - MANAGEMENT_DETAILS
               - PEOPLE_PROFILE_SETTINGS
               - PEOPLE_WITHOUT_MANAGER
+          description: List of PersonMetadata fields to return (that aren't returned by default)
         includeTypes:
-          description: The types of people entities to include in the response in addition to those returned by default.
-          x-enumDescriptions:
-            PEOPLE_WITHOUT_MANAGER: Returns all people without a manager apart from the requested IDs.
-            INVALID_ENTITIES: Includes invalid entities in the response if any of the requested IDs are invalid.
           type: array
           items:
             type: string
             enum:
               - PEOPLE_WITHOUT_MANAGER
               - INVALID_ENTITIES
+          description: The types of people entities to include in the response in addition to those returned by default.
+          x-enumDescriptions:
+            PEOPLE_WITHOUT_MANAGER: Returns all people without a manager apart from the requested IDs.
+            INVALID_ENTITIES: Includes invalid entities in the response if any of the requested IDs are invalid.
           x-speakeasy-enum-descriptions:
             PEOPLE_WITHOUT_MANAGER: Returns all people without a manager apart from the requested IDs.
             INVALID_ENTITIES: Includes invalid entities in the response if any of the requested IDs are invalid.
@@ -11491,12 +11758,12 @@ components:
         results:
           type: array
           items:
-            $ref: "#/components/schemas/Person"
+            $ref: '#/components/schemas/Person'
           description: A Person for each ID in the request, each with PersonMetadata populated.
         relatedDocuments:
           type: array
           items:
-            $ref: "#/components/schemas/RelatedDocuments"
+            $ref: '#/components/schemas/RelatedDocuments'
           description: A list of documents related to this people response. This is only included if DOCUMENT_ACTIVITY is requested and only 1 person is included in the request.
         errors:
           type: array
@@ -11504,11 +11771,11 @@ components:
             type: string
           description: A list of IDs that could not be found.
     CreateShortcutRequest:
-      required:
-        - data
       properties:
         data:
-          $ref: "#/components/schemas/ShortcutMutableProperties"
+          $ref: '#/components/schemas/ShortcutMutableProperties'
+      required:
+        - data
     ShortcutError:
       properties:
         errorType:
@@ -11521,44 +11788,42 @@ components:
     CreateShortcutResponse:
       properties:
         shortcut:
-          $ref: "#/components/schemas/Shortcut"
+          $ref: '#/components/schemas/Shortcut'
         error:
-          $ref: "#/components/schemas/ShortcutError"
+          $ref: '#/components/schemas/ShortcutError'
     DeleteShortcutRequest:
       allOf:
-        - $ref: "#/components/schemas/UserGeneratedContentId"
+        - $ref: '#/components/schemas/UserGeneratedContentId'
         - type: object
           required:
             - id
     GetShortcutRequest:
       oneOf:
-        - $ref: "#/components/schemas/UserGeneratedContentId"
+        - $ref: '#/components/schemas/UserGeneratedContentId'
         - type: object
-          required:
-            - alias
           properties:
             alias:
               type: string
               description: The alias for the shortcut, including any arguments for variable shortcuts.
+          required:
+            - alias
     GetShortcutResponse:
       properties:
         shortcut:
-          $ref: "#/components/schemas/Shortcut"
+          $ref: '#/components/schemas/Shortcut'
           description: Shortcut given the input alias with any provided arguments substituted into the destination URL.
         error:
-          $ref: "#/components/schemas/ShortcutError"
+          $ref: '#/components/schemas/ShortcutError'
     ListShortcutsPaginatedRequest:
-      required:
-        - pageSize
       properties:
         includeFields:
-          description: Array of fields/data to be included in response that are not included by default
           type: array
           items:
             type: string
             enum:
               - FACETS
               - PEOPLE_DETAILS
+          description: Array of fields/data to be included in response that are not included by default
         pageSize:
           type: integer
           example: 10
@@ -11568,14 +11833,16 @@ components:
         filters:
           type: array
           items:
-            $ref: "#/components/schemas/FacetFilter"
+            $ref: '#/components/schemas/FacetFilter'
           description: A list of filters for the query. An AND is assumed between different filters. We support filters on Go Link name, author, department and type.
         sort:
-          $ref: "#/components/schemas/SortOptions"
+          $ref: '#/components/schemas/SortOptions'
           description: Specifies fieldname to sort on and order (ASC|DESC) to sort in
         query:
           type: string
           description: Search query that should be a substring in atleast one of the fields (alias , inputAlias, destinationUrl, description). Empty query does not filter shortcuts.
+      required:
+        - pageSize
     ShortcutsPaginationMetadata:
       properties:
         cursor:
@@ -11586,44 +11853,41 @@ components:
         totalItemCount:
           type: integer
     ListShortcutsPaginatedResponse:
-      required:
-        - shortcuts
-        - meta
       properties:
         shortcuts:
           type: array
           items:
-            $ref: "#/components/schemas/Shortcut"
+            $ref: '#/components/schemas/Shortcut'
           description: List of all shortcuts accessible to the user
         facetResults:
           type: array
           items:
-            $ref: "#/components/schemas/FacetResult"
+            $ref: '#/components/schemas/FacetResult'
         meta:
-          $ref: "#/components/schemas/ShortcutsPaginationMetadata"
+          $ref: '#/components/schemas/ShortcutsPaginationMetadata'
           description: Contains metadata like total item count and whether next page exists
+      required:
+        - shortcuts
+        - meta
     UpdateShortcutRequest:
       allOf:
-        - $ref: "#/components/schemas/UserGeneratedContentId"
-        - $ref: "#/components/schemas/ShortcutMutableProperties"
+        - $ref: '#/components/schemas/UserGeneratedContentId'
+        - $ref: '#/components/schemas/ShortcutMutableProperties'
         - type: object
           required:
             - id
     UpdateShortcutResponse:
       properties:
         shortcut:
-          $ref: "#/components/schemas/Shortcut"
+          $ref: '#/components/schemas/Shortcut'
         error:
-          $ref: "#/components/schemas/ShortcutError"
+          $ref: '#/components/schemas/ShortcutError'
     SummarizeRequest:
-      description: Summary of the document
-      required:
-        - documentSpecs
       properties:
         timestamp:
           type: string
-          description: The ISO 8601 timestamp associated with the client request.
           format: date-time
+          description: The ISO 8601 timestamp associated with the client request.
         query:
           type: string
           description: Optional query that the summary should be about
@@ -11633,11 +11897,14 @@ components:
         documentSpecs:
           type: array
           items:
-            $ref: "#/components/schemas/DocumentSpec"
+            $ref: '#/components/schemas/DocumentSpec'
           description: Specifications of documents to summarize
         trackingToken:
           type: string
           description: An opaque token that represents this particular result. To be used for /feedback reporting.
+      required:
+        - documentSpecs
+      description: Summary of the document
     Summary:
       properties:
         text:
@@ -11655,13 +11922,11 @@ components:
             message:
               type: string
         summary:
-          $ref: "#/components/schemas/Summary"
+          $ref: '#/components/schemas/Summary'
         trackingToken:
           type: string
           description: An opaque token that represents this summary in this particular query. To be used for /feedback reporting.
     ReminderRequest:
-      required:
-        - documentId
       properties:
         documentId:
           type: string
@@ -11675,16 +11940,16 @@ components:
         reason:
           type: string
           description: An optional free-text reason for the reminder. This is particularly useful when a reminder is used to ask for verification from another user (for example, "Duplicate", "Incomplete", "Incorrect").
+      required:
+        - documentId
     VerificationFeed:
       properties:
         documents:
           type: array
           items:
-            $ref: "#/components/schemas/Verification"
+            $ref: '#/components/schemas/Verification'
           description: List of document infos that include verification related information for them.
     VerifyRequest:
-      required:
-        - documentId
       properties:
         documentId:
           type: string
@@ -11696,18 +11961,20 @@ components:
             - DEPRECATE
             - UNVERIFY
           description: The verification action requested.
+      required:
+        - documentId
     ToolParameter:
       type: object
       properties:
         type:
           type: string
-          description: Parameter type (string, number, boolean, object, array)
           enum:
             - string
             - number
             - boolean
             - object
             - array
+          description: Parameter type (string, number, boolean, object, array)
         name:
           type: string
           description: The name of the parameter
@@ -11719,27 +11986,27 @@ components:
           description: Whether the parameter is required
         possibleValues:
           type: array
-          description: The possible values for the parameter. Can contain only primitive values or arrays of primitive values.
           items:
             type: string
+          description: The possible values for the parameter. Can contain only primitive values or arrays of primitive values.
         items:
+          $ref: '#/components/schemas/ToolParameter'
           type: object
           description: When type is 'array', this describes the structure of the item in the array.
-          $ref: "#/components/schemas/ToolParameter"
         properties:
           type: object
-          description: When type is 'object', this describes the structure of the object.
           additionalProperties:
-            $ref: "#/components/schemas/ToolParameter"
+            $ref: '#/components/schemas/ToolParameter'
+          description: When type is 'object', this describes the structure of the object.
     Tool:
       type: object
       properties:
         type:
           type: string
-          description: Type of tool (READ, WRITE)
           enum:
             - READ
             - WRITE
+          description: Type of tool (READ, WRITE)
         name:
           type: string
           description: Unique identifier for the tool
@@ -11751,21 +12018,18 @@ components:
           description: LLM friendly description of the tool
         parameters:
           type: object
-          description: The parameters for the tool. Each key is the name of the parameter and the value is the parameter object.
           additionalProperties:
-            $ref: "#/components/schemas/ToolParameter"
+            $ref: '#/components/schemas/ToolParameter'
+          description: The parameters for the tool. Each key is the name of the parameter and the value is the parameter object.
     ToolsListResponse:
       type: object
       properties:
         tools:
           type: array
           items:
-            $ref: "#/components/schemas/Tool"
+            $ref: '#/components/schemas/Tool'
     ToolsCallParameter:
       type: object
-      required:
-        - name
-        - value
       properties:
         name:
           type: string
@@ -11775,80 +12039,83 @@ components:
           description: The value of the parameter (for primitive types)
         items:
           type: array
-          description: The value of the parameter (for array types)
           items:
-            $ref: "#/components/schemas/ToolsCallParameter"
+            $ref: '#/components/schemas/ToolsCallParameter'
+          description: The value of the parameter (for array types)
         properties:
           type: object
-          description: The value of the parameter (for object types)
           additionalProperties:
-            $ref: "#/components/schemas/ToolsCallParameter"
-    ToolsCallRequest:
-      type: object
+            $ref: '#/components/schemas/ToolsCallParameter'
+          description: The value of the parameter (for object types)
       required:
         - name
-        - parameters
+        - value
+    ToolsCallRequest:
+      type: object
       properties:
         name:
           type: string
           description: Required name of the tool to execute
         parameters:
           type: object
-          description: The parameters for the tool. Each key is the name of the parameter and the value is the parameter object.
           additionalProperties:
-            $ref: "#/components/schemas/ToolsCallParameter"
+            $ref: '#/components/schemas/ToolsCallParameter'
+          description: The parameters for the tool. Each key is the name of the parameter and the value is the parameter object.
+      required:
+        - name
+        - parameters
     ToolsCallResponse:
       type: object
       properties:
         rawResponse:
-          additionalProperties: true
           type: object
+          additionalProperties: true
           description: The raw response from the tool
         error:
           type: string
           description: The error message if applicable
     ActionAuthType:
       type: string
+      enum:
+        - AUTH_USER_OAUTH
+        - AUTH_ADMIN
+        - AUTH_NONE
       description: |
         Authentication mechanism used by an action pack.
           - `AUTH_USER_OAUTH`: Requires per-user OAuth consent to the third-party tool.
           - `AUTH_ADMIN`: Uses a service-account / admin-owned credential. End users do not authorize individually.
           - `AUTH_NONE`: Action pack requires no authentication.
-      enum:
-        - AUTH_USER_OAUTH
-        - AUTH_ADMIN
-        - AUTH_NONE
     ActionAuthStatusResponse:
       type: object
-      required:
-        - authenticated
-        - authType
       properties:
         authenticated:
           type: boolean
           description: Whether the calling user is already authenticated to the tool backing the action pack.
         authType:
-          $ref: "#/components/schemas/ActionAuthType"
+          $ref: '#/components/schemas/ActionAuthType'
+      required:
+        - authenticated
+        - authType
     AuthorizeActionRequest:
       type: object
-      required:
-        - returnUrl
       properties:
         returnUrl:
           type: string
           description: |
             URL on the customer's domain to redirect the end user's browser back to after the third-party OAuth
             callback completes. Must be present in the tenant's return URL allowlist.
+      required:
+        - returnUrl
     AuthorizeActionResponse:
       type: object
-      required:
-        - redirectUrl
       properties:
         redirectUrl:
           type: string
           description: |
             URL that the customer UI should navigate the end user to in order to begin the third-party OAuth flow.
             After the user consents, control returns to `returnUrl` from the request.
+      required:
+        - redirectUrl
     IndexDocumentRequest:
       type: object
       properties:
@@ -14412,6 +14679,91 @@ components:
           description: >-
             If set, response lines will be streamed one-by-one as they become available. Each will be a ChatResponse, formatted as JSON, and separated by a new line. If false, the entire response will be returned at once. Note that if this is set and the model being used does not support streaming, the model's response will not be streamed, but other messages from the endpoint still will be.
           default: true
+  responses:
+    PlatformBadRequest:
+      description: Invalid request (malformed JSON, invalid parameter values, unknown fields).
+      content:
+        application/problem+json:
+          schema:
+            $ref: "#/components/schemas/PlatformProblemDetail"
+    PlatformUnauthorized:
+      description: Missing or invalid authentication token.
+      content:
+        application/problem+json:
+          schema:
+            $ref: "#/components/schemas/PlatformProblemDetail"
+    PlatformForbidden:
+      description: Token valid but lacks permission for the requested operation.
+      content:
+        application/problem+json:
+          schema:
+            $ref: "#/components/schemas/PlatformProblemDetail"
+    PlatformNotFound:
+      description: Resource not found.
+      content:
+        application/problem+json:
+          schema:
+            $ref: "#/components/schemas/PlatformProblemDetail"
+    PlatformRequestTimeout:
+      description: Backend did not respond within the timeout window.
+      content:
+        application/problem+json:
+          schema:
+            $ref: "#/components/schemas/PlatformProblemDetail"
+    PlatformTooManyRequests:
+      description: Rate limit exceeded. Includes Retry-After header.
+      content:
+        application/problem+json:
+          schema:
+            $ref: "#/components/schemas/PlatformProblemDetail"
+    PlatformInternalServerError:
+      description: Unexpected server-side failure.
+      content:
+        application/problem+json:
+          schema:
+            $ref: "#/components/schemas/PlatformProblemDetail"
+    PlatformServiceUnavailable:
+      description: Backend temporarily unavailable.
+      content:
+        application/problem+json:
+          schema:
+            $ref: "#/components/schemas/PlatformProblemDetail"
+    SuccessResponse:
+      description: OK
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/SuccessResponse'
+    BadRequestError:
+      description: Bad Request
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorInfoResponse'
+    UnauthorizedError:
+      description: Not Authorized
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorInfoResponse'
+    NotFoundError:
+      description: Not Found
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorInfoResponse'
+    TooManyRequestsError:
+      description: Too Many Requests
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorInfoResponse'
+    InternalServerError:
+      description: Internal Server Error
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorInfoResponse'
   parameters:
     locale:
       name: locale
@@ -14450,43 +14802,6 @@ components:
       schema:
         type: string
         example: o365sharepoint_abc123
-  responses:
-    SuccessResponse:
-      description: OK
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/SuccessResponse'
-    BadRequestError:
-      description: Bad Request
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/ErrorInfoResponse'
-    UnauthorizedError:
-      description: Not Authorized
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/ErrorInfoResponse'
-    NotFoundError:
-      description: Not Found
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/ErrorInfoResponse'
-    TooManyRequestsError:
-      description: Too Many Requests
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/ErrorInfoResponse'
-    InternalServerError:
-      description: Internal Server Error
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/ErrorInfoResponse'
 x-tagGroups:
   - name: Search & Generative AI
     tags:

--- a/overlayed_specs/glean-merged-spec.yaml
+++ b/overlayed_specs/glean-merged-spec.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.0
 info:
   version: "0.9.0"
   title: Glean API
-  x-source-commit-sha: __SCIO_COMMIT_SHA__
+  x-source-commit-sha: be392b09dbb2d90d1eb33786d69d1b8df8ea98ec
   description: |
     # Introduction
     In addition to the data sources that Glean has built-in support for, Glean also provides a REST API that enables customers to put arbitrary content in the search index. This is useful, for example, for doing permissions-aware search over content in internal tools that reside on-prem as well as for searching over applications that Glean does not currently support first class. In addition these APIs allow the customer to push organization data (people info, organization structure etc) into Glean.
@@ -22,6 +22,7 @@ info:
     These API clients provide type-safe, idiomatic interfaces for working with Glean IndexingAPIs in your language of choice.
   x-logo:
     url: https://app.glean.com/images/glean-text2.svg
+  x-open-api-commit-sha: 127bc440bea5368e5d1cea27cd51c5ef900b9147
   x-speakeasy-name: 'Glean API'
 servers:
   - url: https://{instance}-be.glean.com
@@ -40,7 +41,6 @@ paths:
       operationId: platform-search
       x-visibility: Public
       x-glean-experimental:
-        gated-by: platform.apiSearchEnabled
         id: 5ab612fc-ed50-4419-bec3-e5fe83934653
         introduced: "2026-04-08"
       x-codegen-request-body-name: payload
@@ -6201,6 +6201,12 @@ components:
           enum:
             - DOCUMENT
             - ASSISTANT
+    UgcTrackingSignals:
+      type: object
+      properties:
+        trackingToken:
+          type: string
+          description: An opaque token that represents this particular UGC. To be used for `/feedback` reporting.
     StructuredText:
       allOf:
         - $ref: '#/components/schemas/StructuredTextMutableProperties'
@@ -6485,6 +6491,7 @@ components:
       allOf:
         - $ref: '#/components/schemas/CollectionMutableProperties'
         - $ref: '#/components/schemas/PermissionedObject'
+        - $ref: '#/components/schemas/UgcTrackingSignals'
         - type: object
           properties:
             id:
@@ -6627,6 +6634,7 @@ components:
         - $ref: '#/components/schemas/AnswerDocId'
         - $ref: '#/components/schemas/AnswerMutableProperties'
         - $ref: '#/components/schemas/PermissionedObject'
+        - $ref: '#/components/schemas/UgcTrackingSignals'
         - type: object
           properties:
             combinedAnswerText:
@@ -8136,6 +8144,7 @@ components:
         - $ref: '#/components/schemas/AnnouncementMutableProperties'
         - $ref: '#/components/schemas/DraftProperties'
         - $ref: '#/components/schemas/PermissionedObject'
+        - $ref: '#/components/schemas/UgcTrackingSignals'
         - type: object
           properties:
             id:
@@ -8244,7 +8253,14 @@ components:
           $ref: '#/components/schemas/Answer'
         trackingToken:
           type: string
-          description: An opaque token that represents this particular Answer. To be used for `/feedback` reporting.
+          description: Use `answer.trackingToken` instead.
+          deprecated: true
+          x-glean-deprecated:
+            id: 62de643b-f182-4d4d-a2fc-5e2cbfee7320
+            introduced: "2026-05-07"
+            message: Use `answer.trackingToken` instead.
+            removal: "2027-01-15"
+          x-speakeasy-deprecation-message: "Deprecated on 2026-05-07, removal scheduled for 2027-01-15: Use `answer.trackingToken` instead."
       required:
         - answer
     GetAnswerError:
@@ -9428,11 +9444,18 @@ components:
           $ref: '#/components/schemas/Collection'
         rootCollection:
           $ref: '#/components/schemas/Collection'
-        trackingToken:
-          type: string
-          description: An opaque token that represents this particular Collection. To be used for `/feedback` reporting.
         error:
           $ref: '#/components/schemas/CollectionError'
+        trackingToken:
+          type: string
+          description: Use `collection.trackingToken` instead.
+          deprecated: true
+          x-glean-deprecated:
+            id: 2d6ca3a7-4763-4137-9ebd-740568fe8300
+            introduced: "2026-05-07"
+            message: Use `collection.trackingToken` instead.
+            removal: "2027-01-15"
+          x-speakeasy-deprecation-message: "Deprecated on 2026-05-07, removal scheduled for 2027-01-15: Use `collection.trackingToken` instead."
     ListCollectionsRequest:
       properties:
         includeAudience:

--- a/source_specs/platform.yaml
+++ b/source_specs/platform.yaml
@@ -1,0 +1,339 @@
+openapi: 3.0.0
+info:
+  version: '2026-04-01'
+  title: Glean Platform API
+  x-source-commit-sha: __SCIO_COMMIT_SHA__
+servers:
+  - url: https://{domain}-be.glean.com/api
+    variables:
+      domain:
+        default: domain
+        description: Backend subdomain for the API (e.g. mycompany or be4f5226 for new customers)
+security:
+  - ApiToken: []
+paths:
+  /search:
+    post:
+      tags:
+        - Search
+      summary: Search
+      description: |
+        Execute a search query and retrieve ranked results. This is the data retrieval variant of the search API and returns only results and pagination state.
+      operationId: platform-search-query
+      x-visibility: Public
+      x-glean-experimental:
+        gated-by: platform.apiSearchEnabled
+        id: 5ab612fc-ed50-4419-bec3-e5fe83934653
+        introduced: '2026-04-08'
+      x-codegen-request-body-name: payload
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SearchRequest'
+      responses:
+        '200':
+          description: Successful search.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SearchResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '408':
+          $ref: '#/components/responses/RequestTimeout'
+        '429':
+          $ref: '#/components/responses/TooManyRequests'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailable'
+components:
+  securitySchemes:
+    ApiToken:
+      type: http
+      scheme: bearer
+      description: |
+        Glean API token. Obtain via Admin Console -> Platform -> API Tokens, or via OAuth 2.0 client credentials flow.
+  schemas:
+    Filter:
+      type: object
+      required:
+        - field
+        - values
+      description: |
+        A single filter criterion. Multiple values within a filter are OR'd. Filters are AND'd with each other and with any inline query operators.
+      properties:
+        field:
+          type: string
+          description: |
+            The field to filter on. Accepts built-in operator names such as `type`, `owner`, `from`, `author`, `channel`, `status`, `assignee`, `reporter`, `component`, `mentions`, and `collection`, plus custom datasource property names.
+          example: type
+        values:
+          type: array
+          minItems: 1
+          items:
+            type: string
+          description: One or more values to match.
+          example:
+            - spreadsheet
+            - presentation
+        exclude:
+          type: boolean
+          default: false
+          description: Excludes results matching any of the specified values when true.
+    TimeRange:
+      type: object
+      description: Filter results to those last updated within this range.
+      properties:
+        start:
+          type: string
+          format: date-time
+          description: Inclusive lower bound in ISO 8601 format.
+        end:
+          type: string
+          format: date-time
+          description: Exclusive upper bound in ISO 8601 format.
+    SearchRequest:
+      type: object
+      additionalProperties: false
+      required:
+        - query
+      properties:
+        query:
+          type: string
+          description: |
+            The search query string. Supports inline operators such as `from:jane type:document app:confluence`. Inline operators are AND'd with structured `filters`.
+          example: quarterly planning 2026
+        page_size:
+          type: integer
+          minimum: 1
+          maximum: 100
+          default: 10
+          description: Number of results to return per page.
+        cursor:
+          type: string
+          nullable: true
+          description: |
+            Opaque pagination token from a previous response's `next_cursor` field. Omit on the first request.
+        datasources:
+          type: array
+          items:
+            type: string
+          description: Restrict results to specific datasources.
+          example:
+            - confluence
+            - google_drive
+        filters:
+          type: array
+          items:
+            $ref: '#/components/schemas/Filter'
+          description: |
+            Structured filters applied to search results. Multiple values within a filter are OR'd. Multiple filters are AND'd together. Filters are AND'd with any inline operators in `query`. Note that conflicting constraints on the same field (e.g., `type:document` in the query and `type: spreadsheet` in a filter) produce an empty result set.
+        time_range:
+          $ref: '#/components/schemas/TimeRange'
+    Person:
+      type: object
+      nullable: true
+      description: A person associated with the result.
+      properties:
+        name:
+          type: string
+          description: Display name.
+          example: Jane Smith
+        email:
+          type: string
+          format: email
+          description: Email address.
+          example: jane.smith@company.com
+    Result:
+      type: object
+      required:
+        - url
+        - title
+        - datasource
+      properties:
+        url:
+          type: string
+          format: uri
+          description: Canonical URL of the result.
+          example: https://company.atlassian.net/wiki/spaces/ENG/pages/12345
+        title:
+          type: string
+          description: Result title.
+          example: Q2 2026 Platform Roadmap
+        snippets:
+          type: array
+          items:
+            type: string
+          description: Query-relevant plain-text excerpts from the result body.
+          example:
+            - The platform team will focus on API stability and...
+        datasource:
+          type: string
+          description: The datasource this result originates from.
+          example: confluence
+        document_type:
+          type: string
+          nullable: true
+          description: The document type within the datasource.
+          example: page
+        creator:
+          $ref: '#/components/schemas/Person'
+        owner:
+          $ref: '#/components/schemas/Person'
+        updated_at:
+          type: string
+          format: date-time
+          nullable: true
+          description: When the result was last modified.
+        created_at:
+          type: string
+          format: date-time
+          nullable: true
+          description: When the result was created.
+    SearchResponse:
+      type: object
+      required:
+        - results
+        - has_more
+        - next_cursor
+        - request_id
+      properties:
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/Result'
+          description: Ordered list of search results.
+        has_more:
+          type: boolean
+          description: Indicates whether additional pages of results are available.
+        next_cursor:
+          type: string
+          nullable: true
+          description: Opaque token to pass as `cursor` in the next request.
+        request_id:
+          type: string
+          description: Platform-generated request ID for support correlation.
+    ProblemDetail:
+      type: object
+      required:
+        - type
+        - title
+        - status
+        - detail
+        - code
+        - request_id
+      description: |
+        Error response following RFC 9457, extended with `code` and `documentation_url` for machine-readable classification and self-service remediation.
+      properties:
+        type:
+          type: string
+          format: uri
+          description: URI identifying the error type.
+          example: https://developer.glean.com/errors/invalid-cursor
+        title:
+          type: string
+          description: Short, human-readable summary of the error.
+          example: Invalid Pagination Cursor
+        status:
+          type: integer
+          description: HTTP status code mirrored from the response.
+          example: 400
+        detail:
+          type: string
+          description: Human-readable explanation specific to this occurrence.
+          example: |
+            The provided cursor has expired. Start a new search to get a fresh cursor.
+        code:
+          type: string
+          description: Stable machine-readable error code.
+          enum:
+            - invalid_request
+            - missing_required_field
+            - invalid_parameter
+            - invalid_cursor
+            - expired_cursor
+            - invalid_filter
+            - authentication_required
+            - token_expired
+            - insufficient_permissions
+            - resource_not_found
+            - request_timeout
+            - conflict
+            - gone
+            - unprocessable_query
+            - rate_limit_exceeded
+            - internal_error
+            - service_unavailable
+          example: invalid_cursor
+        documentation_url:
+          type: string
+          format: uri
+          description: Direct URL to documentation for this error code.
+          example: https://developer.glean.com/errors/invalid-cursor
+        request_id:
+          type: string
+          description: Platform-generated request ID for support correlation.
+          example: req_7f8a9b0c1d2e
+  responses:
+    BadRequest:
+      description: Invalid request (malformed JSON, invalid parameter values, unknown fields).
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/ProblemDetail'
+    Unauthorized:
+      description: Missing or invalid authentication token.
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/ProblemDetail'
+    Forbidden:
+      description: Token valid but lacks permission for the requested operation.
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/ProblemDetail'
+    NotFound:
+      description: Resource not found.
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/ProblemDetail'
+    RequestTimeout:
+      description: Backend did not respond within the timeout window.
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/ProblemDetail'
+    TooManyRequests:
+      description: Rate limit exceeded. Includes Retry-After header.
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/ProblemDetail'
+    InternalServerError:
+      description: Unexpected server-side failure.
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/ProblemDetail'
+    ServiceUnavailable:
+      description: Backend temporarily unavailable.
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/ProblemDetail'
+x-tagGroups:
+  - name: Data Retrieval
+    tags:
+      - Search
+      - Tools

--- a/source_specs/platform.yaml
+++ b/source_specs/platform.yaml
@@ -22,7 +22,6 @@ paths:
       operationId: platform-search
       x-visibility: Public
       x-glean-experimental:
-        gated-by: platform.apiSearchEnabled
         id: 5ab612fc-ed50-4419-bec3-e5fe83934653
         introduced: '2026-04-08'
       x-codegen-request-body-name: payload

--- a/source_specs/platform.yaml
+++ b/source_specs/platform.yaml
@@ -12,6 +12,52 @@ servers:
 security:
   - ApiToken: []
 paths:
+  /tools:
+    get:
+      tags:
+        - Tools
+      summary: List tools
+      description: |
+        List tools available to the authenticated user, optionally filtered by tool name.
+      operationId: platform-tools-list
+      x-visibility: Public
+      x-glean-experimental:
+        id: 3cb43a04-ad52-4c25-be62-3ce1daffd513
+        introduced: '2026-05-06'
+      parameters:
+        - in: query
+          name: tool_names
+          description: Optional comma-delimited list of tool names to return.
+          required: false
+          style: form
+          explode: false
+          schema:
+            type: array
+            items:
+              type: string
+      responses:
+        '200':
+          description: Successful response.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ToolsListResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '408':
+          $ref: '#/components/responses/RequestTimeout'
+        '429':
+          $ref: '#/components/responses/TooManyRequests'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailable'
   /search:
     post:
       tags:
@@ -62,6 +108,143 @@ components:
       description: |
         Glean API token. Obtain via Admin Console -> Platform -> API Tokens, or via OAuth 2.0 client credentials flow.
   schemas:
+    ToolParameter:
+      type: object
+      properties:
+        type:
+          type: string
+          description: Parameter type.
+          enum:
+            - string
+            - number
+            - boolean
+            - object
+            - array
+        name:
+          type: string
+          description: Parameter name.
+        description:
+          type: string
+          description: Parameter description.
+        is_required:
+          type: boolean
+          description: Whether the parameter is required.
+        possible_values:
+          type: array
+          description: Possible primitive values for the parameter.
+          items:
+            type: string
+        items:
+          $ref: '#/components/schemas/ToolParameter'
+        properties:
+          type: object
+          description: Object properties for object parameters.
+          additionalProperties:
+            $ref: '#/components/schemas/ToolParameter'
+    Tool:
+      type: object
+      required:
+        - type
+        - name
+        - display_name
+        - description
+        - parameters
+      properties:
+        type:
+          type: string
+          description: Type of tool.
+          enum:
+            - READ
+            - WRITE
+        name:
+          type: string
+          description: Unique identifier for the tool.
+        display_name:
+          type: string
+          description: Human-readable name.
+        description:
+          type: string
+          description: LLM-friendly description of the tool.
+        parameters:
+          type: object
+          description: Parameters supported by the tool.
+          additionalProperties:
+            $ref: '#/components/schemas/ToolParameter'
+    ToolsListResponse:
+      type: object
+      required:
+        - tools
+        - request_id
+      properties:
+        tools:
+          type: array
+          description: List of tools available to the user.
+          items:
+            $ref: '#/components/schemas/Tool'
+        request_id:
+          type: string
+          description: Platform-generated request ID for support correlation.
+    ProblemDetail:
+      type: object
+      required:
+        - type
+        - title
+        - status
+        - detail
+        - code
+        - request_id
+      description: |
+        Error response following RFC 9457, extended with `code` and `documentation_url` for machine-readable classification and self-service remediation.
+      properties:
+        type:
+          type: string
+          format: uri
+          description: URI identifying the error type.
+          example: https://developer.glean.com/errors/invalid-cursor
+        title:
+          type: string
+          description: Short, human-readable summary of the error.
+          example: Invalid Pagination Cursor
+        status:
+          type: integer
+          description: HTTP status code mirrored from the response.
+          example: 400
+        detail:
+          type: string
+          description: Human-readable explanation specific to this occurrence.
+          example: |
+            The provided cursor has expired. Start a new search to get a fresh cursor.
+        code:
+          type: string
+          description: Stable machine-readable error code.
+          enum:
+            - invalid_request
+            - missing_required_field
+            - invalid_parameter
+            - invalid_cursor
+            - expired_cursor
+            - invalid_filter
+            - authentication_required
+            - token_expired
+            - insufficient_permissions
+            - resource_not_found
+            - request_timeout
+            - conflict
+            - gone
+            - unprocessable_query
+            - rate_limit_exceeded
+            - internal_error
+            - service_unavailable
+          example: invalid_cursor
+        documentation_url:
+          type: string
+          format: uri
+          description: Direct URL to documentation for this error code.
+          example: https://developer.glean.com/errors/invalid-cursor
+        request_id:
+          type: string
+          description: Platform-generated request ID for support correlation.
+          example: req_7f8a9b0c1d2e
     Filter:
       type: object
       required:
@@ -221,67 +404,6 @@ components:
         request_id:
           type: string
           description: Platform-generated request ID for support correlation.
-    ProblemDetail:
-      type: object
-      required:
-        - type
-        - title
-        - status
-        - detail
-        - code
-        - request_id
-      description: |
-        Error response following RFC 9457, extended with `code` and `documentation_url` for machine-readable classification and self-service remediation.
-      properties:
-        type:
-          type: string
-          format: uri
-          description: URI identifying the error type.
-          example: https://developer.glean.com/errors/invalid-cursor
-        title:
-          type: string
-          description: Short, human-readable summary of the error.
-          example: Invalid Pagination Cursor
-        status:
-          type: integer
-          description: HTTP status code mirrored from the response.
-          example: 400
-        detail:
-          type: string
-          description: Human-readable explanation specific to this occurrence.
-          example: |
-            The provided cursor has expired. Start a new search to get a fresh cursor.
-        code:
-          type: string
-          description: Stable machine-readable error code.
-          enum:
-            - invalid_request
-            - missing_required_field
-            - invalid_parameter
-            - invalid_cursor
-            - expired_cursor
-            - invalid_filter
-            - authentication_required
-            - token_expired
-            - insufficient_permissions
-            - resource_not_found
-            - request_timeout
-            - conflict
-            - gone
-            - unprocessable_query
-            - rate_limit_exceeded
-            - internal_error
-            - service_unavailable
-          example: invalid_cursor
-        documentation_url:
-          type: string
-          format: uri
-          description: Direct URL to documentation for this error code.
-          example: https://developer.glean.com/errors/invalid-cursor
-        request_id:
-          type: string
-          description: Platform-generated request ID for support correlation.
-          example: req_7f8a9b0c1d2e
   responses:
     BadRequest:
       description: Invalid request (malformed JSON, invalid parameter values, unknown fields).

--- a/source_specs/platform.yaml
+++ b/source_specs/platform.yaml
@@ -19,7 +19,7 @@ paths:
       summary: Search
       description: |
         Execute a search query and retrieve ranked results. This is the data retrieval variant of the search API and returns only results and pagination state.
-      operationId: platform-search-query
+      operationId: platform-search
       x-visibility: Public
       x-glean-experimental:
         gated-by: platform.apiSearchEnabled

--- a/src/source-spec-transformer.js
+++ b/src/source-spec-transformer.js
@@ -68,9 +68,10 @@ const httpMethods = new Set([
   'trace',
 ]);
 
-// This map is the published Platform SDK contract. Adding, removing, or
-// changing an entry changes the public SDK surface and should be reviewed as
-// such.
+// This map is the published Platform SDK contract. Each key is a scio
+// operationId; each value becomes the generated SDK method chain:
+// glean.platform.<group>.<method>(...). Adding, removing, or changing an entry
+// changes the public SDK surface and should be reviewed as such.
 const platformSdkOperationNames = {
   'platform-search': { group: 'search', method: 'query' },
 };

--- a/src/source-spec-transformer.js
+++ b/src/source-spec-transformer.js
@@ -68,6 +68,13 @@ const httpMethods = new Set([
   'trace',
 ]);
 
+// This map is the published Platform SDK contract. Adding, removing, or
+// changing an entry changes the public SDK surface and should be reviewed as
+// such.
+const platformSdkOperationNames = {
+  'platform-search': { group: 'search', method: 'query' },
+};
+
 function rewriteRefs(obj, refMap) {
   if (!obj || typeof obj !== 'object') return;
 
@@ -197,20 +204,6 @@ function transformPlatformApiTokenSecurity(spec) {
   }
 }
 
-function parsePlatformOperationId(operationId, path, method) {
-  const match = /^platform-([a-z0-9]+(?:-[a-z0-9]+)*)-([a-z0-9]+)$/.exec(
-    operationId || '',
-  );
-
-  if (!match) {
-    throw new Error(
-      `Platform operation ${method.toUpperCase()} ${path} must use operationId platform-<family>-<method>; got ${operationId || '<missing>'}`,
-    );
-  }
-
-  return { family: match[1], methodName: match[2] };
-}
-
 function transformPlatformOperations(spec) {
   if (!spec.paths) {
     return;
@@ -228,17 +221,18 @@ function transformPlatformOperations(spec) {
         continue;
       }
 
-      const { family, methodName } = parsePlatformOperationId(
-        operation.operationId,
-        path,
-        method,
-      );
+      const sdkName = platformSdkOperationNames[operation.operationId];
+      if (!sdkName) {
+        throw new Error(
+          `Platform operation ${method.toUpperCase()} ${path} with operationId ${operation.operationId || '<missing>'} has no SDK mapping in platformSdkOperationNames`,
+        );
+      }
 
       if (!operation['x-speakeasy-group']) {
-        operation['x-speakeasy-group'] = `platform.${family}`;
+        operation['x-speakeasy-group'] = `platform.${sdkName.group}`;
       }
       if (!operation['x-speakeasy-name-override']) {
-        operation['x-speakeasy-name-override'] = methodName;
+        operation['x-speakeasy-name-override'] = sdkName.method;
       }
     }
   }

--- a/src/source-spec-transformer.js
+++ b/src/source-spec-transformer.js
@@ -74,6 +74,7 @@ const httpMethods = new Set([
 // changes the public SDK surface and should be reviewed as such.
 const platformSdkOperationNames = {
   'platform-search': { group: 'search', method: 'query' },
+  'platform-tools-list': { group: 'tools', method: 'list' },
 };
 
 function rewriteRefs(obj, refMap) {

--- a/src/source-spec-transformer.js
+++ b/src/source-spec-transformer.js
@@ -191,7 +191,8 @@ function transformPlatformApiTokenSecurity(spec) {
       if (requirement.ApiToken === undefined) {
         return requirement;
       }
-      return { APIToken: requirement.ApiToken };
+      const { ApiToken, ...otherSchemes } = requirement;
+      return { APIToken: ApiToken, ...otherSchemes };
     });
   };
 

--- a/src/source-spec-transformer.js
+++ b/src/source-spec-transformer.js
@@ -57,6 +57,202 @@ export function transformShortcutComponent(spec) {
   return spec;
 }
 
+const httpMethods = new Set([
+  'delete',
+  'get',
+  'head',
+  'options',
+  'patch',
+  'post',
+  'put',
+  'trace',
+]);
+
+function rewriteRefs(obj, refMap) {
+  if (!obj || typeof obj !== 'object') return;
+
+  Object.keys(obj).forEach((key) => {
+    if (key === '$ref' && typeof obj[key] === 'string' && refMap[obj[key]]) {
+      obj[key] = refMap[obj[key]];
+    } else if (typeof obj[key] === 'object') {
+      rewriteRefs(obj[key], refMap);
+    }
+  });
+}
+
+function platformSchemaName(name) {
+  return name.startsWith('Platform') ? name : `Platform${name}`;
+}
+
+function transformPlatformSchemas(spec) {
+  if (!spec.components?.schemas) {
+    return;
+  }
+
+  const schemas = spec.components.schemas;
+  const refMap = {};
+
+  for (const name of Object.keys(schemas)) {
+    const nextName = platformSchemaName(name);
+    if (nextName !== name) {
+      if (schemas[nextName]) {
+        throw new Error(
+          `Platform schema ${name} cannot be renamed to ${nextName} because ${nextName} already exists`,
+        );
+      }
+      refMap[`#/components/schemas/${name}`] =
+        `#/components/schemas/${nextName}`;
+    }
+  }
+
+  for (const [name, schema] of Object.entries(schemas)) {
+    const nextName = platformSchemaName(name);
+    if (nextName !== name) {
+      schemas[nextName] = schema;
+      delete schemas[name];
+    }
+  }
+
+  rewriteRefs(spec, refMap);
+}
+
+function transformPlatformResponses(spec) {
+  if (!spec.components?.responses) {
+    return;
+  }
+
+  const responses = spec.components.responses;
+  const refMap = {};
+
+  for (const name of Object.keys(responses)) {
+    const nextName = platformSchemaName(name);
+    if (nextName !== name) {
+      if (responses[nextName]) {
+        throw new Error(
+          `Platform response ${name} cannot be renamed to ${nextName} because ${nextName} already exists`,
+        );
+      }
+      refMap[`#/components/responses/${name}`] =
+        `#/components/responses/${nextName}`;
+    }
+  }
+
+  for (const [name, response] of Object.entries(responses)) {
+    const nextName = platformSchemaName(name);
+    if (nextName !== name) {
+      responses[nextName] = response;
+      delete responses[name];
+    }
+  }
+
+  rewriteRefs(spec, refMap);
+}
+
+function transformPlatformApiTokenSecurity(spec) {
+  const securitySchemes = spec.components?.securitySchemes;
+  if (securitySchemes?.ApiToken) {
+    if (securitySchemes.APIToken) {
+      throw new Error(
+        'Platform security scheme ApiToken cannot be renamed to APIToken because APIToken already exists',
+      );
+    }
+    securitySchemes.APIToken = securitySchemes.ApiToken;
+    delete securitySchemes.ApiToken;
+  }
+
+  const rewriteSecurity = (requirements) => {
+    if (!Array.isArray(requirements)) {
+      return requirements;
+    }
+
+    return requirements.map((requirement) => {
+      if (!requirement || typeof requirement !== 'object') {
+        return requirement;
+      }
+      if (requirement.ApiToken === undefined) {
+        return requirement;
+      }
+      return { APIToken: requirement.ApiToken };
+    });
+  };
+
+  spec.security = rewriteSecurity(spec.security);
+  if (!spec.paths) {
+    return;
+  }
+
+  for (const pathItem of Object.values(spec.paths)) {
+    if (!pathItem || typeof pathItem !== 'object') continue;
+
+    for (const [method, operation] of Object.entries(pathItem)) {
+      if (
+        !httpMethods.has(method) ||
+        !operation ||
+        typeof operation !== 'object'
+      ) {
+        continue;
+      }
+      operation.security = rewriteSecurity(operation.security);
+    }
+  }
+}
+
+function parsePlatformOperationId(operationId, path, method) {
+  const match = /^platform-([a-z0-9]+(?:-[a-z0-9]+)*)-([a-z0-9]+)$/.exec(
+    operationId || '',
+  );
+
+  if (!match) {
+    throw new Error(
+      `Platform operation ${method.toUpperCase()} ${path} must use operationId platform-<family>-<method>; got ${operationId || '<missing>'}`,
+    );
+  }
+
+  return { family: match[1], methodName: match[2] };
+}
+
+function transformPlatformOperations(spec) {
+  if (!spec.paths) {
+    return;
+  }
+
+  for (const [path, pathItem] of Object.entries(spec.paths)) {
+    if (!pathItem || typeof pathItem !== 'object') continue;
+
+    for (const [method, operation] of Object.entries(pathItem)) {
+      if (
+        !httpMethods.has(method) ||
+        !operation ||
+        typeof operation !== 'object'
+      ) {
+        continue;
+      }
+
+      const { family, methodName } = parsePlatformOperationId(
+        operation.operationId,
+        path,
+        method,
+      );
+
+      if (!operation['x-speakeasy-group']) {
+        operation['x-speakeasy-group'] = `platform.${family}`;
+      }
+      if (!operation['x-speakeasy-name-override']) {
+        operation['x-speakeasy-name-override'] = methodName;
+      }
+    }
+  }
+}
+
+export function transformPlatformSpec(spec) {
+  transformPlatformSchemas(spec);
+  transformPlatformResponses(spec);
+  transformPlatformApiTokenSecurity(spec);
+  transformPlatformOperations(spec);
+
+  return spec;
+}
+
 /**
  * Transforms the BearerAuth security scheme to APIToken
  * @param {Object} spec The OpenAPI spec object
@@ -560,6 +756,10 @@ export function transform(content, filename, commitSha) {
   // Apply Shortcut -> IndexingShortcut transformation for indexing.yaml
   if (filename === 'indexing.yaml') {
     transformShortcutComponent(spec);
+  }
+
+  if (filename === 'platform.yaml') {
+    transformPlatformSpec(spec);
   }
 
   // Apply BearerAuth -> APIToken transformation for all files

--- a/src/source-spec-transformer.js
+++ b/src/source-spec-transformer.js
@@ -97,6 +97,10 @@ function transformPlatformSchemas(spec) {
     return;
   }
 
+  // Platform is merged into the existing public SDK spec, so common names like
+  // SearchRequest, Result, or Person would otherwise collide with legacy REST
+  // schemas. Prefixing every Platform schema keeps the merged model surface
+  // deterministic without requiring each scio schema to know about SDK peers.
   const schemas = spec.components.schemas;
   const refMap = {};
 
@@ -129,6 +133,9 @@ function transformPlatformResponses(spec) {
     return;
   }
 
+  // Shared response names such as BadRequest and Unauthorized are global within
+  // the merged OpenAPI document. Keep Platform problem-detail responses separate
+  // from the existing REST response components.
   const responses = spec.components.responses;
   const refMap = {};
 
@@ -157,6 +164,9 @@ function transformPlatformResponses(spec) {
 }
 
 function transformPlatformApiTokenSecurity(spec) {
+  // scio's Platform source spec uses ApiToken, while the merged SDK spec already
+  // standardizes auth under APIToken. Normalize before merge so Speakeasy sees
+  // one auth scheme instead of generating a second Platform-specific credential.
   const securitySchemes = spec.components?.securitySchemes;
   if (securitySchemes?.ApiToken) {
     if (securitySchemes.APIToken) {
@@ -224,6 +234,8 @@ function transformPlatformOperations(spec) {
 
       const sdkName = platformSdkOperationNames[operation.operationId];
       if (!sdkName) {
+        // Fail closed: adding a Platform endpoint to SDKs is a public surface
+        // decision, so every operation must be explicitly mapped above.
         throw new Error(
           `Platform operation ${method.toUpperCase()} ${path} with operationId ${operation.operationId || '<missing>'} has no SDK mapping in platformSdkOperationNames`,
         );

--- a/tests/post_transform_smoke.test.js
+++ b/tests/post_transform_smoke.test.js
@@ -64,4 +64,32 @@ describe('Post-transformation smoke tests', () => {
 
     expect(hasUnexpected).toBe(false);
   });
+
+  test('platform endpoints have expected SDK mappings', () => {
+    expect(spec.paths?.['/api/search']?.post).toMatchObject({
+      operationId: 'platform-search',
+      'x-speakeasy-group': 'platform.search',
+      'x-speakeasy-name-override': 'query',
+    });
+    expect(spec.paths?.['/api/tools']?.get).toMatchObject({
+      operationId: 'platform-tools-list',
+      'x-speakeasy-group': 'platform.tools',
+      'x-speakeasy-name-override': 'list',
+    });
+  });
+
+  test('platform experimental metadata does not publish runtime gates', () => {
+    for (const operation of [
+      spec.paths?.['/api/search']?.post,
+      spec.paths?.['/api/tools']?.get,
+    ]) {
+      expect(operation?.['x-glean-experimental']).toMatchObject({
+        id: expect.any(String),
+        introduced: expect.any(String),
+      });
+      expect(operation?.['x-glean-experimental']).not.toHaveProperty(
+        'gated-by',
+      );
+    }
+  });
 });

--- a/tests/post_transform_smoke.test.js
+++ b/tests/post_transform_smoke.test.js
@@ -55,10 +55,12 @@ describe('Post-transformation smoke tests', () => {
 
     expect(paths.length).toBeGreaterThan(0);
 
-    const allowedPrefixes = ['/rest/api/v1', '/api/index/v1'];
-    const hasUnexpected = paths.some(
-      (p) => !allowedPrefixes.some((prefix) => p.startsWith(prefix)),
-    );
+    const hasAllowedPrefix = (path) =>
+      path.startsWith('/rest/api/v1') ||
+      path.startsWith('/api/index/v1') ||
+      path === '/api' ||
+      path.startsWith('/api/');
+    const hasUnexpected = paths.some((path) => !hasAllowedPrefix(path));
 
     expect(hasUnexpected).toBe(false);
   });

--- a/tests/source-spec-transformer.test.js
+++ b/tests/source-spec-transformer.test.js
@@ -335,6 +335,33 @@ describe('OpenAPI YAML Transformer', () => {
     );
   });
 
+  test('transformPlatformSpec preserves other security schemes when normalizing ApiToken', () => {
+    const spec = {
+      components: {
+        securitySchemes: {
+          ApiToken: { type: 'http', scheme: 'bearer' },
+          ExtraAuth: { type: 'apiKey', in: 'header', name: 'X-Extra-Auth' },
+        },
+      },
+      security: [{ ApiToken: [], ExtraAuth: ['admin'] }],
+      paths: {
+        '/search': {
+          post: {
+            operationId: 'platform-search',
+            security: [{ ApiToken: [], ExtraAuth: ['search'] }],
+          },
+        },
+      },
+    };
+
+    transformPlatformSpec(spec);
+
+    expect(spec.security).toEqual([{ APIToken: [], ExtraAuth: ['admin'] }]);
+    expect(spec.paths['/search'].post.security).toEqual([
+      { APIToken: [], ExtraAuth: ['search'] },
+    ]);
+  });
+
   test('transformPlatformSpec rejects schema names that collide after prefixing', () => {
     expect(() =>
       transformPlatformSpec({

--- a/tests/source-spec-transformer.test.js
+++ b/tests/source-spec-transformer.test.js
@@ -193,6 +193,16 @@ describe('OpenAPI YAML Transformer', () => {
         },
         schemas: {
           SearchRequest: { type: 'object' },
+          ToolsListResponse: {
+            type: 'object',
+            properties: {
+              tools: {
+                type: 'array',
+                items: { $ref: '#/components/schemas/Tool' },
+              },
+            },
+          },
+          Tool: { type: 'object' },
           Result: {
             type: 'object',
             properties: {
@@ -230,6 +240,24 @@ describe('OpenAPI YAML Transformer', () => {
             },
           },
         },
+        '/tools': {
+          get: {
+            tags: ['Tools'],
+            operationId: 'platform-tools-list',
+            responses: {
+              200: {
+                description: 'ok',
+                content: {
+                  'application/json': {
+                    schema: {
+                      $ref: '#/components/schemas/ToolsListResponse',
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
       },
     };
 
@@ -241,11 +269,14 @@ describe('OpenAPI YAML Transformer', () => {
       'https://{instance}-be.glean.com',
     );
     expect(transformedSpec.paths).toHaveProperty('/api/search');
+    expect(transformedSpec.paths).toHaveProperty('/api/tools');
 
     expect(Object.keys(transformedSpec.components.schemas).sort()).toEqual([
       'PlatformExisting',
       'PlatformResult',
       'PlatformSearchRequest',
+      'PlatformTool',
+      'PlatformToolsListResponse',
     ]);
     expect(
       transformedSpec.paths['/api/search'].post.requestBody.content[
@@ -265,6 +296,19 @@ describe('OpenAPI YAML Transformer', () => {
     expect(transformedSpec.paths['/api/search'].post).toMatchObject({
       'x-speakeasy-group': 'platform.search',
       'x-speakeasy-name-override': 'query',
+    });
+    expect(
+      transformedSpec.paths['/api/tools'].get.responses[200].content[
+        'application/json'
+      ].schema.$ref,
+    ).toBe('#/components/schemas/PlatformToolsListResponse');
+    expect(
+      transformedSpec.components.schemas.PlatformToolsListResponse.properties
+        .tools.items.$ref,
+    ).toBe('#/components/schemas/PlatformTool');
+    expect(transformedSpec.paths['/api/tools'].get).toMatchObject({
+      'x-speakeasy-group': 'platform.tools',
+      'x-speakeasy-name-override': 'list',
     });
     expect(transformedSpec.security).toEqual([{ APIToken: [] }]);
     expect(transformedSpec.components.securitySchemes).toHaveProperty(

--- a/tests/source-spec-transformer.test.js
+++ b/tests/source-spec-transformer.test.js
@@ -10,6 +10,7 @@ import {
   transformServerVariables,
   transformEnumDescriptions,
   transformGleanDeprecated,
+  transformPlatformSpec,
   injectOpenApiCommitSha,
 } from '../src/source-spec-transformer.js';
 
@@ -169,6 +170,182 @@ describe('OpenAPI YAML Transformer', () => {
       'IndexingShortcut',
     );
     expect(transformedSpec.components.schemas).not.toHaveProperty('Shortcut');
+  });
+
+  test('transforms platform components, paths, and SDK names by convention', () => {
+    const platformSpec = {
+      openapi: '3.0.0',
+      info: { title: 'Glean Platform API', version: '2026-04-01' },
+      servers: [{ url: 'https://{domain}-be.glean.com/api' }],
+      components: {
+        securitySchemes: {
+          ApiToken: { type: 'http', scheme: 'bearer' },
+        },
+        responses: {
+          BadRequest: {
+            description: 'bad request',
+            content: {
+              'application/problem+json': {
+                schema: { $ref: '#/components/schemas/Result' },
+              },
+            },
+          },
+        },
+        schemas: {
+          SearchRequest: { type: 'object' },
+          Result: {
+            type: 'object',
+            properties: {
+              related: { $ref: '#/components/schemas/SearchRequest' },
+            },
+          },
+          PlatformExisting: { type: 'object' },
+        },
+      },
+      security: [{ ApiToken: [] }],
+      paths: {
+        '/search': {
+          post: {
+            tags: ['Search'],
+            operationId: 'platform-search-query',
+            requestBody: {
+              content: {
+                'application/json': {
+                  schema: { $ref: '#/components/schemas/SearchRequest' },
+                },
+              },
+            },
+            responses: {
+              200: {
+                description: 'ok',
+                content: {
+                  'application/json': {
+                    schema: { $ref: '#/components/schemas/Result' },
+                  },
+                },
+              },
+              400: {
+                $ref: '#/components/responses/BadRequest',
+              },
+            },
+          },
+        },
+        '/tools': {
+          get: {
+            tags: ['Tools'],
+            operationId: 'platform-tools-list',
+            responses: { 200: { description: 'ok' } },
+          },
+        },
+        '/custom': {
+          get: {
+            tags: ['Custom'],
+            operationId: 'platform-custom-list',
+            'x-speakeasy-group': 'platform.custom-overridden',
+            'x-speakeasy-name-override': 'customList',
+            responses: { 200: { description: 'ok' } },
+          },
+        },
+      },
+    };
+
+    const transformedSpec = yaml.load(
+      transform(yaml.dump(platformSpec), 'platform.yaml'),
+    );
+
+    expect(transformedSpec.servers[0].url).toBe(
+      'https://{instance}-be.glean.com',
+    );
+    expect(transformedSpec.paths).toHaveProperty('/api/search');
+    expect(transformedSpec.paths).toHaveProperty('/api/tools');
+
+    expect(Object.keys(transformedSpec.components.schemas).sort()).toEqual([
+      'PlatformExisting',
+      'PlatformResult',
+      'PlatformSearchRequest',
+    ]);
+    expect(
+      transformedSpec.paths['/api/search'].post.requestBody.content[
+        'application/json'
+      ].schema.$ref,
+    ).toBe('#/components/schemas/PlatformSearchRequest');
+    expect(
+      transformedSpec.components.schemas.PlatformResult.properties.related.$ref,
+    ).toBe('#/components/schemas/PlatformSearchRequest');
+    expect(transformedSpec.components.responses).toHaveProperty(
+      'PlatformBadRequest',
+    );
+    expect(transformedSpec.paths['/api/search'].post.responses[400].$ref).toBe(
+      '#/components/responses/PlatformBadRequest',
+    );
+
+    expect(transformedSpec.paths['/api/search'].post).toMatchObject({
+      'x-speakeasy-group': 'platform.search',
+      'x-speakeasy-name-override': 'query',
+    });
+    expect(transformedSpec.paths['/api/tools'].get).toMatchObject({
+      'x-speakeasy-group': 'platform.tools',
+      'x-speakeasy-name-override': 'list',
+    });
+    expect(transformedSpec.paths['/api/custom'].get).toMatchObject({
+      'x-speakeasy-group': 'platform.custom-overridden',
+      'x-speakeasy-name-override': 'customList',
+    });
+    expect(transformedSpec.security).toEqual([{ APIToken: [] }]);
+    expect(transformedSpec.components.securitySchemes).toHaveProperty(
+      'APIToken',
+    );
+    expect(transformedSpec.components.securitySchemes).not.toHaveProperty(
+      'ApiToken',
+    );
+  });
+
+  test('transformPlatformSpec rejects operationIds outside the platform convention', () => {
+    expect(() =>
+      transformPlatformSpec({
+        paths: {
+          '/search': {
+            post: {
+              operationId: 'platformSearch',
+            },
+          },
+        },
+      }),
+    ).toThrow(
+      'Platform operation POST /search must use operationId platform-<family>-<method>; got platformSearch',
+    );
+  });
+
+  test('transformPlatformSpec rejects schema names that collide after prefixing', () => {
+    expect(() =>
+      transformPlatformSpec({
+        components: {
+          schemas: {
+            SearchRequest: { type: 'object' },
+            PlatformSearchRequest: { type: 'object' },
+          },
+        },
+        paths: {},
+      }),
+    ).toThrow(
+      'Platform schema SearchRequest cannot be renamed to PlatformSearchRequest because PlatformSearchRequest already exists',
+    );
+  });
+
+  test('transformPlatformSpec rejects response names that collide after prefixing', () => {
+    expect(() =>
+      transformPlatformSpec({
+        components: {
+          responses: {
+            BadRequest: { description: 'bad request' },
+            PlatformBadRequest: { description: 'platform bad request' },
+          },
+        },
+        paths: {},
+      }),
+    ).toThrow(
+      'Platform response BadRequest cannot be renamed to PlatformBadRequest because PlatformBadRequest already exists',
+    );
   });
 
   ['client_rest.yaml', 'indexing.yaml'].forEach((filename) => {

--- a/tests/source-spec-transformer.test.js
+++ b/tests/source-spec-transformer.test.js
@@ -172,7 +172,7 @@ describe('OpenAPI YAML Transformer', () => {
     expect(transformedSpec.components.schemas).not.toHaveProperty('Shortcut');
   });
 
-  test('transforms platform components, paths, and SDK names by convention', () => {
+  test('transforms platform components, paths, and SDK names from explicit mappings', () => {
     const platformSpec = {
       openapi: '3.0.0',
       info: { title: 'Glean Platform API', version: '2026-04-01' },
@@ -207,7 +207,7 @@ describe('OpenAPI YAML Transformer', () => {
         '/search': {
           post: {
             tags: ['Search'],
-            operationId: 'platform-search-query',
+            operationId: 'platform-search',
             requestBody: {
               content: {
                 'application/json': {
@@ -230,22 +230,6 @@ describe('OpenAPI YAML Transformer', () => {
             },
           },
         },
-        '/tools': {
-          get: {
-            tags: ['Tools'],
-            operationId: 'platform-tools-list',
-            responses: { 200: { description: 'ok' } },
-          },
-        },
-        '/custom': {
-          get: {
-            tags: ['Custom'],
-            operationId: 'platform-custom-list',
-            'x-speakeasy-group': 'platform.custom-overridden',
-            'x-speakeasy-name-override': 'customList',
-            responses: { 200: { description: 'ok' } },
-          },
-        },
       },
     };
 
@@ -257,7 +241,6 @@ describe('OpenAPI YAML Transformer', () => {
       'https://{instance}-be.glean.com',
     );
     expect(transformedSpec.paths).toHaveProperty('/api/search');
-    expect(transformedSpec.paths).toHaveProperty('/api/tools');
 
     expect(Object.keys(transformedSpec.components.schemas).sort()).toEqual([
       'PlatformExisting',
@@ -283,14 +266,6 @@ describe('OpenAPI YAML Transformer', () => {
       'x-speakeasy-group': 'platform.search',
       'x-speakeasy-name-override': 'query',
     });
-    expect(transformedSpec.paths['/api/tools'].get).toMatchObject({
-      'x-speakeasy-group': 'platform.tools',
-      'x-speakeasy-name-override': 'list',
-    });
-    expect(transformedSpec.paths['/api/custom'].get).toMatchObject({
-      'x-speakeasy-group': 'platform.custom-overridden',
-      'x-speakeasy-name-override': 'customList',
-    });
     expect(transformedSpec.security).toEqual([{ APIToken: [] }]);
     expect(transformedSpec.components.securitySchemes).toHaveProperty(
       'APIToken',
@@ -300,19 +275,19 @@ describe('OpenAPI YAML Transformer', () => {
     );
   });
 
-  test('transformPlatformSpec rejects operationIds outside the platform convention', () => {
+  test('transformPlatformSpec rejects operations without SDK mappings', () => {
     expect(() =>
       transformPlatformSpec({
         paths: {
-          '/search': {
+          '/tools': {
             post: {
-              operationId: 'platformSearch',
+              operationId: 'platform-tools',
             },
           },
         },
       }),
     ).toThrow(
-      'Platform operation POST /search must use operationId platform-<family>-<method>; got platformSearch',
+      'Platform operation POST /tools with operationId platform-tools has no SDK mapping in platformSdkOperationNames',
     );
   });
 


### PR DESCRIPTION
## Why
The new Platform API surface needs to publish into generated SDKs without leaking SDK naming policy into scio's source OpenAPI specs. Scio's `operationId` drives Go server codegen and should remain a stable server/API identity; the SDK publishing repo should own the public SDK namespace and method shape.

The SDK repo also merges several OpenAPI specs together, so Platform schemas and shared responses need deterministic namespacing to avoid collisions with the existing REST and indexing contracts. Public SDK inputs also must not expose scio runtime config details such as feature flag names.

## What Changes
This PR adds Platform API as an SDK generation input and introduces a Platform transform that explicitly maps scio operation IDs to SDK names. The current mappings are `platform-search -> platform.search.query` and `platform-tools-list -> platform.tools.list`, which generate `client.platform.search.query(...)` and `client.platform.tools.list(...)` while preserving source operation IDs.

Platform schemas and shared responses are prefixed, Platform auth is normalized to the existing `APIToken` scheme, and unmapped Platform operations or namespace collisions fail during transform instead of silently producing a broken merged spec. There is no Platform overlay file in this PR; the default path is transform-driven and the SDK surface is reviewed through the explicit mapping.

The regenerated Platform public specs preserve `x-glean-experimental.id` and `introduced` for both endpoints but no longer include `x-glean-experimental.gated-by`. That stripping happens at the scio Redocly public-export boundary before these SDK artifacts are generated.

## Cross-Repo Stack
1. scio source contract and private metadata stripping: https://github.com/askscio/scio/pull/237884
2. Redocly bundle publication: https://github.com/askscio/openapi-redocly/pull/15
3. SDK spec transform and explicit SDK mapping: https://github.com/gleanwork/open-api/pull/102 (this PR)

Merge order should follow the stack above so this repo consumes the Platform bundle produced by the previous steps.

## Test Plan
- `pnpm run transform:source_specs`
- `speakeasy run -s glean-api-specs --skip-upload-spec`
- `pnpm vitest run tests/source-spec-transformer.test.js tests/post_transform_smoke.test.js`
- Verified `gated-by` is absent from `source_specs/platform.yaml`, `generated_specs/platform.yaml`, and `overlayed_specs/glean-merged-spec.yaml`, while experimental `id` and `introduced` remain for `/api/search` and `/api/tools`.
- Verified transformed and merged specs contain `/api/search` as `platform.search.query` and `/api/tools` as `platform.tools.list`, with Platform-prefixed models and responses.
