### PR TITLE
[NI][SDK] Read Platform SDK names from source specs

### DIFF
--- a/generated_specs/admin_rest.yaml
+++ b/generated_specs/admin_rest.yaml
@@ -2,14 +2,14 @@ openapi: 3.0.0
 info:
   version: 0.9.0
   title: Glean Rest Admin API
-  x-source-commit-sha: 3182bb50511105a81bd8a246793f334a96d41617
+  x-source-commit-sha: 23062285513fa182a81205b4400aa16b0e57a395
   description: |
     # Introduction
     These are all the APIs exposed to the users through an auth token to utilize certain admin
     operations. These offer limited exposure to the admin APIs through rest endpoints.
   x-logo:
     url: https://app.glean.com/images/glean-text2.svg
-  x-open-api-commit-sha: eb3e8be368aaa09d127d325de8413064635e76dd
+  x-open-api-commit-sha: ca2d2acb19116a2f72cbdddaeefc22d18588ae17
 servers:
   - url: https://{instance}-be.glean.com
     variables:

--- a/generated_specs/client_rest.yaml
+++ b/generated_specs/client_rest.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.0
 info:
   version: 0.9.0
   title: Glean Client API
-  x-source-commit-sha: 3182bb50511105a81bd8a246793f334a96d41617
+  x-source-commit-sha: 23062285513fa182a81205b4400aa16b0e57a395
   description: |
     # Introduction
     These are the public APIs to enable implementing a custom client interface to the Glean system.
@@ -31,7 +31,7 @@ info:
     Determine the host you need to connect to. This will be the URL of the backend for your Glean deployment, for example, customer-be.glean.com
   x-logo:
     url: https://app.glean.com/images/glean-text2.svg
-  x-open-api-commit-sha: eb3e8be368aaa09d127d325de8413064635e76dd
+  x-open-api-commit-sha: ca2d2acb19116a2f72cbdddaeefc22d18588ae17
 servers:
   - url: https://{instance}-be.glean.com
     variables:

--- a/generated_specs/indexing.yaml
+++ b/generated_specs/indexing.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.0
 info:
   version: 0.9.0
   title: Glean Indexing API
-  x-source-commit-sha: 3182bb50511105a81bd8a246793f334a96d41617
+  x-source-commit-sha: 23062285513fa182a81205b4400aa16b0e57a395
   description: |
     # Introduction
     In addition to the data sources that Glean has built-in support for, Glean also provides a REST API that enables customers to put arbitrary content in the search index. This is useful, for example, for doing permissions-aware search over content in internal tools that reside on-prem as well as for searching over applications that Glean does not currently support first class. In addition these APIs allow the customer to push organization data (people info, organization structure etc) into Glean.
@@ -12,7 +12,7 @@ info:
     with a 6-month sunset period for anything that requires developers to adopt the new versions.
   x-logo:
     url: https://app.glean.com/images/glean-text2.svg
-  x-open-api-commit-sha: eb3e8be368aaa09d127d325de8413064635e76dd
+  x-open-api-commit-sha: ca2d2acb19116a2f72cbdddaeefc22d18588ae17
 servers:
   - url: https://{instance}-be.glean.com
     variables:

--- a/generated_specs/platform.yaml
+++ b/generated_specs/platform.yaml
@@ -3,6 +3,7 @@ info:
   version: "2026-04-01"
   title: Glean Platform API
   x-source-commit-sha: __SCIO_COMMIT_SHA__
+  x-open-api-commit-sha: ca2d2acb19116a2f72cbdddaeefc22d18588ae17
 servers:
   - url: https://{instance}-be.glean.com
     variables:

--- a/overlayed_specs/glean-merged-spec.yaml
+++ b/overlayed_specs/glean-merged-spec.yaml
@@ -2,7 +2,8 @@ openapi: 3.0.0
 info:
   version: "0.9.0"
   title: Glean API
-  x-source-commit-sha: 3182bb50511105a81bd8a246793f334a96d41617
+  x-source-commit-sha: 23062285513fa182a81205b4400aa16b0e57a395
+  x-open-api-commit-sha: ca2d2acb19116a2f72cbdddaeefc22d18588ae17
   description: |
     # Introduction
     In addition to the data sources that Glean has built-in support for, Glean also provides a REST API that enables customers to put arbitrary content in the search index. This is useful, for example, for doing permissions-aware search over content in internal tools that reside on-prem as well as for searching over applications that Glean does not currently support first class. In addition these APIs allow the customer to push organization data (people info, organization structure etc) into Glean.
@@ -22,7 +23,6 @@ info:
     These API clients provide type-safe, idiomatic interfaces for working with Glean IndexingAPIs in your language of choice.
   x-logo:
     url: https://app.glean.com/images/glean-text2.svg
-  x-open-api-commit-sha: eb3e8be368aaa09d127d325de8413064635e76dd
   x-speakeasy-name: 'Glean API'
 servers:
   - url: https://{instance}-be.glean.com

--- a/source_specs/platform.yaml
+++ b/source_specs/platform.yaml
@@ -21,6 +21,9 @@ paths:
         List tools available to the authenticated user, optionally filtered by tool name.
       operationId: platform-tools-list
       x-visibility: Public
+      x-glean-sdk:
+        group: platform.tools
+        method: list
       x-glean-experimental:
         id: 3cb43a04-ad52-4c25-be62-3ce1daffd513
         introduced: '2026-05-06'
@@ -67,6 +70,9 @@ paths:
         Execute a search query and retrieve ranked results. This is the data retrieval variant of the search API and returns only results and pagination state.
       operationId: platform-search
       x-visibility: Public
+      x-glean-sdk:
+        group: platform.search
+        method: query
       x-glean-experimental:
         id: 5ab612fc-ed50-4419-bec3-e5fe83934653
         introduced: '2026-04-08'

--- a/src/source-spec-transformer.js
+++ b/src/source-spec-transformer.js
@@ -68,14 +68,8 @@ const httpMethods = new Set([
   'trace',
 ]);
 
-// This map is the published Platform SDK contract. Each key is a scio
-// operationId; each value becomes the generated SDK method chain:
-// glean.platform.<group>.<method>(...). Adding, removing, or changing an entry
-// changes the public SDK surface and should be reviewed as such.
-const platformSdkOperationNames = {
-  'platform-search': { group: 'search', method: 'query' },
-  'platform-tools-list': { group: 'tools', method: 'list' },
-};
+const platformSdkGroupPattern = /^platform(\.[a-z][a-z0-9]*)+$/;
+const platformSdkMethodPattern = /^[a-z][A-Za-z0-9]*$/;
 
 function rewriteRefs(obj, refMap) {
   if (!obj || typeof obj !== 'object') return;
@@ -222,6 +216,7 @@ function transformPlatformOperations(spec) {
     return;
   }
 
+  const sdkMethods = new Map();
   for (const [path, pathItem] of Object.entries(spec.paths)) {
     if (!pathItem || typeof pathItem !== 'object') continue;
 
@@ -234,21 +229,43 @@ function transformPlatformOperations(spec) {
         continue;
       }
 
-      const sdkName = platformSdkOperationNames[operation.operationId];
-      if (!sdkName) {
-        // Fail closed: adding a Platform endpoint to SDKs is a public surface
-        // decision, so every operation must be explicitly mapped above.
+      const location = `${method.toUpperCase()} ${path} with operationId ${operation.operationId || '<missing>'}`;
+      const sdk = operation['x-glean-sdk'];
+      if (!sdk || typeof sdk !== 'object' || Array.isArray(sdk)) {
         throw new Error(
-          `Platform operation ${method.toUpperCase()} ${path} with operationId ${operation.operationId || '<missing>'} has no SDK mapping in platformSdkOperationNames`,
+          `Platform operation ${location} must declare x-glean-sdk.group and x-glean-sdk.method`,
         );
       }
 
-      if (!operation['x-speakeasy-group']) {
-        operation['x-speakeasy-group'] = `platform.${sdkName.group}`;
+      if (
+        typeof sdk.group !== 'string' ||
+        !platformSdkGroupPattern.test(sdk.group)
+      ) {
+        throw new Error(
+          `Platform operation ${location} has invalid x-glean-sdk.group ${JSON.stringify(sdk.group)}; expected platform.<lowercase identifiers>`,
+        );
       }
-      if (!operation['x-speakeasy-name-override']) {
-        operation['x-speakeasy-name-override'] = sdkName.method;
+
+      if (
+        typeof sdk.method !== 'string' ||
+        !platformSdkMethodPattern.test(sdk.method)
+      ) {
+        throw new Error(
+          `Platform operation ${location} has invalid x-glean-sdk.method ${JSON.stringify(sdk.method)}; expected lower-camel identifier`,
+        );
       }
+
+      const sdkMethodKey = `${sdk.group}.${sdk.method}`;
+      if (sdkMethods.has(sdkMethodKey)) {
+        throw new Error(
+          `Platform operation ${location} declares duplicate SDK method ${sdkMethodKey}; already used by ${sdkMethods.get(sdkMethodKey)}`,
+        );
+      }
+      sdkMethods.set(sdkMethodKey, location);
+
+      operation['x-speakeasy-group'] = sdk.group;
+      operation['x-speakeasy-name-override'] = sdk.method;
+      delete operation['x-glean-sdk'];
     }
   }
 }

--- a/tests/source-spec-transformer.test.js
+++ b/tests/source-spec-transformer.test.js
@@ -172,7 +172,7 @@ describe('OpenAPI YAML Transformer', () => {
     expect(transformedSpec.components.schemas).not.toHaveProperty('Shortcut');
   });
 
-  test('transforms platform components, paths, and SDK names from explicit mappings', () => {
+  test('transforms platform components, paths, and SDK names from x-glean-sdk metadata', () => {
     const platformSpec = {
       openapi: '3.0.0',
       info: { title: 'Glean Platform API', version: '2026-04-01' },
@@ -218,6 +218,10 @@ describe('OpenAPI YAML Transformer', () => {
           post: {
             tags: ['Search'],
             operationId: 'platform-search',
+            'x-glean-sdk': {
+              group: 'platform.search',
+              method: 'query',
+            },
             requestBody: {
               content: {
                 'application/json': {
@@ -244,6 +248,10 @@ describe('OpenAPI YAML Transformer', () => {
           get: {
             tags: ['Tools'],
             operationId: 'platform-tools-list',
+            'x-glean-sdk': {
+              group: 'platform.tools',
+              method: 'list',
+            },
             responses: {
               200: {
                 description: 'ok',
@@ -297,6 +305,9 @@ describe('OpenAPI YAML Transformer', () => {
       'x-speakeasy-group': 'platform.search',
       'x-speakeasy-name-override': 'query',
     });
+    expect(transformedSpec.paths['/api/search'].post).not.toHaveProperty(
+      'x-glean-sdk',
+    );
     expect(
       transformedSpec.paths['/api/tools'].get.responses[200].content[
         'application/json'
@@ -310,6 +321,9 @@ describe('OpenAPI YAML Transformer', () => {
       'x-speakeasy-group': 'platform.tools',
       'x-speakeasy-name-override': 'list',
     });
+    expect(transformedSpec.paths['/api/tools'].get).not.toHaveProperty(
+      'x-glean-sdk',
+    );
     expect(transformedSpec.security).toEqual([{ APIToken: [] }]);
     expect(transformedSpec.components.securitySchemes).toHaveProperty(
       'APIToken',
@@ -319,7 +333,7 @@ describe('OpenAPI YAML Transformer', () => {
     );
   });
 
-  test('transformPlatformSpec rejects operations without SDK mappings', () => {
+  test('transformPlatformSpec rejects operations without x-glean-sdk metadata', () => {
     expect(() =>
       transformPlatformSpec({
         paths: {
@@ -331,7 +345,7 @@ describe('OpenAPI YAML Transformer', () => {
         },
       }),
     ).toThrow(
-      'Platform operation POST /tools with operationId platform-tools has no SDK mapping in platformSdkOperationNames',
+      'Platform operation POST /tools with operationId platform-tools must declare x-glean-sdk.group and x-glean-sdk.method',
     );
   });
 
@@ -348,6 +362,10 @@ describe('OpenAPI YAML Transformer', () => {
         '/search': {
           post: {
             operationId: 'platform-search',
+            'x-glean-sdk': {
+              group: 'platform.search',
+              method: 'query',
+            },
             security: [{ ApiToken: [], ExtraAuth: ['search'] }],
           },
         },
@@ -391,6 +409,55 @@ describe('OpenAPI YAML Transformer', () => {
       }),
     ).toThrow(
       'Platform response BadRequest cannot be renamed to PlatformBadRequest because PlatformBadRequest already exists',
+    );
+  });
+
+  test('transformPlatformSpec rejects invalid SDK metadata', () => {
+    expect(() =>
+      transformPlatformSpec({
+        paths: {
+          '/search': {
+            post: {
+              operationId: 'platform-search',
+              'x-glean-sdk': {
+                group: 'search',
+                method: 'Query',
+              },
+            },
+          },
+        },
+      }),
+    ).toThrow(
+      'Platform operation POST /search with operationId platform-search has invalid x-glean-sdk.group "search"; expected platform.<lowercase identifiers>',
+    );
+  });
+
+  test('transformPlatformSpec rejects duplicate SDK methods', () => {
+    expect(() =>
+      transformPlatformSpec({
+        paths: {
+          '/search': {
+            post: {
+              operationId: 'platform-search',
+              'x-glean-sdk': {
+                group: 'platform.search',
+                method: 'query',
+              },
+            },
+          },
+          '/query': {
+            post: {
+              operationId: 'platform-query',
+              'x-glean-sdk': {
+                group: 'platform.search',
+                method: 'query',
+              },
+            },
+          },
+        },
+      }),
+    ).toThrow(
+      'Platform operation POST /query with operationId platform-query declares duplicate SDK method platform.search.query; already used by POST /search with operationId platform-search',
     );
   });
 


### PR DESCRIPTION
**Internal Description for reviewers**:
  Platform SDK generation currently hardcodes public method names in open-api, so every source endpoint addition requires a second manual mapping update in the SDK publishing repo. This PR makes the Platform transform read scio-owned `x-glean-sdk` metadata, validates format and uniqueness before emitting Speakeasy names, and updates generated specs from the metadata-driven local rehearsal.

**PR Stack** (`cfreeman/api-overhaul-pr19c-platform-speakeasy`):
- #102
- This PR

Companion scio PR: https://github.com/askscio/scio/pull/238861

**Context/Jira (Mandatory if external)**:
N/A

**Test plan**:
- [x] `npm test -- tests/source-spec-transformer.test.js`
- [x] Local bundle/transform/Speakeasy SDK generation rehearsal completed successfully with the companion scio metadata source.
- [ ] _Need review from all reviewers (default: 1)_
---

_Release Notes ([go/relnotesfaq](https://go/relnotesfaq))_

**Change Categories (mandatory - check all that apply)**
* **Internal (This PR will not be included in the external release notes)**
  - [x] Flag-gated development/Internal fix
* **External (Choose one if applicable. A detailed external description is mandatory)**
  - [ ] Bug Fixes/Enhancements
  - [ ] Security or Permissions related change
  - [ ] Feature launch
  - [ ] UI change
  - [ ] 3rd party LLM integration change
  - [ ] External API breaking change
  - [ ] Scrubbed logs change
* **Platform (Choose one if applicable. Choose at least one other category from Internal or External)**
  - [ ] AWS only change
  - [ ] Azure only change
  - [ ] GCP only change

- [ ] Document Updates Needed

_(DO NOT include confidential details. Should be at least 40 characters long.)_
**External description for customers**:
No customer-visible behavior change; this updates internal generation metadata for an unreleased Platform API SDK surface.