### PR TITLE
Add smoke test for Custom Metadata SDK grouping

### DIFF
--- a/tests/post_transform_smoke.test.js
+++ b/tests/post_transform_smoke.test.js
@@ -67,4 +67,45 @@ describe('Post-transformation smoke tests', () => {
 
     expect(hasUnexpected).toBe(false);
   });
+
+  test('Custom Metadata operations land under indexing.customMetadata SDK group', () => {
+    const customMetadataOps = [
+      {
+        path: '/rest/api/index/document/{docId}/custom-metadata/{groupName}',
+        method: 'put',
+        nameOverride: 'upsert',
+      },
+      {
+        path: '/rest/api/index/document/{docId}/custom-metadata/{groupName}',
+        method: 'delete',
+        nameOverride: 'delete',
+      },
+      {
+        path: '/rest/api/index/custom-metadata/schema/{groupName}',
+        method: 'get',
+        nameOverride: 'getSchema',
+      },
+      {
+        path: '/rest/api/index/custom-metadata/schema/{groupName}',
+        method: 'put',
+        nameOverride: 'upsertSchema',
+      },
+      {
+        path: '/rest/api/index/custom-metadata/schema/{groupName}',
+        method: 'delete',
+        nameOverride: 'deleteSchema',
+      },
+    ];
+
+    for (const { path, method, nameOverride } of customMetadataOps) {
+      const operation = spec.paths?.[path]?.[method];
+
+      expect(
+        operation,
+        `expected operation ${method.toUpperCase()} ${path}`,
+      ).toBeDefined();
+      expect(operation['x-speakeasy-group']).toBe('indexing.customMetadata');
+      expect(operation['x-speakeasy-name-override']).toBe(nameOverride);
+    }
+  });
 });

--- a/tests/post_transform_smoke.test.js
+++ b/tests/post_transform_smoke.test.js
@@ -108,4 +108,26 @@ describe('Post-transformation smoke tests', () => {
       expect(operation['x-speakeasy-name-override']).toBe(nameOverride);
     }
   });
+
+  test('CustomMetadataSchema is narrowed via CustomMetadataPropertyDefinition', () => {
+    const schemas = spec.components?.schemas ?? {};
+
+    const propertyDef = schemas.CustomMetadataPropertyDefinition;
+    expect(
+      propertyDef,
+      'CustomMetadataPropertyDefinition schema',
+    ).toBeDefined();
+    expect(Object.keys(propertyDef.properties ?? {}).sort()).toEqual([
+      'name',
+      'propertyType',
+      'skipIndexing',
+    ]);
+    expect(propertyDef.required).toEqual(['name', 'propertyType']);
+
+    const customMetadataSchema = schemas.CustomMetadataSchema;
+    expect(customMetadataSchema, 'CustomMetadataSchema').toBeDefined();
+    expect(customMetadataSchema.properties?.metadataKeys?.items?.$ref).toBe(
+      '#/components/schemas/CustomMetadataPropertyDefinition',
+    );
+  });
 });


### PR DESCRIPTION
## Summary

Adds an assertion in `tests/post_transform_smoke.test.js` that the five Custom Metadata operations land under `x-speakeasy-group: indexing.customMetadata` with the expected `x-speakeasy-name-override` values (`upsert`, `delete`, `getSchema`, `upsertSchema`, `deleteSchema`).

This was originally part of #101 but removed before merge because the regen pipeline hadn't yet committed a fresh `overlayed_specs/glean-merged-spec.yaml`. With that file now on `main`, the assertion is meaningful and protects against future overlay reorders or upstream schema renames silently breaking SDK grouping.

## Test plan

- [x] `pnpm test` — all 64 tests pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)