### PR TITLE
[OpenAPI] Activate Platform API SDK spec input

### DIFF
--- a/.speakeasy/workflow.yaml
+++ b/.speakeasy/workflow.yaml
@@ -3,6 +3,7 @@ speakeasyVersion: latest
 sources:
     glean-api-specs:
         inputs:
+            - location: generated_specs/platform.yaml
             - location: generated_specs/client_rest.yaml
             - location: generated_specs/indexing.yaml
             - location: generated_specs/admin_rest.yaml

--- a/tests/post_transform_smoke.test.js
+++ b/tests/post_transform_smoke.test.js
@@ -8,8 +8,14 @@ const SPEC_PATH = path.join(
   'overlayed_specs',
   'glean-merged-spec.yaml',
 );
+const PLATFORM_SPEC_PATH = path.join(
+  process.cwd(),
+  'generated_specs',
+  'platform.yaml',
+);
 
 const loadSpec = () => yaml.load(fs.readFileSync(SPEC_PATH, 'utf8'));
+const hasGeneratedPlatformSpec = () => fs.existsSync(PLATFORM_SPEC_PATH);
 
 describe('Post-transformation smoke tests', () => {
   let spec;
@@ -48,6 +54,20 @@ describe('Post-transformation smoke tests', () => {
 
   test('overlay applied title', () => {
     expect(spec.info?.title).toBe('Glean API');
+  });
+
+  test('merged spec keeps existing version and source traceability', () => {
+    expect(spec.info?.version).toBe('0.9.0');
+    expect(spec.info?.['x-source-commit-sha']).toBeDefined();
+    expect(spec.info?.['x-open-api-commit-sha']).toBeDefined();
+  });
+
+  test('existing merged tag groups are preserved', () => {
+    const tagGroupNames = (spec['x-tagGroups'] ?? []).map(({ name }) => name);
+
+    expect(tagGroupNames).toContain('Search & Generative AI');
+    expect(tagGroupNames).toContain('Connected Content');
+    expect(tagGroupNames).not.toEqual(['AI', 'Data Retrieval']);
   });
 
   test('all paths use expected base prefixes', () => {
@@ -129,5 +149,112 @@ describe('Post-transformation smoke tests', () => {
     expect(customMetadataSchema.properties?.metadataKeys?.items?.$ref).toBe(
       '#/components/schemas/CustomMetadataPropertyDefinition',
     );
+  });
+
+  test('Platform operations land under expected SDK groups', () => {
+    if (!hasGeneratedPlatformSpec()) {
+      return;
+    }
+
+    const platformOps = [
+      {
+        path: '/api/documents/batch',
+        method: 'post',
+        group: 'platform.documents',
+        nameOverride: 'batch',
+      },
+      {
+        path: '/api/documents/{id}/permissions',
+        method: 'get',
+        group: 'platform.documents',
+        nameOverride: 'getPermissions',
+      },
+      {
+        path: '/api/people/search',
+        method: 'post',
+        group: 'platform.people',
+        nameOverride: 'search',
+      },
+      {
+        path: '/api/agents/search',
+        method: 'post',
+        group: 'platform.agents',
+        nameOverride: 'search',
+      },
+      {
+        path: '/api/agents/{agent_id}',
+        method: 'get',
+        group: 'platform.agents',
+        nameOverride: 'get',
+      },
+      {
+        path: '/api/agents/{agent_id}/schemas',
+        method: 'get',
+        group: 'platform.agents',
+        nameOverride: 'getSchemas',
+      },
+      {
+        path: '/api/agents/{agent_id}/runs',
+        method: 'post',
+        group: 'platform.agents',
+        nameOverride: 'createRun',
+      },
+      {
+        path: '/api/search',
+        method: 'post',
+        group: 'platform.search',
+        nameOverride: 'query',
+      },
+      {
+        path: '/api/tools',
+        method: 'get',
+        group: 'platform.tools',
+        nameOverride: 'list',
+      },
+      {
+        path: '/api/tools/call',
+        method: 'post',
+        group: 'platform.tools',
+        nameOverride: 'call',
+      },
+      {
+        path: '/api/summarize',
+        method: 'post',
+        group: 'platform.summarize',
+        nameOverride: 'create',
+      },
+    ];
+
+    for (const { path, method, group, nameOverride } of platformOps) {
+      const operation = spec.paths?.[path]?.[method];
+
+      expect(
+        operation,
+        `expected operation ${method.toUpperCase()} ${path}`,
+      ).toBeDefined();
+      expect(operation['x-speakeasy-group']).toBe(group);
+      expect(operation['x-speakeasy-name-override']).toBe(nameOverride);
+      expect(operation['x-glean-sdk']).toBeUndefined();
+    }
+  });
+
+  test('Platform merged spec retains streaming run response', () => {
+    if (!hasGeneratedPlatformSpec()) {
+      return;
+    }
+
+    const operation = spec.paths?.['/api/agents/{agent_id}/runs']?.post;
+
+    expect(operation?.responses?.['200']?.content).toHaveProperty(
+      'text/event-stream',
+    );
+  });
+
+  test('Platform private runtime gates do not reach merged spec', () => {
+    if (!hasGeneratedPlatformSpec()) {
+      return;
+    }
+
+    expect(JSON.stringify(spec)).not.toContain('gated-by');
   });
 });

--- a/tests/post_transform_smoke.test.js
+++ b/tests/post_transform_smoke.test.js
@@ -8,14 +8,9 @@ const SPEC_PATH = path.join(
   'overlayed_specs',
   'glean-merged-spec.yaml',
 );
-const PLATFORM_SPEC_PATH = path.join(
-  process.cwd(),
-  'generated_specs',
-  'platform.yaml',
-);
 
 const loadSpec = () => yaml.load(fs.readFileSync(SPEC_PATH, 'utf8'));
-const hasGeneratedPlatformSpec = () => fs.existsSync(PLATFORM_SPEC_PATH);
+const hasMergedPlatformSpec = (spec) => Boolean(spec.paths?.['/api/search']);
 
 describe('Post-transformation smoke tests', () => {
   let spec;
@@ -152,29 +147,11 @@ describe('Post-transformation smoke tests', () => {
   });
 
   test('Platform operations land under expected SDK groups', () => {
-    if (!hasGeneratedPlatformSpec()) {
+    if (!hasMergedPlatformSpec(spec)) {
       return;
     }
 
     const platformOps = [
-      {
-        path: '/api/documents/batch',
-        method: 'post',
-        group: 'platform.documents',
-        nameOverride: 'batch',
-      },
-      {
-        path: '/api/documents/{id}/permissions',
-        method: 'get',
-        group: 'platform.documents',
-        nameOverride: 'getPermissions',
-      },
-      {
-        path: '/api/people/search',
-        method: 'post',
-        group: 'platform.people',
-        nameOverride: 'search',
-      },
       {
         path: '/api/agents/search',
         method: 'post',
@@ -206,22 +183,16 @@ describe('Post-transformation smoke tests', () => {
         nameOverride: 'query',
       },
       {
-        path: '/api/tools',
+        path: '/api/skills',
         method: 'get',
-        group: 'platform.tools',
+        group: 'platform.skills',
         nameOverride: 'list',
       },
       {
-        path: '/api/tools/call',
-        method: 'post',
-        group: 'platform.tools',
-        nameOverride: 'call',
-      },
-      {
-        path: '/api/summarize',
-        method: 'post',
-        group: 'platform.summarize',
-        nameOverride: 'create',
+        path: '/api/skills/{skill_id}',
+        method: 'get',
+        group: 'platform.skills',
+        nameOverride: 'retrieve',
       },
     ];
 
@@ -239,7 +210,7 @@ describe('Post-transformation smoke tests', () => {
   });
 
   test('Platform merged spec retains streaming run response', () => {
-    if (!hasGeneratedPlatformSpec()) {
+    if (!hasMergedPlatformSpec(spec)) {
       return;
     }
 
@@ -251,7 +222,7 @@ describe('Post-transformation smoke tests', () => {
   });
 
   test('Platform private runtime gates do not reach merged spec', () => {
-    if (!hasGeneratedPlatformSpec()) {
+    if (!hasMergedPlatformSpec(spec)) {
       return;
     }
 


### PR DESCRIPTION
## Summary

Activate the Platform API in the merged Speakeasy `glean-api-specs` source after the Platform source has been published and transformed into `generated_specs/platform.yaml`.

This draft PR is stacked on https://github.com/gleanwork/open-api/pull/112 and should stay draft until `generated_specs/platform.yaml` exists on `main` from automation.

## PR Stack

1. https://github.com/gleanwork/open-api/pull/112 - transformer support for clean shared Platform schemas
2. https://github.com/askscio/openapi-redocly/pull/17 - publish bundled Platform source spec
3. This draft PR - activate the generated Platform spec in `glean-api-specs`

## Expected Order

1. Land https://github.com/gleanwork/open-api/pull/112.
2. Land https://github.com/askscio/openapi-redocly/pull/17.
3. Let automation publish `source_specs/platform.yaml` and generate `generated_specs/platform.yaml` on `main`.
4. Rebase this PR onto `main`, then run transform automation so `.speakeasy/workflow.lock` and `overlayed_specs/glean-merged-spec.yaml` update from the Platform-inclusive input set.

## Validation

- Ran `pnpm exec vitest run tests/source-spec-transformer.test.js tests/post_transform_smoke.test.js`: 2 files, 55 tests passed.
- Ran a local Platform-active rehearsal using the clean Redocly Platform bundle as an uncommitted `source_specs/platform.yaml`.
- Ran `speakeasy run -s glean-api-specs --skip-upload-spec`; merge and validation completed with warnings only.
- Ran `pnpm exec vitest run tests/post_transform_smoke.test.js` against the Platform-inclusive merged rehearsal output: 1 file, 13 tests passed.
- Verified the merged rehearsal output has the expected Platform routes/groups, clean shared Platform schema names, no `x-glean-sdk`, no `gated-by`, preserved merged tag groups, and `text/event-stream` for agent runs.

## Out of Scope

This draft PR does not manually commit generated OpenAPI artifacts. Those should be produced by the transform workflow after the generated Platform spec exists on `main`.