### PR TITLE
List platform.yaml on the GitHub Pages index

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -43,8 +43,13 @@
           'client_rest.yaml',
           'indexing.yaml',
           'admin_rest.yaml',
+          'platform.yaml',
         ];
-        const finalSpecs = ['client_rest.yaml', 'indexing.yaml'];
+        const finalSpecs = [
+          'client_rest.yaml',
+          'indexing.yaml',
+          'platform.yaml',
+        ];
 
         const sourceList = document.getElementById('source-specs');
         sourceFiles.forEach((file) => {


### PR DESCRIPTION
## Summary

The index page at https://gleanwork.github.io/open-api/ was missing `platform.yaml` links. The spec lists in `docs/index.html` are hardcoded, so `platform.yaml` needs to be added explicitly.

Missing from:

<img width="1960" height="1254" alt="2026-07-01 at 11 00 37@2x" src="https://github.com/user-attachments/assets/d8c02634-0a6f-4114-b70c-440a96649389" />


## Changes

- `docs/index.html`: add `platform.yaml` to both the **Source Specs** and **Final Specs** link lists.

## Notes

- The **Source Specs** link (`specs/source/platform.yaml`) resolves immediately.
- The **Final Specs** link (`specs/final/platform.yaml`) resolves once the `generate-code-samples.yml` pipeline produces `final_specs/platform.yaml` (wired up in #116).
