### PR TITLE
Remove skills operations from post-transform smoke test

### DIFF
--- a/tests/post_transform_smoke.test.js
+++ b/tests/post_transform_smoke.test.js
@@ -182,18 +182,6 @@ describe('Post-transformation smoke tests', () => {
         group: 'platform.search',
         nameOverride: 'query',
       },
-      {
-        path: '/api/skills',
-        method: 'get',
-        group: 'platform.skills',
-        nameOverride: 'list',
-      },
-      {
-        path: '/api/skills/{skill_id}',
-        method: 'get',
-        group: 'platform.skills',
-        nameOverride: 'retrieve',
-      },
     ];
 
     for (const { path, method, group, nameOverride } of platformOps) {


### PR DESCRIPTION
## Summary

The skills endpoints (`/api/skills`, `/api/skills/{skill_id}`) were removed from the specs, but the post-transform smoke test still asserted their presence, causing CI to fail (e.g. [run 28550140712](https://github.com/gleanwork/open-api/actions/runs/28550140712/job/84645150961)).

This removes the two `platform.skills` operation assertions from `tests/post_transform_smoke.test.js`.

## Testing
- `pnpm exec vitest run tests/post_transform_smoke.test.js` — all 13 tests pass