### PR TITLE
Un-namespace platform SDK groups (glean.agents.search())

### DIFF
--- a/generated_specs/platform.yaml
+++ b/generated_specs/platform.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.0
 info:
   version: "2026-04-01"
   title: Glean Platform API
-  x-source-commit-sha: 44c1747d2fec67e1181e76564b99784cd52b01e3
+  x-source-commit-sha: cf583b0e762aa34ecfba8c88590d6f47342749bd
   x-open-api-commit-sha: 555c01b4c1a23b5ffb6678cc56350eb2e1dac052
 servers:
   - url: https://{instance}-be.glean.com
@@ -55,7 +55,7 @@ paths:
           $ref: "#/components/responses/PlatformInternalServerError"
         "503":
           $ref: "#/components/responses/PlatformServiceUnavailable"
-      x-speakeasy-group: platform.agents
+      x-speakeasy-group: agents
       x-speakeasy-name-override: search
   /api/agents/{agent_id}:
     get:
@@ -100,7 +100,7 @@ paths:
           $ref: "#/components/responses/PlatformInternalServerError"
         "503":
           $ref: "#/components/responses/PlatformServiceUnavailable"
-      x-speakeasy-group: platform.agents
+      x-speakeasy-group: agents
       x-speakeasy-name-override: get
   /api/agents/{agent_id}/schemas:
     get:
@@ -152,7 +152,7 @@ paths:
           $ref: "#/components/responses/PlatformInternalServerError"
         "503":
           $ref: "#/components/responses/PlatformServiceUnavailable"
-      x-speakeasy-group: platform.agents
+      x-speakeasy-group: agents
       x-speakeasy-name-override: getSchemas
   /api/agents/{agent_id}/runs:
     post:
@@ -218,106 +218,8 @@ paths:
           $ref: "#/components/responses/PlatformInternalServerError"
         "503":
           $ref: "#/components/responses/PlatformServiceUnavailable"
-      x-speakeasy-group: platform.agents
+      x-speakeasy-group: agents
       x-speakeasy-name-override: createRun
-  /api/skills:
-    get:
-      tags:
-        - Skills
-      summary: List skills
-      description: |
-        List skills available to the authenticated user.
-      operationId: platform-skills-list
-      x-visibility: Public
-      x-glean-experimental:
-        id: 3eb65937-03a3-472b-9a00-be713f302b5f
-        introduced: "2026-06-23"
-      parameters:
-        - in: query
-          name: page_size
-          description: Maximum number of skills to return.
-          required: false
-          schema:
-            type: integer
-            minimum: 1
-            maximum: 100
-        - in: query
-          name: cursor
-          description: Opaque pagination cursor from a previous response.
-          required: false
-          schema:
-            type: string
-            minLength: 1
-      responses:
-        "200":
-          description: Successful response.
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/PlatformSkillsListResponse"
-        "400":
-          $ref: "#/components/responses/PlatformBadRequest"
-        "401":
-          $ref: "#/components/responses/PlatformUnauthorized"
-        "403":
-          $ref: "#/components/responses/PlatformForbidden"
-        "404":
-          $ref: "#/components/responses/PlatformNotFound"
-        "408":
-          $ref: "#/components/responses/PlatformRequestTimeout"
-        "429":
-          $ref: "#/components/responses/PlatformTooManyRequests"
-        "500":
-          $ref: "#/components/responses/PlatformInternalServerError"
-        "503":
-          $ref: "#/components/responses/PlatformServiceUnavailable"
-      x-speakeasy-group: platform.skills
-      x-speakeasy-name-override: list
-  /api/skills/{skill_id}:
-    get:
-      tags:
-        - Skills
-      summary: Retrieve skill
-      description: |
-        Retrieve metadata for a skill available to the authenticated user.
-      operationId: platform-skills-get
-      x-visibility: Public
-      x-glean-experimental:
-        id: 8f8d1c92-a484-4769-9903-200613dc8a72
-        introduced: "2026-06-23"
-      parameters:
-        - name: skill_id
-          in: path
-          required: true
-          description: Glean skill ID.
-          schema:
-            type: string
-            minLength: 1
-      responses:
-        "200":
-          description: Successful response.
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/PlatformSkillGetResponse"
-        "400":
-          $ref: "#/components/responses/PlatformBadRequest"
-        "401":
-          $ref: "#/components/responses/PlatformUnauthorized"
-        "403":
-          $ref: "#/components/responses/PlatformForbidden"
-        "404":
-          $ref: "#/components/responses/PlatformNotFound"
-        "408":
-          $ref: "#/components/responses/PlatformRequestTimeout"
-        "429":
-          $ref: "#/components/responses/PlatformTooManyRequests"
-        "500":
-          $ref: "#/components/responses/PlatformInternalServerError"
-        "503":
-          $ref: "#/components/responses/PlatformServiceUnavailable"
-      x-speakeasy-group: platform.skills
-      x-speakeasy-name-override: retrieve
   /api/search:
     post:
       tags:
@@ -360,7 +262,7 @@ paths:
           $ref: "#/components/responses/PlatformInternalServerError"
         "503":
           $ref: "#/components/responses/PlatformServiceUnavailable"
-      x-speakeasy-group: platform.search
+      x-speakeasy-group: search
       x-speakeasy-name-override: query
 components:
   securitySchemes:
@@ -692,138 +594,6 @@ components:
         request_id:
           type: string
           description: Platform-generated request ID for support correlation.
-    PlatformSkillStatus:
-      type: string
-      enum:
-        - DRAFT
-        - ENABLED
-        - DISABLED
-      description: Current skill status.
-    PlatformSkillOrigin:
-      type: string
-      enum:
-        - CUSTOM
-      description: Source category for the skill.
-    PlatformSkillSyncStatus:
-      type: string
-      enum:
-        - UP_TO_DATE
-        - UPDATE_AVAILABLE
-        - SYNC_FAILED
-      description: Current external-source sync status.
-    PlatformSkillSourceProvenance:
-      type: object
-      properties:
-        source_url:
-          type: string
-          description: URL of the external source the skill was imported from.
-        commit_sha:
-          type: string
-          description: Source commit SHA for the imported skill.
-        imported_at:
-          type: string
-          format: date-time
-          description: Time the skill was imported.
-        last_synced_at:
-          type: string
-          format: date-time
-          description: Time the skill was last synced from its source.
-        sync_status:
-          $ref: "#/components/schemas/PlatformSkillSyncStatus"
-        sync_error:
-          type: string
-          description: Human-readable sync failure reason, present only when sync_status is SYNC_FAILED.
-    PlatformPersonReference:
-      type: object
-      description: A lightweight reference to a person, used where a payload merely points at someone.
-      required:
-        - name
-      properties:
-        id:
-          type: string
-          description: Opaque Glean person ID.
-        name:
-          type: string
-          description: Display name.
-    PlatformSkill:
-      type: object
-      required:
-        - id
-        - display_name
-        - description
-        - latest_version
-        - latest_minor_version
-        - status
-        - origin
-        - owner
-        - created_at
-        - updated_at
-      properties:
-        id:
-          type: string
-          description: Glean skill ID.
-        display_name:
-          type: string
-          description: Human-readable skill name.
-        description:
-          type: string
-          description: Human-readable skill description.
-        latest_version:
-          type: integer
-          description: Latest major version number for the skill.
-        latest_minor_version:
-          type: integer
-          description: Latest minor version number for the skill.
-        status:
-          $ref: "#/components/schemas/PlatformSkillStatus"
-        origin:
-          $ref: "#/components/schemas/PlatformSkillOrigin"
-        source_provenance:
-          $ref: "#/components/schemas/PlatformSkillSourceProvenance"
-        owner:
-          $ref: "#/components/schemas/PlatformPersonReference"
-        created_at:
-          type: string
-          format: date-time
-          description: Time the skill was created.
-        updated_at:
-          type: string
-          format: date-time
-          description: Time the skill was last updated.
-    PlatformSkillsListResponse:
-      type: object
-      required:
-        - skills
-        - has_more
-        - next_cursor
-        - request_id
-      properties:
-        skills:
-          type: array
-          description: Skills available to the user.
-          items:
-            $ref: "#/components/schemas/PlatformSkill"
-        has_more:
-          type: boolean
-          description: Whether additional results are available.
-        next_cursor:
-          type: string
-          nullable: true
-          description: Cursor for the next page, or null when no more results are available.
-        request_id:
-          type: string
-          description: Platform-generated request ID for support correlation.
-    PlatformSkillGetResponse:
-      type: object
-      required:
-        - skill
-        - request_id
-      properties:
-        skill:
-          $ref: "#/components/schemas/PlatformSkill"
-        request_id:
-          type: string
-          description: Platform-generated request ID for support correlation.
     PlatformFilterOperator:
       type: string
       description: Supported filter operator.
@@ -921,6 +691,18 @@ components:
             Structured filters applied to search results. Equality operators OR multiple values within a filter. Multiple filters are AND'd together, including range filters on the same field. Filters are AND'd with any inline operators in `query`. Note that conflicting constraints on the same field (e.g., `type:document` in the query and `type: spreadsheet` in a filter) produce an empty result set.
         time_range:
           $ref: "#/components/schemas/PlatformTimeRange"
+    PlatformPersonReference:
+      type: object
+      description: A lightweight reference to a person, used where a payload merely points at someone.
+      required:
+        - name
+      properties:
+        id:
+          type: string
+          description: Opaque Glean person ID.
+        name:
+          type: string
+          description: Display name.
     PlatformResult:
       type: object
       required:

--- a/overlayed_specs/glean-merged-spec.yaml
+++ b/overlayed_specs/glean-merged-spec.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.0
 info:
   version: "0.9.0"
   title: Glean API
-  x-source-commit-sha: 44c1747d2fec67e1181e76564b99784cd52b01e3
+  x-source-commit-sha: cf583b0e762aa34ecfba8c88590d6f47342749bd
   x-open-api-commit-sha: 555c01b4c1a23b5ffb6678cc56350eb2e1dac052
   description: |
     # Introduction
@@ -73,7 +73,7 @@ paths:
           $ref: "#/components/responses/PlatformInternalServerError"
         "503":
           $ref: "#/components/responses/PlatformServiceUnavailable"
-      x-speakeasy-group: platform.agents
+      x-speakeasy-group: agents
       x-speakeasy-name-override: search
       security:
         - APIToken: []
@@ -120,7 +120,7 @@ paths:
           $ref: "#/components/responses/PlatformInternalServerError"
         "503":
           $ref: "#/components/responses/PlatformServiceUnavailable"
-      x-speakeasy-group: platform.agents
+      x-speakeasy-group: agents
       x-speakeasy-name-override: get
       security:
         - APIToken: []
@@ -174,7 +174,7 @@ paths:
           $ref: "#/components/responses/PlatformInternalServerError"
         "503":
           $ref: "#/components/responses/PlatformServiceUnavailable"
-      x-speakeasy-group: platform.agents
+      x-speakeasy-group: agents
       x-speakeasy-name-override: getSchemas
       security:
         - APIToken: []
@@ -242,110 +242,8 @@ paths:
           $ref: "#/components/responses/PlatformInternalServerError"
         "503":
           $ref: "#/components/responses/PlatformServiceUnavailable"
-      x-speakeasy-group: platform.agents
+      x-speakeasy-group: agents
       x-speakeasy-name-override: createRun
-      security:
-        - APIToken: []
-  /api/skills:
-    get:
-      tags:
-        - Skills
-      summary: List skills
-      description: |
-        List skills available to the authenticated user.
-      operationId: platform-skills-list
-      x-visibility: Public
-      x-glean-experimental:
-        id: 3eb65937-03a3-472b-9a00-be713f302b5f
-        introduced: "2026-06-23"
-      parameters:
-        - in: query
-          name: page_size
-          description: Maximum number of skills to return.
-          required: false
-          schema:
-            type: integer
-            minimum: 1
-            maximum: 100
-        - in: query
-          name: cursor
-          description: Opaque pagination cursor from a previous response.
-          required: false
-          schema:
-            type: string
-            minLength: 1
-      responses:
-        "200":
-          description: Successful response.
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/PlatformSkillsListResponse"
-        "400":
-          $ref: "#/components/responses/PlatformBadRequest"
-        "401":
-          $ref: "#/components/responses/PlatformUnauthorized"
-        "403":
-          $ref: "#/components/responses/PlatformForbidden"
-        "404":
-          $ref: "#/components/responses/PlatformNotFound"
-        "408":
-          $ref: "#/components/responses/PlatformRequestTimeout"
-        "429":
-          $ref: "#/components/responses/PlatformTooManyRequests"
-        "500":
-          $ref: "#/components/responses/PlatformInternalServerError"
-        "503":
-          $ref: "#/components/responses/PlatformServiceUnavailable"
-      x-speakeasy-group: platform.skills
-      x-speakeasy-name-override: list
-      security:
-        - APIToken: []
-  /api/skills/{skill_id}:
-    get:
-      tags:
-        - Skills
-      summary: Retrieve skill
-      description: |
-        Retrieve metadata for a skill available to the authenticated user.
-      operationId: platform-skills-get
-      x-visibility: Public
-      x-glean-experimental:
-        id: 8f8d1c92-a484-4769-9903-200613dc8a72
-        introduced: "2026-06-23"
-      parameters:
-        - name: skill_id
-          in: path
-          required: true
-          description: Glean skill ID.
-          schema:
-            type: string
-            minLength: 1
-      responses:
-        "200":
-          description: Successful response.
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/PlatformSkillGetResponse"
-        "400":
-          $ref: "#/components/responses/PlatformBadRequest"
-        "401":
-          $ref: "#/components/responses/PlatformUnauthorized"
-        "403":
-          $ref: "#/components/responses/PlatformForbidden"
-        "404":
-          $ref: "#/components/responses/PlatformNotFound"
-        "408":
-          $ref: "#/components/responses/PlatformRequestTimeout"
-        "429":
-          $ref: "#/components/responses/PlatformTooManyRequests"
-        "500":
-          $ref: "#/components/responses/PlatformInternalServerError"
-        "503":
-          $ref: "#/components/responses/PlatformServiceUnavailable"
-      x-speakeasy-group: platform.skills
-      x-speakeasy-name-override: retrieve
       security:
         - APIToken: []
   /api/search:
@@ -390,7 +288,7 @@ paths:
           $ref: "#/components/responses/PlatformInternalServerError"
         "503":
           $ref: "#/components/responses/PlatformServiceUnavailable"
-      x-speakeasy-group: platform.search
+      x-speakeasy-group: search
       x-speakeasy-name-override: query
       security:
         - APIToken: []
@@ -5397,138 +5295,6 @@ components:
         request_id:
           type: string
           description: Platform-generated request ID for support correlation.
-    PlatformSkillStatus:
-      type: string
-      enum:
-        - DRAFT
-        - ENABLED
-        - DISABLED
-      description: Current skill status.
-    PlatformSkillOrigin:
-      type: string
-      enum:
-        - CUSTOM
-      description: Source category for the skill.
-    PlatformSkillSyncStatus:
-      type: string
-      enum:
-        - UP_TO_DATE
-        - UPDATE_AVAILABLE
-        - SYNC_FAILED
-      description: Current external-source sync status.
-    PlatformSkillSourceProvenance:
-      type: object
-      properties:
-        source_url:
-          type: string
-          description: URL of the external source the skill was imported from.
-        commit_sha:
-          type: string
-          description: Source commit SHA for the imported skill.
-        imported_at:
-          type: string
-          format: date-time
-          description: Time the skill was imported.
-        last_synced_at:
-          type: string
-          format: date-time
-          description: Time the skill was last synced from its source.
-        sync_status:
-          $ref: "#/components/schemas/PlatformSkillSyncStatus"
-        sync_error:
-          type: string
-          description: Human-readable sync failure reason, present only when sync_status is SYNC_FAILED.
-    PlatformPersonReference:
-      type: object
-      description: A lightweight reference to a person, used where a payload merely points at someone.
-      required:
-        - name
-      properties:
-        id:
-          type: string
-          description: Opaque Glean person ID.
-        name:
-          type: string
-          description: Display name.
-    PlatformSkill:
-      type: object
-      required:
-        - id
-        - display_name
-        - description
-        - latest_version
-        - latest_minor_version
-        - status
-        - origin
-        - owner
-        - created_at
-        - updated_at
-      properties:
-        id:
-          type: string
-          description: Glean skill ID.
-        display_name:
-          type: string
-          description: Human-readable skill name.
-        description:
-          type: string
-          description: Human-readable skill description.
-        latest_version:
-          type: integer
-          description: Latest major version number for the skill.
-        latest_minor_version:
-          type: integer
-          description: Latest minor version number for the skill.
-        status:
-          $ref: "#/components/schemas/PlatformSkillStatus"
-        origin:
-          $ref: "#/components/schemas/PlatformSkillOrigin"
-        source_provenance:
-          $ref: "#/components/schemas/PlatformSkillSourceProvenance"
-        owner:
-          $ref: "#/components/schemas/PlatformPersonReference"
-        created_at:
-          type: string
-          format: date-time
-          description: Time the skill was created.
-        updated_at:
-          type: string
-          format: date-time
-          description: Time the skill was last updated.
-    PlatformSkillsListResponse:
-      type: object
-      required:
-        - skills
-        - has_more
-        - next_cursor
-        - request_id
-      properties:
-        skills:
-          type: array
-          description: Skills available to the user.
-          items:
-            $ref: "#/components/schemas/PlatformSkill"
-        has_more:
-          type: boolean
-          description: Whether additional results are available.
-        next_cursor:
-          type: string
-          nullable: true
-          description: Cursor for the next page, or null when no more results are available.
-        request_id:
-          type: string
-          description: Platform-generated request ID for support correlation.
-    PlatformSkillGetResponse:
-      type: object
-      required:
-        - skill
-        - request_id
-      properties:
-        skill:
-          $ref: "#/components/schemas/PlatformSkill"
-        request_id:
-          type: string
-          description: Platform-generated request ID for support correlation.
     PlatformFilterOperator:
       type: string
       description: Supported filter operator.
@@ -5626,6 +5392,18 @@ components:
             Structured filters applied to search results. Equality operators OR multiple values within a filter. Multiple filters are AND'd together, including range filters on the same field. Filters are AND'd with any inline operators in `query`. Note that conflicting constraints on the same field (e.g., `type:document` in the query and `type: spreadsheet` in a filter) produce an empty result set.
         time_range:
           $ref: "#/components/schemas/PlatformTimeRange"
+    PlatformPersonReference:
+      type: object
+      description: A lightweight reference to a person, used where a payload merely points at someone.
+      required:
+        - name
+      properties:
+        id:
+          type: string
+          description: Opaque Glean person ID.
+        name:
+          type: string
+          description: Display name.
     PlatformResult:
       type: object
       required:

--- a/overlayed_specs/glean-platform-api-specs.yaml
+++ b/overlayed_specs/glean-platform-api-specs.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.0
 info:
   version: "2026-04-01"
   title: Glean Platform API
-  x-source-commit-sha: 44c1747d2fec67e1181e76564b99784cd52b01e3
+  x-source-commit-sha: cf583b0e762aa34ecfba8c88590d6f47342749bd
   x-open-api-commit-sha: 555c01b4c1a23b5ffb6678cc56350eb2e1dac052
 servers:
   - url: https://{instance}-be.glean.com
@@ -55,7 +55,7 @@ paths:
           $ref: "#/components/responses/PlatformInternalServerError"
         "503":
           $ref: "#/components/responses/PlatformServiceUnavailable"
-      x-speakeasy-group: platform.agents
+      x-speakeasy-group: agents
       x-speakeasy-name-override: search
   /api/agents/{agent_id}:
     get:
@@ -100,7 +100,7 @@ paths:
           $ref: "#/components/responses/PlatformInternalServerError"
         "503":
           $ref: "#/components/responses/PlatformServiceUnavailable"
-      x-speakeasy-group: platform.agents
+      x-speakeasy-group: agents
       x-speakeasy-name-override: get
   /api/agents/{agent_id}/schemas:
     get:
@@ -152,7 +152,7 @@ paths:
           $ref: "#/components/responses/PlatformInternalServerError"
         "503":
           $ref: "#/components/responses/PlatformServiceUnavailable"
-      x-speakeasy-group: platform.agents
+      x-speakeasy-group: agents
       x-speakeasy-name-override: getSchemas
   /api/agents/{agent_id}/runs:
     post:
@@ -218,106 +218,8 @@ paths:
           $ref: "#/components/responses/PlatformInternalServerError"
         "503":
           $ref: "#/components/responses/PlatformServiceUnavailable"
-      x-speakeasy-group: platform.agents
+      x-speakeasy-group: agents
       x-speakeasy-name-override: createRun
-  /api/skills:
-    get:
-      tags:
-        - Skills
-      summary: List skills
-      description: |
-        List skills available to the authenticated user.
-      operationId: platform-skills-list
-      x-visibility: Public
-      x-glean-experimental:
-        id: 3eb65937-03a3-472b-9a00-be713f302b5f
-        introduced: "2026-06-23"
-      parameters:
-        - in: query
-          name: page_size
-          description: Maximum number of skills to return.
-          required: false
-          schema:
-            type: integer
-            minimum: 1
-            maximum: 100
-        - in: query
-          name: cursor
-          description: Opaque pagination cursor from a previous response.
-          required: false
-          schema:
-            type: string
-            minLength: 1
-      responses:
-        "200":
-          description: Successful response.
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/PlatformSkillsListResponse"
-        "400":
-          $ref: "#/components/responses/PlatformBadRequest"
-        "401":
-          $ref: "#/components/responses/PlatformUnauthorized"
-        "403":
-          $ref: "#/components/responses/PlatformForbidden"
-        "404":
-          $ref: "#/components/responses/PlatformNotFound"
-        "408":
-          $ref: "#/components/responses/PlatformRequestTimeout"
-        "429":
-          $ref: "#/components/responses/PlatformTooManyRequests"
-        "500":
-          $ref: "#/components/responses/PlatformInternalServerError"
-        "503":
-          $ref: "#/components/responses/PlatformServiceUnavailable"
-      x-speakeasy-group: platform.skills
-      x-speakeasy-name-override: list
-  /api/skills/{skill_id}:
-    get:
-      tags:
-        - Skills
-      summary: Retrieve skill
-      description: |
-        Retrieve metadata for a skill available to the authenticated user.
-      operationId: platform-skills-get
-      x-visibility: Public
-      x-glean-experimental:
-        id: 8f8d1c92-a484-4769-9903-200613dc8a72
-        introduced: "2026-06-23"
-      parameters:
-        - name: skill_id
-          in: path
-          required: true
-          description: Glean skill ID.
-          schema:
-            type: string
-            minLength: 1
-      responses:
-        "200":
-          description: Successful response.
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/PlatformSkillGetResponse"
-        "400":
-          $ref: "#/components/responses/PlatformBadRequest"
-        "401":
-          $ref: "#/components/responses/PlatformUnauthorized"
-        "403":
-          $ref: "#/components/responses/PlatformForbidden"
-        "404":
-          $ref: "#/components/responses/PlatformNotFound"
-        "408":
-          $ref: "#/components/responses/PlatformRequestTimeout"
-        "429":
-          $ref: "#/components/responses/PlatformTooManyRequests"
-        "500":
-          $ref: "#/components/responses/PlatformInternalServerError"
-        "503":
-          $ref: "#/components/responses/PlatformServiceUnavailable"
-      x-speakeasy-group: platform.skills
-      x-speakeasy-name-override: retrieve
   /api/search:
     post:
       tags:
@@ -360,7 +262,7 @@ paths:
           $ref: "#/components/responses/PlatformInternalServerError"
         "503":
           $ref: "#/components/responses/PlatformServiceUnavailable"
-      x-speakeasy-group: platform.search
+      x-speakeasy-group: search
       x-speakeasy-name-override: query
 components:
   securitySchemes:
@@ -692,138 +594,6 @@ components:
         request_id:
           type: string
           description: Platform-generated request ID for support correlation.
-    PlatformSkillStatus:
-      type: string
-      enum:
-        - DRAFT
-        - ENABLED
-        - DISABLED
-      description: Current skill status.
-    PlatformSkillOrigin:
-      type: string
-      enum:
-        - CUSTOM
-      description: Source category for the skill.
-    PlatformSkillSyncStatus:
-      type: string
-      enum:
-        - UP_TO_DATE
-        - UPDATE_AVAILABLE
-        - SYNC_FAILED
-      description: Current external-source sync status.
-    PlatformSkillSourceProvenance:
-      type: object
-      properties:
-        source_url:
-          type: string
-          description: URL of the external source the skill was imported from.
-        commit_sha:
-          type: string
-          description: Source commit SHA for the imported skill.
-        imported_at:
-          type: string
-          format: date-time
-          description: Time the skill was imported.
-        last_synced_at:
-          type: string
-          format: date-time
-          description: Time the skill was last synced from its source.
-        sync_status:
-          $ref: "#/components/schemas/PlatformSkillSyncStatus"
-        sync_error:
-          type: string
-          description: Human-readable sync failure reason, present only when sync_status is SYNC_FAILED.
-    PlatformPersonReference:
-      type: object
-      description: A lightweight reference to a person, used where a payload merely points at someone.
-      required:
-        - name
-      properties:
-        id:
-          type: string
-          description: Opaque Glean person ID.
-        name:
-          type: string
-          description: Display name.
-    PlatformSkill:
-      type: object
-      required:
-        - id
-        - display_name
-        - description
-        - latest_version
-        - latest_minor_version
-        - status
-        - origin
-        - owner
-        - created_at
-        - updated_at
-      properties:
-        id:
-          type: string
-          description: Glean skill ID.
-        display_name:
-          type: string
-          description: Human-readable skill name.
-        description:
-          type: string
-          description: Human-readable skill description.
-        latest_version:
-          type: integer
-          description: Latest major version number for the skill.
-        latest_minor_version:
-          type: integer
-          description: Latest minor version number for the skill.
-        status:
-          $ref: "#/components/schemas/PlatformSkillStatus"
-        origin:
-          $ref: "#/components/schemas/PlatformSkillOrigin"
-        source_provenance:
-          $ref: "#/components/schemas/PlatformSkillSourceProvenance"
-        owner:
-          $ref: "#/components/schemas/PlatformPersonReference"
-        created_at:
-          type: string
-          format: date-time
-          description: Time the skill was created.
-        updated_at:
-          type: string
-          format: date-time
-          description: Time the skill was last updated.
-    PlatformSkillsListResponse:
-      type: object
-      required:
-        - skills
-        - has_more
-        - next_cursor
-        - request_id
-      properties:
-        skills:
-          type: array
-          description: Skills available to the user.
-          items:
-            $ref: "#/components/schemas/PlatformSkill"
-        has_more:
-          type: boolean
-          description: Whether additional results are available.
-        next_cursor:
-          type: string
-          nullable: true
-          description: Cursor for the next page, or null when no more results are available.
-        request_id:
-          type: string
-          description: Platform-generated request ID for support correlation.
-    PlatformSkillGetResponse:
-      type: object
-      required:
-        - skill
-        - request_id
-      properties:
-        skill:
-          $ref: "#/components/schemas/PlatformSkill"
-        request_id:
-          type: string
-          description: Platform-generated request ID for support correlation.
     PlatformFilterOperator:
       type: string
       description: Supported filter operator.
@@ -921,6 +691,18 @@ components:
             Structured filters applied to search results. Equality operators OR multiple values within a filter. Multiple filters are AND'd together, including range filters on the same field. Filters are AND'd with any inline operators in `query`. Note that conflicting constraints on the same field (e.g., `type:document` in the query and `type: spreadsheet` in a filter) produce an empty result set.
         time_range:
           $ref: "#/components/schemas/PlatformTimeRange"
+    PlatformPersonReference:
+      type: object
+      description: A lightweight reference to a person, used where a payload merely points at someone.
+      required:
+        - name
+      properties:
+        id:
+          type: string
+          description: Opaque Glean person ID.
+        name:
+          type: string
+          description: Display name.
     PlatformResult:
       type: object
       required:

--- a/src/source-spec-transformer.js
+++ b/src/source-spec-transformer.js
@@ -273,7 +273,13 @@ function transformPlatformOperations(spec) {
       }
       sdkMethods.set(sdkMethodKey, location);
 
-      operation['x-speakeasy-group'] = sdk.group;
+      // Drop the leading `platform.` segment so Speakeasy emits top-level SDK
+      // namespaces (glean.agents.search()) instead of nesting every platform
+      // endpoint under a redundant `platform` group
+      // (glean.platform.agents.search()). scio keeps sending the
+      // platform-prefixed group as the source contract; only the derived
+      // Speakeasy group is un-namespaced here.
+      operation['x-speakeasy-group'] = sdk.group.replace(/^platform\./, '');
       operation['x-speakeasy-name-override'] = sdk.method;
       // x-glean-sdk is a source contract between scio and this transform; the
       // generated public spec only needs the Speakeasy extensions it derives.

--- a/tests/post_transform_smoke.test.js
+++ b/tests/post_transform_smoke.test.js
@@ -155,31 +155,31 @@ describe('Post-transformation smoke tests', () => {
       {
         path: '/api/agents/search',
         method: 'post',
-        group: 'platform.agents',
+        group: 'agents',
         nameOverride: 'search',
       },
       {
         path: '/api/agents/{agent_id}',
         method: 'get',
-        group: 'platform.agents',
+        group: 'agents',
         nameOverride: 'get',
       },
       {
         path: '/api/agents/{agent_id}/schemas',
         method: 'get',
-        group: 'platform.agents',
+        group: 'agents',
         nameOverride: 'getSchemas',
       },
       {
         path: '/api/agents/{agent_id}/runs',
         method: 'post',
-        group: 'platform.agents',
+        group: 'agents',
         nameOverride: 'createRun',
       },
       {
         path: '/api/search',
         method: 'post',
-        group: 'platform.search',
+        group: 'search',
         nameOverride: 'query',
       },
     ];

--- a/tests/source-spec-transformer.test.js
+++ b/tests/source-spec-transformer.test.js
@@ -471,7 +471,7 @@ describe('OpenAPI YAML Transformer', () => {
     );
 
     expect(transformedSpec.paths['/api/search'].post).toMatchObject({
-      'x-speakeasy-group': 'platform.search',
+      'x-speakeasy-group': 'search',
       'x-speakeasy-name-override': 'query',
     });
     expect(transformedSpec.paths['/api/search'].post).not.toHaveProperty(
@@ -487,14 +487,14 @@ describe('OpenAPI YAML Transformer', () => {
         .tools.items.$ref,
     ).toBe('#/components/schemas/PlatformTool');
     expect(transformedSpec.paths['/api/tools'].get).toMatchObject({
-      'x-speakeasy-group': 'platform.tools',
+      'x-speakeasy-group': 'tools',
       'x-speakeasy-name-override': 'list',
     });
     expect(transformedSpec.paths['/api/tools'].get).not.toHaveProperty(
       'x-glean-sdk',
     );
     expect(transformedSpec.paths['/api/tools/call'].post).toMatchObject({
-      'x-speakeasy-group': 'platform.tools',
+      'x-speakeasy-group': 'tools',
       'x-speakeasy-name-override': 'call',
     });
     expect(
@@ -512,7 +512,7 @@ describe('OpenAPI YAML Transformer', () => {
     expect(
       transformedSpec.paths['/api/agents/{agent_id}/runs'].post,
     ).toMatchObject({
-      'x-speakeasy-group': 'platform.agents',
+      'x-speakeasy-group': 'agents',
       'x-speakeasy-name-override': 'createRun',
     });
     expect(
@@ -686,11 +686,11 @@ describe('OpenAPI YAML Transformer', () => {
     transformPlatformSpec(spec);
 
     expect(spec.paths['/tools'].get).toMatchObject({
-      'x-speakeasy-group': 'platform.tools',
+      'x-speakeasy-group': 'tools',
       'x-speakeasy-name-override': 'list',
     });
     expect(spec.paths['/tools/call'].post).toMatchObject({
-      'x-speakeasy-group': 'platform.tools',
+      'x-speakeasy-group': 'tools',
       'x-speakeasy-name-override': 'call',
     });
   });


### PR DESCRIPTION
## What

Downstream SDKs currently generate platform endpoints under a redundant `platform` namespace, e.g. `glean.platform.agents.search()` (see gleanwork/api-client-typescript#130). This makes them top-level instead: `glean.agents.search()`.

## Why

The `platform` namespace comes entirely from the `x-speakeasy-group` extension (`platform.agents`, `platform.search`, ...), which Speakeasy turns into a nested SDK namespace. That group is derived in `source-spec-transformer.js` from the `x-glean-sdk.group` source contract that scio provides.

## Changes

- **`src/source-spec-transformer.js`** — strip the leading `platform.` segment when deriving `x-speakeasy-group` (`sdk.group.replace(/^platform\./, '')`). scio still sends `platform.agents` as the source contract; only the derived SDK grouping is un-namespaced. The existing validation pattern guarantees at least one segment remains after `platform.`.
- **Regenerated specs** (`generated_specs/platform.yaml`, `overlayed_specs/glean-merged-spec.yaml`, `overlayed_specs/glean-platform-api-specs.yaml`) so `platform.agents` → `agents`, `platform.search` → `search`.
- **Tests** updated to expect the un-namespaced groups (`source-spec-transformer.test.js`, `post_transform_smoke.test.js`).

## Notes

- **Breaking change** for the platform SDK surface (`glean.platform.*` → `glean.*`); should land with an SDK major bump / changelog and coordinated downstream regeneration.
- No collision risk in the merged SDK: client stays under `client.*`, indexing under `indexing.*`, so top-level `agents`/`search` don't clash.
- Regeneration also drops stale `skills` endpoints that were removed from source in #118 but never regenerated in the committed artifacts. CI would remove these on the next transform regardless.
- All 70 tests pass; prettier clean.
