### PR TITLE
Drop required `platform.` prefix from SDK group

### DIFF
--- a/overlayed_specs/glean-merged-spec.yaml
+++ b/overlayed_specs/glean-merged-spec.yaml
@@ -73,7 +73,7 @@ paths:
           $ref: "#/components/responses/PlatformInternalServerError"
         "503":
           $ref: "#/components/responses/PlatformServiceUnavailable"
-      x-speakeasy-group: platform.agents
+      x-speakeasy-group: agents
       x-speakeasy-name-override: search
       security:
         - APIToken: []
@@ -120,7 +120,7 @@ paths:
           $ref: "#/components/responses/PlatformInternalServerError"
         "503":
           $ref: "#/components/responses/PlatformServiceUnavailable"
-      x-speakeasy-group: platform.agents
+      x-speakeasy-group: agents
       x-speakeasy-name-override: get
       security:
         - APIToken: []
@@ -174,7 +174,7 @@ paths:
           $ref: "#/components/responses/PlatformInternalServerError"
         "503":
           $ref: "#/components/responses/PlatformServiceUnavailable"
-      x-speakeasy-group: platform.agents
+      x-speakeasy-group: agents
       x-speakeasy-name-override: getSchemas
       security:
         - APIToken: []
@@ -242,7 +242,7 @@ paths:
           $ref: "#/components/responses/PlatformInternalServerError"
         "503":
           $ref: "#/components/responses/PlatformServiceUnavailable"
-      x-speakeasy-group: platform.agents
+      x-speakeasy-group: agents
       x-speakeasy-name-override: createRun
       security:
         - APIToken: []
@@ -390,7 +390,7 @@ paths:
           $ref: "#/components/responses/PlatformInternalServerError"
         "503":
           $ref: "#/components/responses/PlatformServiceUnavailable"
-      x-speakeasy-group: platform.search
+      x-speakeasy-group: search
       x-speakeasy-name-override: query
       security:
         - APIToken: []

--- a/overlayed_specs/glean-platform-api-specs.yaml
+++ b/overlayed_specs/glean-platform-api-specs.yaml
@@ -55,7 +55,7 @@ paths:
           $ref: "#/components/responses/PlatformInternalServerError"
         "503":
           $ref: "#/components/responses/PlatformServiceUnavailable"
-      x-speakeasy-group: platform.agents
+      x-speakeasy-group: agents
       x-speakeasy-name-override: search
   /api/agents/{agent_id}:
     get:
@@ -100,7 +100,7 @@ paths:
           $ref: "#/components/responses/PlatformInternalServerError"
         "503":
           $ref: "#/components/responses/PlatformServiceUnavailable"
-      x-speakeasy-group: platform.agents
+      x-speakeasy-group: agents
       x-speakeasy-name-override: get
   /api/agents/{agent_id}/schemas:
     get:
@@ -152,7 +152,7 @@ paths:
           $ref: "#/components/responses/PlatformInternalServerError"
         "503":
           $ref: "#/components/responses/PlatformServiceUnavailable"
-      x-speakeasy-group: platform.agents
+      x-speakeasy-group: agents
       x-speakeasy-name-override: getSchemas
   /api/agents/{agent_id}/runs:
     post:
@@ -218,7 +218,7 @@ paths:
           $ref: "#/components/responses/PlatformInternalServerError"
         "503":
           $ref: "#/components/responses/PlatformServiceUnavailable"
-      x-speakeasy-group: platform.agents
+      x-speakeasy-group: agents
       x-speakeasy-name-override: createRun
   /api/skills:
     get:
@@ -360,7 +360,7 @@ paths:
           $ref: "#/components/responses/PlatformInternalServerError"
         "503":
           $ref: "#/components/responses/PlatformServiceUnavailable"
-      x-speakeasy-group: platform.search
+      x-speakeasy-group: search
       x-speakeasy-name-override: query
 components:
   securitySchemes:

--- a/src/source-spec-transformer.js
+++ b/src/source-spec-transformer.js
@@ -68,7 +68,7 @@ const httpMethods = new Set([
   'trace',
 ]);
 
-const platformSdkGroupPattern = /^platform(\.[a-z][a-z0-9]*)+$/;
+const platformSdkGroupPattern = /^[a-z][a-z0-9]*(\.[a-z][a-z0-9]*)*$/;
 const platformSdkMethodPattern = /^[a-z][A-Za-z0-9]*$/;
 
 function rewriteRefs(obj, refMap) {
@@ -252,7 +252,7 @@ function transformPlatformOperations(spec) {
         !platformSdkGroupPattern.test(sdk.group)
       ) {
         throw new Error(
-          `Platform operation ${location} has invalid x-glean-sdk.group ${JSON.stringify(sdk.group)}; expected platform.<lowercase identifiers>`,
+          `Platform operation ${location} has invalid x-glean-sdk.group ${JSON.stringify(sdk.group)}; expected lowercase dot-separated identifiers`,
         );
       }
 

--- a/tests/post_transform_smoke.test.js
+++ b/tests/post_transform_smoke.test.js
@@ -155,31 +155,31 @@ describe('Post-transformation smoke tests', () => {
       {
         path: '/api/agents/search',
         method: 'post',
-        group: 'platform.agents',
+        group: 'agents',
         nameOverride: 'search',
       },
       {
         path: '/api/agents/{agent_id}',
         method: 'get',
-        group: 'platform.agents',
+        group: 'agents',
         nameOverride: 'get',
       },
       {
         path: '/api/agents/{agent_id}/schemas',
         method: 'get',
-        group: 'platform.agents',
+        group: 'agents',
         nameOverride: 'getSchemas',
       },
       {
         path: '/api/agents/{agent_id}/runs',
         method: 'post',
-        group: 'platform.agents',
+        group: 'agents',
         nameOverride: 'createRun',
       },
       {
         path: '/api/search',
         method: 'post',
-        group: 'platform.search',
+        group: 'search',
         nameOverride: 'query',
       },
     ];

--- a/tests/source-spec-transformer.test.js
+++ b/tests/source-spec-transformer.test.js
@@ -307,7 +307,7 @@ describe('OpenAPI YAML Transformer', () => {
             tags: ['Search'],
             operationId: 'platform-search',
             'x-glean-sdk': {
-              group: 'platform.search',
+              group: 'search',
               method: 'query',
             },
             requestBody: {
@@ -337,7 +337,7 @@ describe('OpenAPI YAML Transformer', () => {
             tags: ['Tools'],
             operationId: 'platform-tools-list',
             'x-glean-sdk': {
-              group: 'platform.tools',
+              group: 'tools',
               method: 'list',
             },
             responses: {
@@ -359,7 +359,7 @@ describe('OpenAPI YAML Transformer', () => {
             tags: ['Tools'],
             operationId: 'platform-tools-call',
             'x-glean-sdk': {
-              group: 'platform.tools',
+              group: 'tools',
               method: 'call',
             },
             requestBody: {
@@ -388,7 +388,7 @@ describe('OpenAPI YAML Transformer', () => {
             tags: ['Agents'],
             operationId: 'platform-agents-create-run',
             'x-glean-sdk': {
-              group: 'platform.agents',
+              group: 'agents',
               method: 'createRun',
             },
             requestBody: {
@@ -471,7 +471,7 @@ describe('OpenAPI YAML Transformer', () => {
     );
 
     expect(transformedSpec.paths['/api/search'].post).toMatchObject({
-      'x-speakeasy-group': 'platform.search',
+      'x-speakeasy-group': 'search',
       'x-speakeasy-name-override': 'query',
     });
     expect(transformedSpec.paths['/api/search'].post).not.toHaveProperty(
@@ -487,14 +487,14 @@ describe('OpenAPI YAML Transformer', () => {
         .tools.items.$ref,
     ).toBe('#/components/schemas/PlatformTool');
     expect(transformedSpec.paths['/api/tools'].get).toMatchObject({
-      'x-speakeasy-group': 'platform.tools',
+      'x-speakeasy-group': 'tools',
       'x-speakeasy-name-override': 'list',
     });
     expect(transformedSpec.paths['/api/tools'].get).not.toHaveProperty(
       'x-glean-sdk',
     );
     expect(transformedSpec.paths['/api/tools/call'].post).toMatchObject({
-      'x-speakeasy-group': 'platform.tools',
+      'x-speakeasy-group': 'tools',
       'x-speakeasy-name-override': 'call',
     });
     expect(
@@ -512,7 +512,7 @@ describe('OpenAPI YAML Transformer', () => {
     expect(
       transformedSpec.paths['/api/agents/{agent_id}/runs'].post,
     ).toMatchObject({
-      'x-speakeasy-group': 'platform.agents',
+      'x-speakeasy-group': 'agents',
       'x-speakeasy-name-override': 'createRun',
     });
     expect(
@@ -561,7 +561,7 @@ describe('OpenAPI YAML Transformer', () => {
           post: {
             operationId: 'platform-search',
             'x-glean-sdk': {
-              group: 'platform.search',
+              group: 'search',
               method: 'query',
             },
             security: [{ ApiToken: [], ExtraAuth: ['search'] }],
@@ -618,7 +618,7 @@ describe('OpenAPI YAML Transformer', () => {
             post: {
               operationId: 'platform-search',
               'x-glean-sdk': {
-                group: 'search',
+                group: 'Search',
                 method: 'Query',
               },
             },
@@ -626,7 +626,7 @@ describe('OpenAPI YAML Transformer', () => {
         },
       }),
     ).toThrow(
-      'Platform operation POST /search with operationId platform-search has invalid x-glean-sdk.group "search"; expected platform.<lowercase identifiers>',
+      'Platform operation POST /search with operationId platform-search has invalid x-glean-sdk.group "Search"; expected lowercase dot-separated identifiers',
     );
   });
 
@@ -638,7 +638,7 @@ describe('OpenAPI YAML Transformer', () => {
             post: {
               operationId: 'platform-search',
               'x-glean-sdk': {
-                group: 'platform.search',
+                group: 'search',
                 method: 'query',
               },
             },
@@ -647,7 +647,7 @@ describe('OpenAPI YAML Transformer', () => {
             post: {
               operationId: 'platform-query',
               'x-glean-sdk': {
-                group: 'platform.search',
+                group: 'search',
                 method: 'query',
               },
             },
@@ -655,7 +655,7 @@ describe('OpenAPI YAML Transformer', () => {
         },
       }),
     ).toThrow(
-      'Platform operation POST /query with operationId platform-query declares duplicate SDK method platform.search.query; already used by POST /search with operationId platform-search',
+      'Platform operation POST /query with operationId platform-query declares duplicate SDK method search.query; already used by POST /search with operationId platform-search',
     );
   });
 
@@ -666,7 +666,7 @@ describe('OpenAPI YAML Transformer', () => {
           get: {
             operationId: 'platform-tools-list',
             'x-glean-sdk': {
-              group: 'platform.tools',
+              group: 'tools',
               method: 'list',
             },
           },
@@ -675,7 +675,7 @@ describe('OpenAPI YAML Transformer', () => {
           post: {
             operationId: 'platform-tools-call',
             'x-glean-sdk': {
-              group: 'platform.tools',
+              group: 'tools',
               method: 'call',
             },
           },
@@ -686,11 +686,11 @@ describe('OpenAPI YAML Transformer', () => {
     transformPlatformSpec(spec);
 
     expect(spec.paths['/tools'].get).toMatchObject({
-      'x-speakeasy-group': 'platform.tools',
+      'x-speakeasy-group': 'tools',
       'x-speakeasy-name-override': 'list',
     });
     expect(spec.paths['/tools/call'].post).toMatchObject({
-      'x-speakeasy-group': 'platform.tools',
+      'x-speakeasy-group': 'tools',
       'x-speakeasy-name-override': 'call',
     });
   });


### PR DESCRIPTION
## Summary

The upstream source spec (`source_specs/platform.yaml`) recently removed the `platform.` prefix from `x-glean-sdk.group` values (e.g. `platform.agents` → `agents`, `platform.search` → `search`). The transformer still hard-required the prefix, so the [Transform OpenAPI Specs workflow](https://github.com/gleanwork/open-api/actions/runs/28554272851/job/84658195315) failed at `transform:source_specs`:

```
Platform operation POST /api/agents/search ... has invalid x-glean-sdk.group "agents"; expected platform.<lowercase identifiers>
```

## Changes

- **`src/source-spec-transformer.js`**: Loosened `platformSdkGroupPattern` from `/^platform(\.[a-z][a-z0-9]*)+$/` to `/^[a-z][a-z0-9]*(\.[a-z][a-z0-9]*)*$/` so bare groups (and optional dotted sub-groups) are accepted; updated the validation error message.
- **`tests/post_transform_smoke.test.js`** and **`tests/source-spec-transformer.test.js`**: Updated expected group values to the unprefixed form; adjusted the invalid-metadata and duplicate-method tests/messages accordingly.
- **`overlayed_specs/*.yaml`**: Refreshed the committed `x-speakeasy-group` values to match what CI regenerates.

`generated_specs/` is intentionally left untouched since CI regenerates it via the transform + speakeasy steps.

## Testing

- `pnpm test` → 70 passed
- `pnpm run lint` → clean