### PR TITLE
Add opt-in X-Glean-Include-Experimental header for experimental operations

### DIFF
--- a/generated_specs/platform.yaml
+++ b/generated_specs/platform.yaml
@@ -57,6 +57,8 @@ paths:
           $ref: "#/components/responses/PlatformServiceUnavailable"
       x-speakeasy-group: agents
       x-speakeasy-name-override: search
+      parameters:
+        - $ref: "#/components/parameters/xGleanIncludeExperimentalHeader"
   /api/agents/{agent_id}:
     get:
       tags:
@@ -77,6 +79,7 @@ paths:
           schema:
             type: string
             minLength: 1
+        - $ref: "#/components/parameters/xGleanIncludeExperimentalHeader"
       responses:
         "200":
           description: Successful response.
@@ -129,6 +132,7 @@ paths:
           schema:
             type: boolean
             default: false
+        - $ref: "#/components/parameters/xGleanIncludeExperimentalHeader"
       responses:
         "200":
           description: Successful response.
@@ -175,6 +179,7 @@ paths:
           schema:
             type: string
             minLength: 1
+        - $ref: "#/components/parameters/xGleanIncludeExperimentalHeader"
       requestBody:
         required: true
         content:
@@ -264,6 +269,8 @@ paths:
           $ref: "#/components/responses/PlatformServiceUnavailable"
       x-speakeasy-group: search
       x-speakeasy-name-override: query
+      parameters:
+        - $ref: "#/components/parameters/xGleanIncludeExperimentalHeader"
 components:
   securitySchemes:
     APIToken:
@@ -832,3 +839,16 @@ components:
         application/problem+json:
           schema:
             $ref: "#/components/schemas/PlatformProblemDetail"
+  parameters:
+    xGleanIncludeExperimentalHeader:
+      name: X-Glean-Include-Experimental
+      in: header
+      required: false
+      description: Opt in to experimental Glean API endpoints. Set once when constructing the SDK.
+      x-speakeasy-globals-hidden: true
+      x-speakeasy-name-override: includeExperimental
+      schema:
+        type: boolean
+x-speakeasy-globals:
+  parameters:
+    - $ref: "#/components/parameters/xGleanIncludeExperimentalHeader"

--- a/src/source-spec-transformer.js
+++ b/src/source-spec-transformer.js
@@ -282,12 +282,103 @@ function transformPlatformOperations(spec) {
   }
 }
 
+const EXPERIMENTAL_HEADER_COMPONENT = 'xGleanIncludeExperimentalHeader';
+const EXPERIMENTAL_HEADER_REF = `#/components/parameters/${EXPERIMENTAL_HEADER_COMPONENT}`;
+const experimentalHttpMethods = new Set([
+  'get',
+  'put',
+  'post',
+  'delete',
+  'patch',
+  'options',
+  'head',
+  'trace',
+]);
+
+/**
+ * Turns x-glean-experimental annotations into an opt-in SDK-level header.
+ *
+ * For every operation annotated with x-glean-experimental, this attaches an
+ * X-Glean-Include-Experimental header modeled as a hidden Speakeasy global
+ * (x-speakeasy-globals + x-speakeasy-globals-hidden). Users set it once when
+ * constructing the SDK; it is then auto-populated on experimental operations
+ * only and hidden from individual method signatures.
+ *
+ * The header is opt-in: the schema has no default, so a user who never sets it
+ * sends nothing. The original x-glean-experimental annotation is preserved for
+ * downstream doc consumers.
+ *
+ * @param {Object} spec The OpenAPI spec object
+ * @returns {Object} Transformed spec object
+ */
+export function transformGleanExperimental(spec) {
+  if (!spec.paths) return spec;
+
+  let anyExperimental = false;
+  for (const pathItem of Object.values(spec.paths)) {
+    if (!pathItem || typeof pathItem !== 'object') continue;
+
+    for (const [method, operation] of Object.entries(pathItem)) {
+      if (
+        !experimentalHttpMethods.has(method) ||
+        !operation ||
+        typeof operation !== 'object'
+      ) {
+        continue;
+      }
+      if (!operation['x-glean-experimental']) continue;
+
+      anyExperimental = true;
+      operation.parameters = operation.parameters || [];
+      const alreadyReferenced = operation.parameters.some(
+        (p) => p && p.$ref === EXPERIMENTAL_HEADER_REF,
+      );
+      if (!alreadyReferenced) {
+        operation.parameters.push({ $ref: EXPERIMENTAL_HEADER_REF });
+      }
+    }
+  }
+
+  if (!anyExperimental) return spec;
+
+  // Define the shared component parameter that backs the global.
+  spec.components = spec.components || {};
+  spec.components.parameters = spec.components.parameters || {};
+  spec.components.parameters[EXPERIMENTAL_HEADER_COMPONENT] = {
+    name: 'X-Glean-Include-Experimental',
+    in: 'header',
+    required: false,
+    description:
+      'Opt in to experimental Glean API endpoints. Set once when constructing the SDK.',
+    'x-speakeasy-globals-hidden': true,
+    'x-speakeasy-name-override': 'includeExperimental',
+    schema: { type: 'boolean' },
+  };
+
+  // Register it as an SDK-level global parameter so Speakeasy surfaces it as a
+  // one-time client option rather than a per-method argument.
+  spec['x-speakeasy-globals'] = spec['x-speakeasy-globals'] || {};
+  spec['x-speakeasy-globals'].parameters =
+    spec['x-speakeasy-globals'].parameters || [];
+  const alreadyRegistered = spec['x-speakeasy-globals'].parameters.some(
+    (p) => p && p.$ref === EXPERIMENTAL_HEADER_REF,
+  );
+  if (!alreadyRegistered) {
+    spec['x-speakeasy-globals'].parameters.push({
+      $ref: EXPERIMENTAL_HEADER_REF,
+    });
+  }
+
+  return spec;
+}
+
 export function transformPlatformSpec(spec) {
   transformPlatformTagGroups(spec);
   transformPlatformSchemas(spec);
   transformPlatformResponses(spec);
   transformPlatformApiTokenSecurity(spec);
   transformPlatformOperations(spec);
+  transformGleanExperimental(spec);
 
   return spec;
 }

--- a/tests/source-spec-transformer.test.js
+++ b/tests/source-spec-transformer.test.js
@@ -10,6 +10,7 @@ import {
   transformServerVariables,
   transformEnumDescriptions,
   transformGleanDeprecated,
+  transformGleanExperimental,
   transformPlatformSpec,
   injectOpenApiCommitSha,
 } from '../src/source-spec-transformer.js';
@@ -1611,5 +1612,100 @@ describe('OpenAPI YAML Transformer', () => {
     expect(deprecatedField['x-speakeasy-deprecation-message']).toBe(
       'Deprecated on 2024-04-01, removal scheduled for 2024-10-01: This field is deprecated',
     );
+  });
+
+  test('transformGleanExperimental wires an opt-in global header for experimental operations', () => {
+    const testSpec = {
+      paths: {
+        '/agents/search': {
+          post: {
+            operationId: 'platform-agents-search',
+            'x-glean-experimental': {
+              id: 'exp-uuid-1',
+              introduced: '2026-05-12',
+            },
+          },
+        },
+      },
+    };
+
+    const transformedSpec = transformGleanExperimental(testSpec);
+    const operation = transformedSpec.paths['/agents/search'].post;
+
+    // Operation references the shared component parameter.
+    expect(operation.parameters).toContainEqual({
+      $ref: '#/components/parameters/xGleanIncludeExperimentalHeader',
+    });
+
+    // Original annotation is preserved.
+    expect(operation['x-glean-experimental']).toEqual({
+      id: 'exp-uuid-1',
+      introduced: '2026-05-12',
+    });
+
+    // Component parameter is defined as a hidden global header, opt-in (no default).
+    const param =
+      transformedSpec.components.parameters.xGleanIncludeExperimentalHeader;
+    expect(param.name).toBe('X-Glean-Include-Experimental');
+    expect(param.in).toBe('header');
+    expect(param.required).toBe(false);
+    expect(param['x-speakeasy-globals-hidden']).toBe(true);
+    expect(param['x-speakeasy-name-override']).toBe('includeExperimental');
+    expect(param.schema).toEqual({ type: 'boolean' });
+    expect(param.schema.default).toBeUndefined();
+
+    // Registered as an SDK-level global.
+    expect(transformedSpec['x-speakeasy-globals'].parameters).toContainEqual({
+      $ref: '#/components/parameters/xGleanIncludeExperimentalHeader',
+    });
+  });
+
+  test('transformGleanExperimental is idempotent and skips non-experimental operations', () => {
+    const testSpec = {
+      paths: {
+        '/agents/search': {
+          post: {
+            operationId: 'platform-agents-search',
+            'x-glean-experimental': {
+              id: 'exp-uuid-1',
+              introduced: '2026-05-12',
+            },
+          },
+        },
+        '/stable': {
+          get: { operationId: 'stable-get' },
+        },
+      },
+    };
+
+    transformGleanExperimental(testSpec);
+    const transformedSpec = transformGleanExperimental(testSpec);
+
+    // Experimental op has exactly one reference (no duplicates on re-run).
+    const refs = transformedSpec.paths['/agents/search'].post.parameters.filter(
+      (p) =>
+        p.$ref === '#/components/parameters/xGleanIncludeExperimentalHeader',
+    );
+    expect(refs).toHaveLength(1);
+
+    // Global registered exactly once.
+    expect(transformedSpec['x-speakeasy-globals'].parameters).toHaveLength(1);
+
+    // Non-experimental op is untouched.
+    expect(transformedSpec.paths['/stable'].get.parameters).toBeUndefined();
+  });
+
+  test('transformGleanExperimental makes no changes when no experimental operations exist', () => {
+    const testSpec = {
+      paths: {
+        '/stable': { get: { operationId: 'stable-get' } },
+      },
+    };
+
+    const transformedSpec = transformGleanExperimental(testSpec);
+
+    expect(transformedSpec['x-speakeasy-globals']).toBeUndefined();
+    expect(transformedSpec.components).toBeUndefined();
+    expect(transformedSpec.paths['/stable'].get.parameters).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary

Turns `x-glean-experimental` annotations into an **opt-in, SDK-level header** so Speakeasy-generated SDKs can gate access to experimental endpoints.

Previously `x-glean-experimental` was a passthrough annotation with no effect on SDK generation. This adds `transformGleanExperimental` (wired into `transformPlatformSpec`), which for every operation carrying `x-glean-experimental`:

- References a shared `xGleanIncludeExperimentalHeader` component parameter.
- Defines it as a **hidden Speakeasy global** (`x-speakeasy-globals` + `x-speakeasy-globals-hidden: true`), surfaced as an `includeExperimental` client option via `x-speakeasy-name-override`.
- Registers it under the spec-root `x-speakeasy-globals`.

### Design decisions
- **Opt-in:** the schema is `type: boolean` with **no default**, so nothing is sent unless the user explicitly enables it when constructing the SDK.
- **Hidden from per-method signatures** — set once at SDK init (supported in all four targets: Go, Python, Java, TypeScript).
- **Original `x-glean-experimental` annotation preserved** for downstream doc consumers.

The transform is idempotent and only mutates the spec when experimental operations exist.

## Resulting SDK UX

```ts
const glean = new Glean({ apiToken: "...", includeExperimental: true });
await glean.agents.search({ ... }); // sends X-Glean-Include-Experimental: true
```

Users who don't opt in send no header; the option never appears in individual method signatures.

## Changes
- `src/source-spec-transformer.js` — new `transformGleanExperimental`, wired into `transformPlatformSpec`.
- `tests/source-spec-transformer.test.js` — 3 new tests (wiring/opt-in shape, idempotency + skipping non-experimental ops, no-op when none exist).
- `generated_specs/platform.yaml` — regenerated: adds the component parameter, the `x-speakeasy-globals` registration, and `$ref`s on all 5 experimental operations (annotations preserved).

## Verification
- `pnpm test` → 73 passed
- `pnpm lint` → clean
- `pnpm transform:source_specs` produces the component, global registration, and per-operation refs in `generated_specs/platform.yaml`.

## Follow-up to confirm
On the next Speakeasy generation run, verify the merged `glean-api-specs` source (platform + 3 other specs) surfaces the single global cleanly in `overlayed_specs/glean-merged-spec.yaml`.
