### PR TITLE
fix: nest untagged client/indexing operations under client/indexing SDK groups

### DIFF
--- a/overlayed_specs/glean-client-api-specs.yaml
+++ b/overlayed_specs/glean-client-api-specs.yaml
@@ -410,6 +410,8 @@ paths:
           description: Too Many Requests
       security:
         - APIToken: []
+      x-speakeasy-name-override: checkDatasourceAuth
+      x-speakeasy-group: client.authentication
   /rest/api/v1/createauthtoken:
     post:
       tags:
@@ -910,6 +912,8 @@ paths:
           description: Internal server error.
       security:
         - APIToken: []
+      x-speakeasy-name-override: retrieveFile
+      x-speakeasy-group: client.chat
   /rest/api/v1/agents:
     post:
       tags:
@@ -944,6 +948,8 @@ paths:
           description: Internal server error
       security:
         - APIToken: []
+      x-speakeasy-group: client.agents
+      x-speakeasy-name-override: create
   /rest/api/v1/agents/{agent_id}:
     get:
       tags:
@@ -1029,6 +1035,8 @@ paths:
           description: Internal server error
       security:
         - APIToken: []
+      x-speakeasy-group: client.agents
+      x-speakeasy-name-override: update
   /rest/api/v1/agents/{agent_id}/schemas:
     get:
       tags:
@@ -2225,6 +2233,8 @@ paths:
           description: Too Many Requests.
       security:
         - APIToken: []
+      x-speakeasy-name-override: retrievePhoto
+      x-speakeasy-group: client.entities
   /rest/api/v1/createshortcut:
     post:
       tags:
@@ -2653,6 +2663,8 @@ paths:
           description: Too Many Requests
       security:
         - APIToken: []
+      x-speakeasy-name-override: retrieveAuthStatus
+      x-speakeasy-group: client.tools
     post:
       tags:
         - Tools
@@ -2692,6 +2704,8 @@ paths:
           description: Too Many Requests
       security:
         - APIToken: []
+      x-speakeasy-name-override: authorize
+      x-speakeasy-group: client.tools
   /rest/api/v1/governance/data/policies/{id}:
     get:
       operationId: getpolicy
@@ -3036,6 +3050,8 @@ paths:
         "500":
           description: Internal error
       x-visibility: Public
+      x-speakeasy-group: client.governance.data.findings.exports
+      x-speakeasy-name-override: create
     get:
       operationId: listfindingsexports
       summary: Lists findings exports
@@ -3056,6 +3072,8 @@ paths:
         "500":
           description: Internal error
       x-visibility: Public
+      x-speakeasy-group: client.governance.data.findings.exports
+      x-speakeasy-name-override: list
   /rest/api/v1/governance/data/findings/exports/{id}:
     get:
       operationId: downloadfindingsexport
@@ -3085,6 +3103,8 @@ paths:
         "500":
           description: Internal error
       x-visibility: Public
+      x-speakeasy-group: client.governance.data.findings.exports
+      x-speakeasy-name-override: download
     delete:
       operationId: deletefindingsexport
       summary: Deletes findings export
@@ -3109,6 +3129,8 @@ paths:
         "500":
           description: Internal error
       x-visibility: Public
+      x-speakeasy-group: client.governance.data.findings.exports
+      x-speakeasy-name-override: delete
   /rest/api/v1/configure/datasources/{datasourceId}/instances/{instanceId}:
     get:
       operationId: getDatasourceInstanceConfiguration
@@ -3150,6 +3172,8 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
       x-visibility: Preview
+      x-speakeasy-name-override: retrieveConfiguration
+      x-speakeasy-group: client.datasources
     patch:
       operationId: updateDatasourceInstanceConfiguration
       summary: Update datasource instance configuration
@@ -3196,6 +3220,8 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
       x-visibility: Preview
+      x-speakeasy-name-override: updateConfiguration
+      x-speakeasy-group: client.datasources
   /rest/api/v1/datasource/{datasourceInstanceId}/credentialstatus:
     get:
       operationId: getDatasourceCredentialStatus
@@ -3236,6 +3262,8 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
       x-visibility: Preview
+      x-speakeasy-name-override: retrieveCredentialStatus
+      x-speakeasy-group: client.datasources
   /rest/api/v1/datasource/{datasourceInstanceId}/credentials:
     post:
       operationId: rotateDatasourceCredentials
@@ -3283,6 +3311,8 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
       x-visibility: Preview
+      x-speakeasy-name-override: rotateCredentials
+      x-speakeasy-group: client.datasources
   /rest/api/v1/chat#stream:
     post:
       tags:

--- a/overlayed_specs/glean-indexing-api-specs.yaml
+++ b/overlayed_specs/glean-indexing-api-specs.yaml
@@ -1087,6 +1087,8 @@ paths:
           description: Not Authorized
         "429":
           description: Too Many Requests
+      x-speakeasy-group: indexing.documents
+      x-speakeasy-name-override: debugEvents
   /rest/api/index/document/{docId}/custom-metadata/{groupName}:
     servers:
       - url: https://{instance}-be.glean.com

--- a/overlayed_specs/glean-merged-spec.yaml
+++ b/overlayed_specs/glean-merged-spec.yaml
@@ -671,6 +671,8 @@ paths:
         "429":
           description: Too Many Requests
       x-visibility: Public
+      x-speakeasy-name-override: checkDatasourceAuth
+      x-speakeasy-group: client.authentication
   /rest/api/v1/createauthtoken:
     post:
       operationId: createauthtoken
@@ -1171,6 +1173,8 @@ paths:
         "500":
           description: Internal server error.
       x-visibility: Public
+      x-speakeasy-name-override: retrieveFile
+      x-speakeasy-group: client.chat
   /rest/api/v1/agents:
     post:
       operationId: createAgent
@@ -1205,6 +1209,8 @@ paths:
         "500":
           description: Internal server error
       x-visibility: Preview
+      x-speakeasy-group: client.agents
+      x-speakeasy-name-override: create
   /rest/api/v1/agents/{agent_id}:
     get:
       operationId: getAgent
@@ -1290,6 +1296,8 @@ paths:
         "500":
           description: Internal server error
       x-visibility: Preview
+      x-speakeasy-group: client.agents
+      x-speakeasy-name-override: update
   /rest/api/v1/agents/{agent_id}/schemas:
     get:
       operationId: getAgentSchemas
@@ -2486,6 +2494,8 @@ paths:
         "429":
           description: Too Many Requests.
       x-visibility: Public
+      x-speakeasy-name-override: retrievePhoto
+      x-speakeasy-group: client.entities
   /rest/api/v1/createshortcut:
     post:
       operationId: createshortcut
@@ -2907,6 +2917,8 @@ paths:
         "429":
           description: Too Many Requests
       x-visibility: Preview
+      x-speakeasy-name-override: retrieveAuthStatus
+      x-speakeasy-group: client.tools
     post:
       operationId: authorizeActionPack
       summary: Start the OAuth authorization flow for an action pack.
@@ -2946,6 +2958,8 @@ paths:
         "429":
           description: Too Many Requests
       x-visibility: Preview
+      x-speakeasy-name-override: authorize
+      x-speakeasy-group: client.tools
     parameters:
       - name: actionPackId
         in: path
@@ -4072,6 +4086,8 @@ paths:
         "429":
           description: Too Many Requests
       x-beta: true
+      x-speakeasy-group: indexing.documents
+      x-speakeasy-name-override: debugEvents
   /rest/api/index/document/{docId}/custom-metadata/{groupName}:
     put:
       summary: Add or update custom metadata
@@ -4580,6 +4596,8 @@ paths:
         "500":
           description: Internal error
       x-visibility: Public
+      x-speakeasy-group: client.governance.data.findings.exports
+      x-speakeasy-name-override: create
     get:
       operationId: listfindingsexports
       summary: Lists findings exports
@@ -4600,6 +4618,8 @@ paths:
         "500":
           description: Internal error
       x-visibility: Public
+      x-speakeasy-group: client.governance.data.findings.exports
+      x-speakeasy-name-override: list
   /rest/api/v1/governance/data/findings/exports/{id}:
     get:
       operationId: downloadfindingsexport
@@ -4629,6 +4649,8 @@ paths:
         "500":
           description: Internal error
       x-visibility: Public
+      x-speakeasy-group: client.governance.data.findings.exports
+      x-speakeasy-name-override: download
     delete:
       operationId: deletefindingsexport
       summary: Deletes findings export
@@ -4653,6 +4675,8 @@ paths:
         "500":
           description: Internal error
       x-visibility: Public
+      x-speakeasy-group: client.governance.data.findings.exports
+      x-speakeasy-name-override: delete
   /rest/api/v1/configure/datasources/{datasourceId}/instances/{instanceId}:
     get:
       operationId: getDatasourceInstanceConfiguration
@@ -4694,6 +4718,8 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
       x-visibility: Preview
+      x-speakeasy-name-override: retrieveConfiguration
+      x-speakeasy-group: client.datasources
     patch:
       operationId: updateDatasourceInstanceConfiguration
       summary: Update datasource instance configuration
@@ -4740,6 +4766,8 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
       x-visibility: Preview
+      x-speakeasy-name-override: updateConfiguration
+      x-speakeasy-group: client.datasources
   /rest/api/v1/datasource/{datasourceInstanceId}/credentialstatus:
     get:
       operationId: getDatasourceCredentialStatus
@@ -4780,6 +4808,8 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
       x-visibility: Preview
+      x-speakeasy-name-override: retrieveCredentialStatus
+      x-speakeasy-group: client.datasources
   /rest/api/v1/datasource/{datasourceInstanceId}/credentials:
     post:
       operationId: rotateDatasourceCredentials
@@ -4827,6 +4857,8 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
       x-visibility: Preview
+      x-speakeasy-name-override: rotateCredentials
+      x-speakeasy-group: client.datasources
   /rest/api/v1/chat#stream:
     post:
       tags:

--- a/overlays/admin-modifications-overlay.yaml
+++ b/overlays/admin-modifications-overlay.yaml
@@ -46,3 +46,21 @@ actions:
     update:
       x-speakeasy-group: client.governance.documents.visibilityoverrides
       x-speakeasy-name-override: create
+
+  # Governance data findings exports
+  - target: $["paths"]["/rest/api/v1/governance/data/findings/exports"]["post"]
+    update:
+      x-speakeasy-group: client.governance.data.findings.exports
+      x-speakeasy-name-override: create
+  - target: $["paths"]["/rest/api/v1/governance/data/findings/exports"]["get"]
+    update:
+      x-speakeasy-group: client.governance.data.findings.exports
+      x-speakeasy-name-override: list
+  - target: $["paths"]["/rest/api/v1/governance/data/findings/exports/{id}"]["get"]
+    update:
+      x-speakeasy-group: client.governance.data.findings.exports
+      x-speakeasy-name-override: download
+  - target: $["paths"]["/rest/api/v1/governance/data/findings/exports/{id}"]["delete"]
+    update:
+      x-speakeasy-group: client.governance.data.findings.exports
+      x-speakeasy-name-override: delete

--- a/overlays/agent-modifications-overlay.yaml
+++ b/overlays/agent-modifications-overlay.yaml
@@ -5,6 +5,16 @@ info:
   version: 0.0.5
 
 actions:
+  - target: $["paths"]["/rest/api/v1/agents"]["post"]
+    update:
+      x-speakeasy-group: client.agents
+      x-speakeasy-name-override: create
+
+  - target: $["paths"]["/rest/api/v1/agents/{agent_id}"]["post"]
+    update:
+      x-speakeasy-group: client.agents
+      x-speakeasy-name-override: update
+
   - target: $["paths"]["/rest/api/v1/agents/{agent_id}"]["get"]
     update:
       x-speakeasy-group: client.agents

--- a/overlays/client-modifications-overlay.yaml
+++ b/overlays/client-modifications-overlay.yaml
@@ -63,6 +63,11 @@ actions:
       x-speakeasy-name-override: createToken
       x-speakeasy-group: client.authentication
 
+  - target: $["paths"]["/rest/api/v1/checkdatasourceauth"]["post"]
+    update:
+      x-speakeasy-name-override: checkDatasourceAuth
+      x-speakeasy-group: client.authentication
+
   # Chat
   - target: $["paths"]["/rest/api/v1/chat"]["post"]
     update:
@@ -114,6 +119,11 @@ actions:
   - target: $["paths"]["/rest/api/v1/listchats"]["post"]
     update:
       x-speakeasy-name-override: list
+      x-speakeasy-group: client.chat
+
+  - target: $["paths"]["/rest/api/v1/chat-files/{fileId}"]["get"]
+    update:
+      x-speakeasy-name-override: retrieveFile
       x-speakeasy-group: client.chat
 
   # Collections
@@ -182,6 +192,11 @@ actions:
   - target: $["paths"]["/rest/api/v1/people"]["post"]
     update:
       x-speakeasy-name-override: readPeople
+      x-speakeasy-group: client.entities
+
+  - target: $["paths"]["/rest/api/v1/people/{person_id}/photo"]["get"]
+    update:
+      x-speakeasy-name-override: retrievePhoto
       x-speakeasy-group: client.entities
 
   # Insights
@@ -294,6 +309,37 @@ actions:
         - Tools
       x-speakeasy-name-override: run
       x-speakeasy-group: client.tools
+
+  - target: $["paths"]["/rest/api/v1/actions/actionpack/{actionPackId}/auth"]["get"]
+    update:
+      x-speakeasy-name-override: retrieveAuthStatus
+      x-speakeasy-group: client.tools
+
+  - target: $["paths"]["/rest/api/v1/actions/actionpack/{actionPackId}/auth"]["post"]
+    update:
+      x-speakeasy-name-override: authorize
+      x-speakeasy-group: client.tools
+
+  # Datasources
+  - target: $["paths"]["/rest/api/v1/configure/datasources/{datasourceId}/instances/{instanceId}"]["get"]
+    update:
+      x-speakeasy-name-override: retrieveConfiguration
+      x-speakeasy-group: client.datasources
+
+  - target: $["paths"]["/rest/api/v1/configure/datasources/{datasourceId}/instances/{instanceId}"]["patch"]
+    update:
+      x-speakeasy-name-override: updateConfiguration
+      x-speakeasy-group: client.datasources
+
+  - target: $["paths"]["/rest/api/v1/datasource/{datasourceInstanceId}/credentialstatus"]["get"]
+    update:
+      x-speakeasy-name-override: retrieveCredentialStatus
+      x-speakeasy-group: client.datasources
+
+  - target: $["paths"]["/rest/api/v1/datasource/{datasourceInstanceId}/credentials"]["post"]
+    update:
+      x-speakeasy-name-override: rotateCredentials
+      x-speakeasy-group: client.datasources
 
   # Verification
   - target: $["paths"]["/rest/api/v1/listverifications"]["post"]

--- a/overlays/indexing-modifications-overlay.yaml
+++ b/overlays/indexing-modifications-overlay.yaml
@@ -195,6 +195,11 @@ actions:
       x-speakeasy-group: indexing.documents
       x-speakeasy-name-override: debug
 
+  - target: $["paths"]["/api/index/v1/debug/{datasource}/document/events"]["post"]
+    update:
+      x-speakeasy-group: indexing.documents
+      x-speakeasy-name-override: debugEvents
+
   - target: $["paths"]["/api/index/v1/debug/{datasource}/user"]["post"]
     update:
       x-speakeasy-name-override: debug


### PR DESCRIPTION
## Problem

Client and indexing operations should live under the `client.*` / `indexing.*` SDK namespaces, with only the platform APIs (`agents`, `search`) at the top level. However, several endpoints were reachable at the top level — e.g. `glean.chat.getChatFile()` instead of `glean.client.chat.retrieveFile()`.

## Root cause

An operation only lands under a nested SDK group when an overlay assigns it an `x-speakeasy-group`. A set of client/indexing endpoints had **no overlay entry**, so Speakeasy fell back to grouping them by their OpenAPI **tag** (`Chat`, `Agents`, `Entities`, `Tools`, `Authentication`, `Governance`, `Datasources`, `Troubleshooting`), which places them at the top level.

## Changes

Added `x-speakeasy-group` + name overrides for the previously untagged operations:

- **client-modifications-overlay.yaml**: `checkDatasourceAuth` → `client.authentication`; `chat-files/{fileId}` → `client.chat.retrieveFile`; `people/{person_id}/photo` → `client.entities.retrievePhoto`; actionpack auth GET/POST → `client.tools.retrieveAuthStatus` / `authorize`; new `client.datasources` group for the configure + credentials endpoints
- **agent-modifications-overlay.yaml**: `POST /agents` → `client.agents.create`; `POST /agents/{agent_id}` → `client.agents.update`
- **admin-modifications-overlay.yaml**: findings exports → `client.governance.data.findings.exports.{create,list,download,delete}`
- **indexing-modifications-overlay.yaml**: `debug/{datasource}/document/events` → `indexing.documents.debugEvents`

Regenerated the affected `overlayed_specs/*`.

## Verification

- Scanned all three overlayed specs: the only remaining top-level groups are `agents` and `search` (platform); every client/indexing op is now nested.
- `pnpm test` passes (70/70), including the smoke test asserting platform stays bare while client/indexing stay grouped.