### PR TITLE
Fix client/indexing SDK methods leaking to the top-level namespace

### DIFF
--- a/.speakeasy/workflow.lock
+++ b/.speakeasy/workflow.lock
@@ -2,16 +2,22 @@ speakeasyVersion: 1.787.0
 sources:
     glean-api-specs:
         sourceNamespace: glean-api-specs
-        sourceRevisionDigest: sha256:33f674fcfaeec4d436d4ed7d96bb50d3ff4fd83ab1dfc897195f7e554b82fa87
-        sourceBlobDigest: sha256:8e36a2243615e5eaac4d86668fe856169d64767afdc94f704055540748b47ebc
+        sourceRevisionDigest: sha256:bff014c893ae13fd203067f3886d3e7707c73f4eb414c9731fcd104c51ce4f50
+        sourceBlobDigest: sha256:32282ad3f193147c756f7ab63678a53944ceb851459d0fdf0f666aec1ea6fabd
         tags:
             - latest
-            - main
             - 0.9.0
     glean-client-and-indexing-specs:
         sourceNamespace: glean-client-and-indexing-specs
         sourceRevisionDigest: sha256:7d7550316a7fc147ed5b70e41e81e33cf2f2f004d6000a83fee749b145eebfc4
         sourceBlobDigest: sha256:a9f406c6555d15a4b8d6acb6d2749f89090620386b1366b577f243007fd8f77a
+        tags:
+            - latest
+            - 0.9.0
+    glean-client-api-specs:
+        sourceNamespace: glean-client-api-specs
+        sourceRevisionDigest: sha256:8b1a4378ab2e5242e7ef69cd76a0be3fd6f041d8115d97b1132254b637d811e7
+        sourceBlobDigest: sha256:96f046253981e5c55ee68f116c663b91ec3b006adc1cbbbc122c82b84d379cad
         tags:
             - latest
             - 0.9.0
@@ -82,6 +88,8 @@ workflow:
                 - location: overlays/admin-modifications-overlay.yaml
                 - location: overlays/oauth-client-security-overlay.yaml
             output: overlayed_specs/glean-client-api-specs.yaml
+            registry:
+                location: registry.speakeasyapi.dev/glean-el2/sdk/glean-client-api-specs
         glean-client-merged-code-samples-spec:
             inputs:
                 - location: overlayed_specs/glean-client-api-specs.yaml

--- a/.speakeasy/workflow.yaml
+++ b/.speakeasy/workflow.yaml
@@ -33,6 +33,8 @@ sources:
             - location: overlays/admin-modifications-overlay.yaml
             - location: overlays/oauth-client-security-overlay.yaml
         output: overlayed_specs/glean-client-api-specs.yaml
+        registry:
+            location: registry.speakeasyapi.dev/glean-el2/sdk/glean-client-api-specs
     glean-client-merged-code-samples-spec:
         inputs:
             - location: overlayed_specs/glean-client-api-specs.yaml

--- a/overlayed_specs/glean-client-api-specs.yaml
+++ b/overlayed_specs/glean-client-api-specs.yaml
@@ -410,6 +410,8 @@ paths:
           description: Too Many Requests
       security:
         - APIToken: []
+      x-speakeasy-name-override: checkDatasourceAuth
+      x-speakeasy-group: client.authentication
   /rest/api/v1/createauthtoken:
     post:
       tags:
@@ -910,6 +912,8 @@ paths:
           description: Internal server error.
       security:
         - APIToken: []
+      x-speakeasy-name-override: retrieveFile
+      x-speakeasy-group: client.chat
   /rest/api/v1/agents:
     post:
       tags:
@@ -944,6 +948,8 @@ paths:
           description: Internal server error
       security:
         - APIToken: []
+      x-speakeasy-group: client.agents
+      x-speakeasy-name-override: create
   /rest/api/v1/agents/{agent_id}:
     get:
       tags:
@@ -1029,6 +1035,8 @@ paths:
           description: Internal server error
       security:
         - APIToken: []
+      x-speakeasy-group: client.agents
+      x-speakeasy-name-override: update
   /rest/api/v1/agents/{agent_id}/schemas:
     get:
       tags:
@@ -2225,6 +2233,8 @@ paths:
           description: Too Many Requests.
       security:
         - APIToken: []
+      x-speakeasy-name-override: retrievePersonPhoto
+      x-speakeasy-group: client.entities
   /rest/api/v1/createshortcut:
     post:
       tags:
@@ -2653,6 +2663,8 @@ paths:
           description: Too Many Requests
       security:
         - APIToken: []
+      x-speakeasy-name-override: retrieveActionPackAuthStatus
+      x-speakeasy-group: client.tools
     post:
       tags:
         - Tools
@@ -2692,6 +2704,8 @@ paths:
           description: Too Many Requests
       security:
         - APIToken: []
+      x-speakeasy-name-override: authorizeActionPack
+      x-speakeasy-group: client.tools
   /rest/api/v1/governance/data/policies/{id}:
     get:
       operationId: getpolicy
@@ -3036,6 +3050,8 @@ paths:
         "500":
           description: Internal error
       x-visibility: Public
+      x-speakeasy-group: client.governance.data.findings
+      x-speakeasy-name-override: create
     get:
       operationId: listfindingsexports
       summary: Lists findings exports
@@ -3056,6 +3072,8 @@ paths:
         "500":
           description: Internal error
       x-visibility: Public
+      x-speakeasy-group: client.governance.data.findings
+      x-speakeasy-name-override: list
   /rest/api/v1/governance/data/findings/exports/{id}:
     get:
       operationId: downloadfindingsexport
@@ -3085,6 +3103,8 @@ paths:
         "500":
           description: Internal error
       x-visibility: Public
+      x-speakeasy-group: client.governance.data.findings
+      x-speakeasy-name-override: download
     delete:
       operationId: deletefindingsexport
       summary: Deletes findings export
@@ -3109,6 +3129,8 @@ paths:
         "500":
           description: Internal error
       x-visibility: Public
+      x-speakeasy-group: client.governance.data.findings
+      x-speakeasy-name-override: delete
   /rest/api/v1/configure/datasources/{datasourceId}/instances/{instanceId}:
     get:
       operationId: getDatasourceInstanceConfiguration
@@ -3150,6 +3172,8 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
       x-visibility: Preview
+      x-speakeasy-group: client.datasources
+      x-speakeasy-name-override: retrieveConfiguration
     patch:
       operationId: updateDatasourceInstanceConfiguration
       summary: Update datasource instance configuration
@@ -3196,6 +3220,8 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
       x-visibility: Preview
+      x-speakeasy-group: client.datasources
+      x-speakeasy-name-override: updateConfiguration
   /rest/api/v1/datasource/{datasourceInstanceId}/credentialstatus:
     get:
       operationId: getDatasourceCredentialStatus
@@ -3236,6 +3262,8 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
       x-visibility: Preview
+      x-speakeasy-group: client.datasources
+      x-speakeasy-name-override: retrieveCredentialStatus
   /rest/api/v1/datasource/{datasourceInstanceId}/credentials:
     post:
       operationId: rotateDatasourceCredentials
@@ -3283,6 +3311,8 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
       x-visibility: Preview
+      x-speakeasy-group: client.datasources
+      x-speakeasy-name-override: rotateCredentials
   /rest/api/v1/chat#stream:
     post:
       tags:

--- a/overlayed_specs/glean-merged-spec.yaml
+++ b/overlayed_specs/glean-merged-spec.yaml
@@ -671,6 +671,8 @@ paths:
         "429":
           description: Too Many Requests
       x-visibility: Public
+      x-speakeasy-name-override: checkDatasourceAuth
+      x-speakeasy-group: client.authentication
   /rest/api/v1/createauthtoken:
     post:
       operationId: createauthtoken
@@ -1171,6 +1173,8 @@ paths:
         "500":
           description: Internal server error.
       x-visibility: Public
+      x-speakeasy-name-override: retrieveFile
+      x-speakeasy-group: client.chat
   /rest/api/v1/agents:
     post:
       operationId: createAgent
@@ -1205,6 +1209,8 @@ paths:
         "500":
           description: Internal server error
       x-visibility: Preview
+      x-speakeasy-group: client.agents
+      x-speakeasy-name-override: create
   /rest/api/v1/agents/{agent_id}:
     get:
       operationId: getAgent
@@ -1290,6 +1296,8 @@ paths:
         "500":
           description: Internal server error
       x-visibility: Preview
+      x-speakeasy-group: client.agents
+      x-speakeasy-name-override: update
   /rest/api/v1/agents/{agent_id}/schemas:
     get:
       operationId: getAgentSchemas
@@ -2486,6 +2494,8 @@ paths:
         "429":
           description: Too Many Requests.
       x-visibility: Public
+      x-speakeasy-name-override: retrievePersonPhoto
+      x-speakeasy-group: client.entities
   /rest/api/v1/createshortcut:
     post:
       operationId: createshortcut
@@ -2907,6 +2917,8 @@ paths:
         "429":
           description: Too Many Requests
       x-visibility: Preview
+      x-speakeasy-name-override: retrieveActionPackAuthStatus
+      x-speakeasy-group: client.tools
     post:
       operationId: authorizeActionPack
       summary: Start the OAuth authorization flow for an action pack.
@@ -2946,6 +2958,8 @@ paths:
         "429":
           description: Too Many Requests
       x-visibility: Preview
+      x-speakeasy-name-override: authorizeActionPack
+      x-speakeasy-group: client.tools
     parameters:
       - name: actionPackId
         in: path
@@ -4072,6 +4086,8 @@ paths:
         "429":
           description: Too Many Requests
       x-beta: true
+      x-speakeasy-group: indexing.documents
+      x-speakeasy-name-override: debugEvents
   /rest/api/index/document/{docId}/custom-metadata/{groupName}:
     put:
       summary: Add or update custom metadata
@@ -4580,6 +4596,8 @@ paths:
         "500":
           description: Internal error
       x-visibility: Public
+      x-speakeasy-group: client.governance.data.findings
+      x-speakeasy-name-override: create
     get:
       operationId: listfindingsexports
       summary: Lists findings exports
@@ -4600,6 +4618,8 @@ paths:
         "500":
           description: Internal error
       x-visibility: Public
+      x-speakeasy-group: client.governance.data.findings
+      x-speakeasy-name-override: list
   /rest/api/v1/governance/data/findings/exports/{id}:
     get:
       operationId: downloadfindingsexport
@@ -4629,6 +4649,8 @@ paths:
         "500":
           description: Internal error
       x-visibility: Public
+      x-speakeasy-group: client.governance.data.findings
+      x-speakeasy-name-override: download
     delete:
       operationId: deletefindingsexport
       summary: Deletes findings export
@@ -4653,6 +4675,8 @@ paths:
         "500":
           description: Internal error
       x-visibility: Public
+      x-speakeasy-group: client.governance.data.findings
+      x-speakeasy-name-override: delete
   /rest/api/v1/configure/datasources/{datasourceId}/instances/{instanceId}:
     get:
       operationId: getDatasourceInstanceConfiguration
@@ -4694,6 +4718,8 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
       x-visibility: Preview
+      x-speakeasy-group: client.datasources
+      x-speakeasy-name-override: retrieveConfiguration
     patch:
       operationId: updateDatasourceInstanceConfiguration
       summary: Update datasource instance configuration
@@ -4740,6 +4766,8 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
       x-visibility: Preview
+      x-speakeasy-group: client.datasources
+      x-speakeasy-name-override: updateConfiguration
   /rest/api/v1/datasource/{datasourceInstanceId}/credentialstatus:
     get:
       operationId: getDatasourceCredentialStatus
@@ -4780,6 +4808,8 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
       x-visibility: Preview
+      x-speakeasy-group: client.datasources
+      x-speakeasy-name-override: retrieveCredentialStatus
   /rest/api/v1/datasource/{datasourceInstanceId}/credentials:
     post:
       operationId: rotateDatasourceCredentials
@@ -4827,6 +4857,8 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
       x-visibility: Preview
+      x-speakeasy-group: client.datasources
+      x-speakeasy-name-override: rotateCredentials
   /rest/api/v1/chat#stream:
     post:
       tags:

--- a/overlays/admin-modifications-overlay.yaml
+++ b/overlays/admin-modifications-overlay.yaml
@@ -46,3 +46,39 @@ actions:
     update:
       x-speakeasy-group: client.governance.documents.visibilityoverrides
       x-speakeasy-name-override: create
+
+  # Governance data findings exports
+  - target: $["paths"]["/rest/api/v1/governance/data/findings/exports"]["get"]
+    update:
+      x-speakeasy-group: client.governance.data.findings
+      x-speakeasy-name-override: list
+  - target: $["paths"]["/rest/api/v1/governance/data/findings/exports"]["post"]
+    update:
+      x-speakeasy-group: client.governance.data.findings
+      x-speakeasy-name-override: create
+  - target: $["paths"]["/rest/api/v1/governance/data/findings/exports/{id}"]["get"]
+    update:
+      x-speakeasy-group: client.governance.data.findings
+      x-speakeasy-name-override: download
+  - target: $["paths"]["/rest/api/v1/governance/data/findings/exports/{id}"]["delete"]
+    update:
+      x-speakeasy-group: client.governance.data.findings
+      x-speakeasy-name-override: delete
+
+  # Datasource configuration & credentials (admin)
+  - target: $["paths"]["/rest/api/v1/configure/datasources/{datasourceId}/instances/{instanceId}"]["get"]
+    update:
+      x-speakeasy-group: client.datasources
+      x-speakeasy-name-override: retrieveConfiguration
+  - target: $["paths"]["/rest/api/v1/configure/datasources/{datasourceId}/instances/{instanceId}"]["patch"]
+    update:
+      x-speakeasy-group: client.datasources
+      x-speakeasy-name-override: updateConfiguration
+  - target: $["paths"]["/rest/api/v1/datasource/{datasourceInstanceId}/credentialstatus"]["get"]
+    update:
+      x-speakeasy-group: client.datasources
+      x-speakeasy-name-override: retrieveCredentialStatus
+  - target: $["paths"]["/rest/api/v1/datasource/{datasourceInstanceId}/credentials"]["post"]
+    update:
+      x-speakeasy-group: client.datasources
+      x-speakeasy-name-override: rotateCredentials

--- a/overlays/agent-modifications-overlay.yaml
+++ b/overlays/agent-modifications-overlay.yaml
@@ -5,10 +5,20 @@ info:
   version: 0.0.5
 
 actions:
+  - target: $["paths"]["/rest/api/v1/agents"]["post"]
+    update:
+      x-speakeasy-group: client.agents
+      x-speakeasy-name-override: create
+
   - target: $["paths"]["/rest/api/v1/agents/{agent_id}"]["get"]
     update:
       x-speakeasy-group: client.agents
       x-speakeasy-name-override: retrieve
+
+  - target: $["paths"]["/rest/api/v1/agents/{agent_id}"]["post"]
+    update:
+      x-speakeasy-group: client.agents
+      x-speakeasy-name-override: update
 
   - target: $["paths"]["/rest/api/v1/agents/{agent_id}/schemas"]["get"]
     update:

--- a/overlays/client-modifications-overlay.yaml
+++ b/overlays/client-modifications-overlay.yaml
@@ -63,6 +63,11 @@ actions:
       x-speakeasy-name-override: createToken
       x-speakeasy-group: client.authentication
 
+  - target: $["paths"]["/rest/api/v1/checkdatasourceauth"]["post"]
+    update:
+      x-speakeasy-name-override: checkDatasourceAuth
+      x-speakeasy-group: client.authentication
+
   # Chat
   - target: $["paths"]["/rest/api/v1/chat"]["post"]
     update:
@@ -114,6 +119,11 @@ actions:
   - target: $["paths"]["/rest/api/v1/listchats"]["post"]
     update:
       x-speakeasy-name-override: list
+      x-speakeasy-group: client.chat
+
+  - target: $["paths"]["/rest/api/v1/chat-files/{fileId}"]["get"]
+    update:
+      x-speakeasy-name-override: retrieveFile
       x-speakeasy-group: client.chat
 
   # Collections
@@ -182,6 +192,11 @@ actions:
   - target: $["paths"]["/rest/api/v1/people"]["post"]
     update:
       x-speakeasy-name-override: readPeople
+      x-speakeasy-group: client.entities
+
+  - target: $["paths"]["/rest/api/v1/people/{person_id}/photo"]["get"]
+    update:
+      x-speakeasy-name-override: retrievePersonPhoto
       x-speakeasy-group: client.entities
 
   # Insights
@@ -293,6 +308,16 @@ actions:
       tags:
         - Tools
       x-speakeasy-name-override: run
+      x-speakeasy-group: client.tools
+
+  - target: $["paths"]["/rest/api/v1/actions/actionpack/{actionPackId}/auth"]["get"]
+    update:
+      x-speakeasy-name-override: retrieveActionPackAuthStatus
+      x-speakeasy-group: client.tools
+
+  - target: $["paths"]["/rest/api/v1/actions/actionpack/{actionPackId}/auth"]["post"]
+    update:
+      x-speakeasy-name-override: authorizeActionPack
       x-speakeasy-group: client.tools
 
   # Verification

--- a/overlays/indexing-modifications-overlay.yaml
+++ b/overlays/indexing-modifications-overlay.yaml
@@ -195,6 +195,11 @@ actions:
       x-speakeasy-group: indexing.documents
       x-speakeasy-name-override: debug
 
+  - target: $["paths"]["/api/index/v1/debug/{datasource}/document/events"]["post"]
+    update:
+      x-speakeasy-group: indexing.documents
+      x-speakeasy-name-override: debugEvents
+
   - target: $["paths"]["/api/index/v1/debug/{datasource}/user"]["post"]
     update:
       x-speakeasy-name-override: debug

--- a/tests/post_transform_smoke.test.js
+++ b/tests/post_transform_smoke.test.js
@@ -216,4 +216,49 @@ describe('Post-transformation smoke tests', () => {
 
     expect(JSON.stringify(spec)).not.toContain('gated-by');
   });
+
+  test('every operation carries an x-speakeasy-group with an allowed top-level namespace', () => {
+    // The SDK namespace is derived from x-speakeasy-group. Any operation
+    // without a group silently falls back to its `tags` and leaks a method to
+    // the SDK top level. The top level is reserved for the Platform API, so
+    // client/indexing operations must be nested under `client.*` / `indexing.*`.
+    // `agents` and `search` are the intentional Platform (top-level) groups.
+    const allowedTopLevelSegments = new Set([
+      'client',
+      'indexing',
+      'agents',
+      'search',
+    ]);
+    const methods = ['get', 'post', 'put', 'delete', 'patch'];
+
+    const ungrouped = [];
+    const badTopLevel = [];
+
+    for (const [path, pathItem] of Object.entries(spec.paths ?? {})) {
+      for (const method of methods) {
+        const operation = pathItem?.[method];
+        if (!operation) continue;
+
+        const group = operation['x-speakeasy-group'];
+        if (!group) {
+          ungrouped.push(`${method.toUpperCase()} ${path}`);
+          continue;
+        }
+
+        const topLevelSegment = group.split('.')[0];
+        if (!allowedTopLevelSegments.has(topLevelSegment)) {
+          badTopLevel.push(`${method.toUpperCase()} ${path} -> ${group}`);
+        }
+      }
+    }
+
+    expect(
+      ungrouped,
+      `operations missing x-speakeasy-group (they would leak to the SDK top level via their tags):\n${ungrouped.join('\n')}`,
+    ).toEqual([]);
+    expect(
+      badTopLevel,
+      `operations with an unexpected top-level SDK namespace:\n${badTopLevel.join('\n')}`,
+    ).toEqual([]);
+  });
 });


### PR DESCRIPTION
## Problem

Client and indexing API methods are reachable at the **top level** of the generated SDKs when they should only be reachable under their namespace. For example, today both of these work:

```ts
glean.chat.getChatFile()         // ❌ should not exist
glean.client.chat.retrieveFile() // ✅ correct
```

The SDK top level is meant to hold **only** the Platform API.

## Root cause

Speakeasy derives each SDK method's namespace from `x-speakeasy-group`. When an operation has **no** group override, it falls back to the operation's `tags`, which places the method at the **top level**. The `client.*` / `indexing.*` groups are applied by hand-maintained overlays, and a handful of operations were never added — so they leak.

The handled set is essentially the original flat RPC endpoints (`POST /rest/api/v1/<verb><noun>`). The misses are mostly newer RESTful/GET endpoints added after the overlays were authored, plus one flat-POST oversight (`checkdatasourceauth`) and two agents ops the dedicated agents overlay never covered.

## Fix

### Part 1 — Close the leaks
Added `x-speakeasy-group` (+ `x-speakeasy-name-override`) for every previously ungrouped client/indexing operation:

**`client-modifications-overlay.yaml`**
- `getChatFile` → `client.chat` (`retrieveFile`)
- `checkdatasourceauth` → `client.authentication` (`checkDatasourceAuth`)
- `getPersonPhoto` → `client.entities` (`retrievePersonPhoto`)
- `getActionPackAuthStatus` → `client.tools` (`retrieveActionPackAuthStatus`)
- `authorizeActionPack` → `client.tools` (`authorizeActionPack`)

**`agent-modifications-overlay.yaml`**
- `createAgent` → `client.agents` (`create`)
- `editAgent` → `client.agents` (`update`)

**`admin-modifications-overlay.yaml`**
- findings exports (list/create/download/delete) → `client.governance.data.findings`
- datasource config + credentials (get/patch/get/post) → `client.datasources` (`retrieveConfiguration` / `updateConfiguration` / `retrieveCredentialStatus` / `rotateCredentials`)

**`indexing-modifications-overlay.yaml`**
- `debug/{datasource}/document/events` → `indexing.documents` (`debugEvents`)

Regenerated `overlayed_specs/glean-merged-spec.yaml` and `overlayed_specs/glean-client-api-specs.yaml` via `speakeasy run`. The merged spec now only has these top-level segments: `client`, `indexing`, and the intentional Platform groups `agents` / `search`.

### Part 2 — Regression guard
Extended `tests/post_transform_smoke.test.js` to assert that **every** operation in the merged spec carries an `x-speakeasy-group` whose top-level segment is on an allowlist (`client`, `indexing`, `agents`, `search`). Any future ungrouped or mis-prefixed endpoint now fails CI instead of silently leaking.

## Naming decisions (please review)
These were open questions flagged during planning; sensible defaults were chosen and are easy to adjust:
1. Method names for the newly grouped ops (e.g. `getChatFile` → `retrieveFile`).
2. Findings exports placed under a **new** `client.governance.data.findings` subgroup (vs. folding into existing `.reports`).
3. Introduced a **new** `client.datasources` namespace for the admin datasource config/credential ops.
4. Indexing debug events op placed under `indexing.documents` as `debugEvents`.

## ⚠️ Breaking change
Removing the top-level aliases (`glean.chat.getChatFile()`, `glean.governance.*`, `glean.datasources.*`, etc.) is a **breaking change** for anyone using the old paths. This must be called out in the SDK release notes / changelogs when the clients regenerate.

## Verification
- `pnpm test` → 71 passing (incl. the new guard)
- `pnpm lint` → clean
- Confirmed 0 ungrouped and 0 unexpected-top-level operations in the merged spec.