### PR TITLE
Add x-speakeasy-group for tool-servers auth operations

### DIFF
--- a/overlays/client-modifications-overlay.yaml
+++ b/overlays/client-modifications-overlay.yaml
@@ -320,6 +320,16 @@ actions:
       x-speakeasy-name-override: authorizeActionPack
       x-speakeasy-group: client.tools
 
+  - target: $["paths"]["/rest/api/v1/tool-servers/{serverId}/auth"]["get"]
+    update:
+      x-speakeasy-name-override: retrieveToolServerAuthStatus
+      x-speakeasy-group: client.tools
+
+  - target: $["paths"]["/rest/api/v1/tool-servers/{serverId}/auth"]["post"]
+    update:
+      x-speakeasy-name-override: authorizeToolServer
+      x-speakeasy-group: client.tools
+
   # Verification
   - target: $["paths"]["/rest/api/v1/listverifications"]["post"]
     update:


### PR DESCRIPTION
## Problem

The [transform workflow](https://github.com/gleanwork/open-api/actions/runs/28821431844/job/85473790188) is failing at the post-transformation smoke test:

```
operations missing x-speakeasy-group (they would leak to the SDK top level via their tags):
GET /rest/api/v1/tool-servers/{serverId}/auth
POST /rest/api/v1/tool-servers/{serverId}/auth
```

## Root cause

A recent "Update OpenAPI specs" commit added two new tool-server auth operations (`getToolServerAuthStatus` and `authorizeToolServer`) to `source_specs/client_rest.yaml`, but no corresponding `x-speakeasy-group` was defined in the client overlay. Without a group, these operations fall back to their `tags` and leak methods to the SDK top level (reserved for the Platform API), which the smoke test guards against.

## Fix

Added overlay entries for both operations under the existing `client.tools` group, following the same pattern as the `actionpack/{actionPackId}/auth` operations.

## Verification

Ran `pnpm run transform:source_specs` + `speakeasy run -s glean-api-specs` locally and confirmed both operations now carry `x-speakeasy-group: client.tools`, and the previously-failing smoke test passes.