### PR TITLE
Add includeExperimental flag to experimental endpoint code samples

### DIFF
--- a/src/code-sample-transformer.js
+++ b/src/code-sample-transformer.js
@@ -17,6 +17,33 @@ export function* codeSnippets(pathSpec) {
 }
 
 /**
+ * Generator that yields language and code sample pairs from pathSpec, but only
+ * for operations that are marked as experimental via `x-glean-experimental`.
+ *
+ * Experimental endpoints are gated behind an opt-in flag in the SDKs (surfaced
+ * as the `X-Glean-Include-Experimental` request header). Without it, the SDK
+ * will refuse to call the endpoint, so the generated samples for these
+ * operations need the flag to actually run.
+ *
+ * @param {Object} pathSpec The OpenAPI spec object for the specific path being processed
+ * @yields {[string, Object]} A tuple containing the language and code sample object
+ */
+export function* experimentalCodeSnippets(pathSpec) {
+  for (const [_, methodSpec] of Object.entries(pathSpec)) {
+    if (
+      methodSpec &&
+      methodSpec['x-glean-experimental'] &&
+      methodSpec['x-codeSamples']
+    ) {
+      const codeSamples = methodSpec['x-codeSamples'];
+      for (const sample of codeSamples) {
+        yield [sample.lang, sample];
+      }
+    }
+  }
+}
+
+/**
  * Extracts code snippet for a specific language from pathSpec
  * @param {Object} pathSpec The OpenAPI spec object for the specific path being processed
  * @param {string} language The language to extract code snippets for
@@ -140,6 +167,81 @@ export function addServerURLToCodeSamples(spec) {
 }
 
 /**
+ * Transforms code samples for experimental endpoints (those marked with
+ * `x-glean-experimental`) so they include the SDK option needed to opt into
+ * experimental features. Without this option the SDKs will not call the
+ * endpoint, so the samples would not actually run as-is.
+ *
+ * This must run *after* {@link addServerURLToCodeSamples} so that the
+ * server URL constructor line already exists to anchor the injection onto
+ * (for Python/TypeScript/Go).
+ *
+ * Supported transformations:
+ * - Python: Adds `include_experimental=True,` after the `server_url` line
+ * - TypeScript: Adds `includeExperimental: true,` after the `serverURL` line
+ * - Go: Adds `apiclientgo.WithIncludeExperimental(true),` after `WithServerURL`
+ * - Java: Swaps `Glean.builder()` for the regen-safe `GleanBuilder.create()`
+ *   (adding its import) and adds `.includeExperimental(true)` after `.apiToken(...)`
+ *
+ * @param {Object} spec The OpenAPI specification object containing code samples
+ * @returns {Object} The modified OpenAPI specification with updated code samples
+ */
+export function addIncludeExperimentalToCodeSamples(spec) {
+  const transformationsByLang = {
+    python: [
+      [
+        /([\s]*)(server_url="https:\/\/mycompany-be\.glean\.com",)/,
+        '$1$2$1include_experimental=True,',
+      ],
+    ],
+    typescript: [
+      [
+        /([\s]*)(serverURL: "https:\/\/mycompany-be\.glean\.com",)/,
+        '$1$2$1includeExperimental: true,',
+      ],
+    ],
+    go: [
+      [
+        /([\s]*)(apiclientgo\.WithServerURL\("https:\/\/mycompany-be\.glean\.com"\),)/,
+        '$1$2$1apiclientgo.WithIncludeExperimental(true),',
+      ],
+    ],
+    java: [
+      // The experimental flag lives on the regen-safe GleanBuilder, so add its
+      // import alongside the existing Glean import.
+      [
+        /(import com\.glean\.api_client\.glean_api_client\.Glean;\n)/,
+        '$1import com.glean.api_client.glean_api_client.hooks.GleanBuilder;\n',
+      ],
+      // Swap the generated builder for the regen-safe one that exposes the flag.
+      [/Glean\.builder\(\)/, 'GleanBuilder.create()'],
+      // Add the flag right after the apiToken(...) call, matching indentation.
+      [/([\s]*)(\.apiToken\([^\n]*\))/, '$1$2$1.includeExperimental(true)'],
+    ],
+  };
+
+  for (const [_, pathSpec] of path(spec)) {
+    for (const [lang, codeSample] of experimentalCodeSnippets(pathSpec)) {
+      const transformations = transformationsByLang[lang];
+
+      if (!transformations) {
+        continue;
+      }
+
+      let codeSampleSource = codeSample.source;
+
+      for (const [pattern, replacement] of transformations) {
+        codeSampleSource = codeSampleSource.replace(pattern, replacement);
+      }
+
+      codeSample.source = codeSampleSource;
+    }
+  }
+
+  return spec;
+}
+
+/**
  * Transforms OpenAPI YAML by adjusting server URLs and paths
  * @param {string} content The OpenAPI YAML content
  * @param {string} filename The name of the file being processed
@@ -150,6 +252,7 @@ export function transform(content, _filename) {
 
   transformPythonCodeSamplesToPython(spec);
   addServerURLToCodeSamples(spec);
+  addIncludeExperimentalToCodeSamples(spec);
 
   return yaml.dump(spec, {
     lineWidth: -1, // Preserve line breaks

--- a/tests/code-sample-transformer.test.js
+++ b/tests/code-sample-transformer.test.js
@@ -286,4 +286,161 @@ paths:
       `);
     });
   });
+
+  describe('experimentalCodeSnippets', () => {
+    test('yields samples only for operations marked x-glean-experimental', () => {
+      const spec = yaml.load(
+        readFixture('example-with-experimental-code-samples.yaml'),
+      );
+
+      const experimentalLangs = [];
+      for (const [, pathSpec] of codeSampleTransformer.path(spec)) {
+        for (const [lang] of codeSampleTransformer.experimentalCodeSnippets(
+          pathSpec,
+        )) {
+          experimentalLangs.push(lang);
+        }
+      }
+
+      // Only the /api/agents/search (experimental) samples should be yielded,
+      // not the /api/agents/stable ones.
+      expect(experimentalLangs).toMatchInlineSnapshot(`
+        [
+          "python",
+          "typescript",
+          "go",
+          "java",
+        ]
+      `);
+    });
+  });
+
+  describe('addIncludeExperimentalToCodeSamples', () => {
+    let spec;
+
+    beforeEach(() => {
+      spec = yaml.load(
+        readFixture('example-with-experimental-code-samples.yaml'),
+      );
+      // Mirror the production order: server URL is injected first, then the
+      // experimental flag is anchored onto it.
+      codeSampleTransformer.addServerURLToCodeSamples(spec);
+      codeSampleTransformer.addIncludeExperimentalToCodeSamples(spec);
+    });
+
+    test('adds include_experimental to the experimental Python sample', () => {
+      const experimentalSpec = spec.paths['/api/agents/search'];
+
+      expect(
+        codeSampleTransformer.extractCodeSnippet(experimentalSpec, 'python')
+          .source,
+      ).toMatchInlineSnapshot(`
+        "from glean.api_client import Glean
+        import os
+
+
+        with Glean(
+            api_token=os.getenv("GLEAN_API_TOKEN", ""),
+            server_url="https://mycompany-be.glean.com",
+            include_experimental=True,
+        ) as glean:
+
+            res = glean.agents.search(name="HR Policy Agent")
+
+            # Handle response
+            print(res)"
+      `);
+    });
+
+    test('adds includeExperimental to the experimental TypeScript sample', () => {
+      const experimentalSpec = spec.paths['/api/agents/search'];
+
+      expect(
+        codeSampleTransformer.extractCodeSnippet(experimentalSpec, 'typescript')
+          .source,
+      ).toMatchInlineSnapshot(`
+        "import { Glean } from "@gleanwork/api-client";
+
+        const glean = new Glean({
+          apiToken: process.env["GLEAN_API_TOKEN"] ?? "",
+          serverURL: "https://mycompany-be.glean.com",
+          includeExperimental: true,
+        });
+
+        async function run() {
+          const result = await glean.agents.search({
+            name: "HR Policy Agent",
+          });
+
+          console.log(result);
+        }
+
+        run();"
+      `);
+    });
+
+    test('adds WithIncludeExperimental to the experimental Go sample', () => {
+      const experimentalSpec = spec.paths['/api/agents/search'];
+
+      expect(
+        codeSampleTransformer.extractCodeSnippet(experimentalSpec, 'go').source,
+      ).toContain('apiclientgo.WithIncludeExperimental(true),');
+    });
+
+    test('swaps to GleanBuilder and adds includeExperimental in the experimental Java sample', () => {
+      const experimentalSpec = spec.paths['/api/agents/search'];
+
+      expect(
+        codeSampleTransformer.extractCodeSnippet(experimentalSpec, 'java')
+          .source,
+      ).toMatchInlineSnapshot(`
+        "package hello.world;
+
+        import com.glean.api_client.glean_api_client.Glean;
+        import com.glean.api_client.glean_api_client.hooks.GleanBuilder;
+        import com.glean.api_client.glean_api_client.models.components.PlatformAgentsSearchRequest;
+        import com.glean.api_client.glean_api_client.models.operations.PlatformAgentsSearchResponse;
+        import java.lang.Exception;
+
+        public class Application {
+
+            public static void main(String[] args) throws Exception {
+
+                Glean sdk = GleanBuilder.create()
+                        .apiToken(System.getenv().getOrDefault("GLEAN_API_TOKEN", ""))
+                        .includeExperimental(true)
+                    .build();
+
+                PlatformAgentsSearchResponse res = sdk.agents().search()
+                        .request(PlatformAgentsSearchRequest.builder()
+                            .name("HR Policy Agent")
+                            .build())
+                        .call();
+
+                if (res.platformAgentsSearchResponse().isPresent()) {
+                    System.out.println(res.platformAgentsSearchResponse().get());
+                }
+            }
+        }"
+      `);
+    });
+
+    test('does not modify non-experimental samples', () => {
+      const stableSpec = spec.paths['/api/agents/stable'];
+
+      const python = codeSampleTransformer.extractCodeSnippet(
+        stableSpec,
+        'python',
+      ).source;
+      const java = codeSampleTransformer.extractCodeSnippet(
+        stableSpec,
+        'java',
+      ).source;
+
+      expect(python).not.toContain('include_experimental');
+      expect(java).not.toContain('includeExperimental');
+      expect(java).not.toContain('GleanBuilder');
+      expect(java).toContain('Glean.builder()');
+    });
+  });
 });

--- a/tests/fixtures/example-with-experimental-code-samples.yaml
+++ b/tests/fixtures/example-with-experimental-code-samples.yaml
@@ -1,0 +1,168 @@
+openapi: 3.0.0
+info:
+  version: 0.9.0
+  title: Glean Platform API
+  x-speakeasy-name: 'Glean Platform API'
+servers:
+  - url: https://{instance}-be.glean.com
+    variables:
+      instance:
+        default: instance-name
+security:
+  - APIToken: []
+paths:
+  /api/agents/search:
+    post:
+      tags:
+        - Agents
+      summary: Search agents
+      operationId: platform-agents-search
+      x-visibility: Public
+      x-glean-experimental:
+        id: 4abc1e17-8e06-490b-99a7-e8f97592405a
+        introduced: '2026-05-12'
+      x-speakeasy-group: agents
+      x-speakeasy-name-override: search
+      responses:
+        '200':
+          description: OK
+      x-codeSamples:
+        - lang: python
+          label: Python (API Client)
+          source: |-
+            from glean.api_client import Glean
+            import os
+
+
+            with Glean(
+                api_token=os.getenv("GLEAN_API_TOKEN", ""),
+            ) as glean:
+
+                res = glean.agents.search(name="HR Policy Agent")
+
+                # Handle response
+                print(res)
+        - lang: typescript
+          label: Typescript (API Client)
+          source: |-
+            import { Glean } from "@gleanwork/api-client";
+
+            const glean = new Glean({
+              apiToken: process.env["GLEAN_API_TOKEN"] ?? "",
+            });
+
+            async function run() {
+              const result = await glean.agents.search({
+                name: "HR Policy Agent",
+              });
+
+              console.log(result);
+            }
+
+            run();
+        - lang: go
+          label: Go (API Client)
+          source: |-
+            package main
+
+            import(
+            	"context"
+            	"os"
+            	apiclientgo "github.com/gleanwork/api-client-go"
+            	"github.com/gleanwork/api-client-go/models/components"
+            	"log"
+            )
+
+            func main() {
+                ctx := context.Background()
+
+                s := apiclientgo.New(
+                    apiclientgo.WithSecurity(os.Getenv("GLEAN_API_TOKEN")),
+                )
+
+                res, err := s.Agents.Search(ctx, components.PlatformAgentsSearchRequest{
+                    Name: apiclientgo.Pointer("HR Policy Agent"),
+                })
+                if err != nil {
+                    log.Fatal(err)
+                }
+                if res.PlatformAgentsSearchResponse != nil {
+                    // handle response
+                }
+            }
+        - lang: java
+          label: Java (API Client)
+          source: |-
+            package hello.world;
+
+            import com.glean.api_client.glean_api_client.Glean;
+            import com.glean.api_client.glean_api_client.models.components.PlatformAgentsSearchRequest;
+            import com.glean.api_client.glean_api_client.models.operations.PlatformAgentsSearchResponse;
+            import java.lang.Exception;
+
+            public class Application {
+
+                public static void main(String[] args) throws Exception {
+
+                    Glean sdk = Glean.builder()
+                            .apiToken(System.getenv().getOrDefault("GLEAN_API_TOKEN", ""))
+                        .build();
+
+                    PlatformAgentsSearchResponse res = sdk.agents().search()
+                            .request(PlatformAgentsSearchRequest.builder()
+                                .name("HR Policy Agent")
+                                .build())
+                            .call();
+
+                    if (res.platformAgentsSearchResponse().isPresent()) {
+                        System.out.println(res.platformAgentsSearchResponse().get());
+                    }
+                }
+            }
+  /api/agents/stable:
+    post:
+      tags:
+        - Agents
+      summary: Stable (non-experimental) endpoint
+      operationId: platform-agents-stable
+      x-visibility: Public
+      x-speakeasy-group: agents
+      x-speakeasy-name-override: stable
+      responses:
+        '200':
+          description: OK
+      x-codeSamples:
+        - lang: python
+          label: Python (API Client)
+          source: |-
+            from glean.api_client import Glean
+            import os
+
+
+            with Glean(
+                api_token=os.getenv("GLEAN_API_TOKEN", ""),
+            ) as glean:
+
+                res = glean.agents.stable()
+
+                # Handle response
+                print(res)
+        - lang: java
+          label: Java (API Client)
+          source: |-
+            package hello.world;
+
+            import com.glean.api_client.glean_api_client.Glean;
+            import java.lang.Exception;
+
+            public class Application {
+
+                public static void main(String[] args) throws Exception {
+
+                    Glean sdk = Glean.builder()
+                            .apiToken(System.getenv().getOrDefault("GLEAN_API_TOKEN", ""))
+                        .build();
+
+                    sdk.agents().stable().call();
+                }
+            }


### PR DESCRIPTION
## Summary

Endpoints marked with `x-glean-experimental` require the SDK's experimental opt-in (surfaced as the `X-Glean-Include-Experimental` request header). Without it, the SDKs refuse to call the endpoint — so the generated code samples for these operations don't actually run as-is.

This adds a post-processing transform that injects the experimental opt-in into the code samples for experimental endpoints only.

## Changes

- **`experimentalCodeSnippets(pathSpec)`** — generator that yields samples only for operations carrying `x-glean-experimental`.
- **`addIncludeExperimentalToCodeSamples(spec)`** — injects the flag per language, wired into `transform()` to run *after* `addServerURLToCodeSamples` (so the server-URL constructor line exists to anchor onto):
  - **Python**: `include_experimental=True,` after the `server_url` line
  - **TypeScript**: `includeExperimental: true,` after the `serverURL` line
  - **Go**: `apiclientgo.WithIncludeExperimental(true),` after `WithServerURL`
  - **Java**: swaps `Glean.builder()` → the regen-safe `GleanBuilder.create()` (adding its import) and appends `.includeExperimental(true)` after `.apiToken(...)`

## Notes

- Java uses the documented **regen-safe** `GleanBuilder.create()` because the generated `Glean.builder()` isn't guaranteed to expose `includeExperimental`. Since platform Java samples never carry a `serverURL` line, the Java edit anchors on `.apiToken(...)` instead.
- Verified end-to-end against the real `merged_code_samples_specs/glean-platform-merged-code-samples-spec.yaml`: all four `/api/agents/search` samples correctly gain the flag, and there are zero leaks into non-experimental samples.

## Testing

- New fixture `tests/fixtures/example-with-experimental-code-samples.yaml` (one experimental + one stable endpoint).
- 6 new tests covering all four languages + a guard that non-experimental samples stay untouched.
- All 77 tests pass; prettier clean.
