### PR TITLE
Allow Skills as a top-level SDK group

### DIFF
--- a/.github/workflows/transform.yml
+++ b/.github/workflows/transform.yml
@@ -6,6 +6,7 @@ on:
       - main
     paths:
       - 'source_specs/**'
+      - 'tests/post_transform_smoke.test.js'
   schedule:
     - cron: '0 0 * * *'
   workflow_dispatch:

--- a/tests/post_transform_smoke.test.js
+++ b/tests/post_transform_smoke.test.js
@@ -222,13 +222,13 @@ describe('Post-transformation smoke tests', () => {
     // without a group silently falls back to its `tags` and leaks a method to
     // the SDK top level. The top level is reserved for the Platform API, so
     // client/indexing operations must be nested under `client.*` / `indexing.*`.
-    // `agents` and `search` are the intentional Platform (top-level) groups.
+    const platformSegments = new Set(['agents', 'search', 'skills']);
     const allowedTopLevelSegments = new Set([
       'client',
       'indexing',
-      'agents',
-      'search',
+      ...platformSegments,
     ]);
+
     const methods = ['get', 'post', 'put', 'delete', 'patch'];
 
     const ungrouped = [];


### PR DESCRIPTION
## Summary

- allow `skills` as an intentional top-level Platform SDK group
- rerun the transform workflow when the post-transform smoke test changes

This follows the upstream metadata fix in https://github.com/askscio/scio/pull/261296. The generated Skills operations now correctly use `x-speakeasy-group: skills`, but the downstream smoke-test allowlist still rejected that namespace.

## Validation

- `pnpm test` (77 tests passed)
- `pnpm run lint`
- full source transformation and Speakeasy merge
- post-transform smoke tests (14 tests passed)
- `git diff --check`
