### PR TITLE
Fix indexing submission SDK grouping

### DIFF
--- a/.github/workflows/transform.yml
+++ b/.github/workflows/transform.yml
@@ -6,6 +6,7 @@ on:
       - main
     paths:
       - 'source_specs/**'
+      - 'overlays/**'
       - 'tests/post_transform_smoke.test.js'
   schedule:
     - cron: '0 0 * * *'

--- a/overlays/indexing-modifications-overlay.yaml
+++ b/overlays/indexing-modifications-overlay.yaml
@@ -22,6 +22,11 @@ actions:
       x-speakeasy-name-override: add
       x-speakeasy-group: indexing.datasources
 
+  - target: $["paths"]["/rest/api/index/submissions/{datasourceInstance}/{type}"]["post"]
+    update:
+      x-speakeasy-name-override: submit
+      x-speakeasy-group: indexing.datasources
+
   # Documents
   - target: $["paths"]["/api/index/v1/deletedocument"]["post"]
     update:


### PR DESCRIPTION
## Summary
- group the new datasource submission operation under `indexing.datasources`
- expose it as `submit` in generated SDKs
- rerun the transform workflow when overlays change

## Context
Fixes the post-transform smoke-test failure in [this workflow run](https://github.com/gleanwork/open-api/actions/runs/29435401343/job/87420679562), where `POST /rest/api/index/submissions/{datasourceInstance}/{type}` was missing `x-speakeasy-group`.

## Validation
- `pnpm run lint`
- `pnpm test` (77 tests passed)
- source transform + Speakeasy overlays
- `pnpm exec vitest run tests/post_transform_smoke.test.js` (14 tests passed)
