### PR TITLE
[fix] Add x-speakeasy-group overlays for new client API endpoints

### DIFF
--- a/overlays/agent-modifications-overlay.yaml
+++ b/overlays/agent-modifications-overlay.yaml
@@ -39,3 +39,8 @@ actions:
     update:
       x-speakeasy-group: client.agents
       x-speakeasy-name-override: runStream
+
+  - target: $["paths"]["/rest/api/v1/agents/{agent_id}/import"]["post"]
+    update:
+      x-speakeasy-group: client.agents
+      x-speakeasy-name-override: import

--- a/overlays/client-modifications-overlay.yaml
+++ b/overlays/client-modifications-overlay.yaml
@@ -330,6 +330,11 @@ actions:
       x-speakeasy-name-override: authorizeToolServer
       x-speakeasy-group: client.tools
 
+  - target: $["paths"]["/rest/api/v1/tool-servers/{serverId}/tools"]["get"]
+    update:
+      x-speakeasy-name-override: getToolServerTools
+      x-speakeasy-group: client.tools
+
   # Verification
   - target: $["paths"]["/rest/api/v1/listverifications"]["post"]
     update:


### PR DESCRIPTION
## Summary

CI failed on the transform workflow's post-transformation smoke tests after new client API endpoints landed without `x-speakeasy-group` assignments:

- `POST /rest/api/v1/agents/{agent_id}/import`
- `GET /rest/api/v1/tool-servers/{serverId}/tools`

Without these groups, operations would leak to the SDK top level via their tags. This adds overlay entries to nest them under `client.agents` and `client.tools`, matching existing patterns.

Failing run: https://github.com/gleanwork/open-api/actions/runs/31031963358/job/92394623827

## Test plan

- [x] Ran `pnpm run transform:source_specs` locally
- [x] Ran `speakeasy run -s glean-api-specs` and verified both endpoints receive the expected `x-speakeasy-group` values in `overlayed_specs/glean-merged-spec.yaml`
- [ ] CI transform workflow passes post-transformation smoke tests