### PR TITLE
[fix] Allow platform chat namespace in post-transform smoke tests

### DIFF
--- a/tests/post_transform_smoke.test.js
+++ b/tests/post_transform_smoke.test.js
@@ -182,6 +182,12 @@ describe('Post-transformation smoke tests', () => {
         group: 'search',
         nameOverride: 'query',
       },
+      {
+        path: '/api/chat',
+        method: 'post',
+        group: 'chat',
+        nameOverride: 'create',
+      },
     ];
 
     for (const { path, method, group, nameOverride } of platformOps) {
@@ -222,7 +228,7 @@ describe('Post-transformation smoke tests', () => {
     // without a group silently falls back to its `tags` and leaks a method to
     // the SDK top level. The top level is reserved for the Platform API, so
     // client/indexing operations must be nested under `client.*` / `indexing.*`.
-    const platformSegments = new Set(['agents', 'search', 'skills']);
+    const platformSegments = new Set(['agents', 'chat', 'search', 'skills']);
     const allowedTopLevelSegments = new Set([
       'client',
       'indexing',


### PR DESCRIPTION
## Summary

PR #140 fixed the missing `x-speakeasy-group` overlays for two new client API endpoints, but CI still fails on a separate issue: the new Platform API `POST /api/chat` endpoint uses `x-speakeasy-group: chat`, which the smoke test did not recognize as an allowed top-level SDK namespace.

This updates the post-transformation smoke test to treat `chat` as a valid Platform API namespace (alongside `agents`, `search`, and `skills`) and adds an explicit assertion for the new endpoint.

Failing run: https://github.com/gleanwork/open-api/actions/runs/31036664766/job/92410356368

## Test plan

- [x] Ran `pnpm exec vitest run tests/post_transform_smoke.test.js` locally after regenerating the merged spec
- [ ] CI transform workflow passes post-transformation smoke tests