### PR TITLE
Fix examples that contradict their schemas, and check them in CI

### DIFF
--- a/src/source-spec-transformer.js
+++ b/src/source-spec-transformer.js
@@ -1,6 +1,123 @@
 import yaml from 'js-yaml';
 
 /**
+ * Repairs `example` values that contradict the schema they are attached to.
+ *
+ * These examples are not decorative. Anything that builds a request body from the
+ * spec copies them verbatim — the developer site's interactive "try it" panel
+ * prefills exactly these values — so an example whose type does not match its
+ * schema ships a request the API rejects, and the first click on the page returns
+ * an error. Speakeasy's SDK samples mask the same defect by passing examples
+ * through typed models that silently coerce whatever does not fit, which is why a
+ * broken example can look correct in the Python tab and fail in the panel beside it.
+ *
+ * Each repair is guarded so it only fires on the wrong shape: once the upstream
+ * spec is corrected at source, every one of these becomes a no-op rather than
+ * clobbering a now-valid example. `validate-examples.js` is the general net that
+ * fails CI when a new mismatch appears; this function fixes the known ones.
+ *
+ * @param {Object} spec The OpenAPI spec object
+ * @returns {Object} The same spec, repaired in place
+ */
+export function transformInvalidExamples(spec) {
+  const schemas = spec.components?.schemas;
+  if (!schemas) return spec;
+
+  // `values` items are FacetFilterValue objects, not bare strings. Applies to
+  // every schema carrying a facet-filter example, request and response alike.
+  const repairFacetFilterValues = (filters) => {
+    if (!Array.isArray(filters)) return;
+    for (const filter of filters) {
+      if (!Array.isArray(filter?.values)) continue;
+      filter.values = filter.values.map((v) =>
+        typeof v === 'string' ? { value: v, relationType: 'EQUALS' } : v,
+      );
+    }
+  };
+  for (const schema of Object.values(schemas)) {
+    if (!schema?.example) continue;
+    repairFacetFilterValues(schema.example.facetFilters);
+    repairFacetFilterValues(schema.example.rewrittenFacetFilters);
+  }
+
+  // `status` is a single string ("Done"), not a list.
+  const documentMetadata = schemas.DocumentMetadata;
+  if (Array.isArray(documentMetadata?.example?.status)) {
+    documentMetadata.example.status = documentMetadata.example.status[0];
+  }
+
+  // CustomData maps a field name to a CustomDataValue object, so a bare string
+  // has to become the object's stringValue.
+  const customData = documentMetadata?.example?.customData;
+  if (customData && typeof customData === 'object') {
+    for (const [key, value] of Object.entries(customData)) {
+      if (typeof value === 'string') customData[key] = { stringValue: value };
+    }
+  }
+
+  // The schema calls this a "phone number as a number string" — so, a string.
+  const personMetadata = schemas.PersonMetadata;
+  if (typeof personMetadata?.example?.phone === 'number') {
+    personMetadata.example.phone = String(personMetadata.example.phone);
+  }
+
+  // objectName is a single string. Its example listed several candidate names,
+  // which reads as "any of these" but validates as none of them.
+  const objectName = schemas.objectName;
+  if (objectName?.type === 'string' && Array.isArray(objectName.example)) {
+    objectName.example = objectName.example[0];
+  }
+
+  // mustIncludeSuggestions is a QuerySuggestionList — the wrapper object, not the
+  // bare suggestion array the example supplied.
+  const suggestions = schemas.SearchResult?.example?.mustIncludeSuggestions;
+  if (Array.isArray(suggestions)) {
+    schemas.SearchResult.example.mustIncludeSuggestions = {
+      suggestions,
+    };
+  }
+
+  return spec;
+}
+
+/**
+ * Gives pagination `cursor` properties an empty-string example.
+ *
+ * A cursor has no example, so a renderer synthesizing a request body from the
+ * schema fills the placeholder `"string"` — and the API answers HTTP 500 to a
+ * malformed cursor rather than ignoring it, so the very first request a reader
+ * sends from the docs fails. An empty cursor means "start from the beginning",
+ * which is exactly what a first request wants, and is the only value that is both
+ * type-correct and semantically valid: any literal token we could invent would be
+ * expired or forged.
+ *
+ * The 500 is worth fixing at the API too — a bad cursor is a client error — but
+ * that would still leave the docs sending a request that fails, so the example is
+ * needed either way.
+ *
+ * @param {Object} spec The OpenAPI spec object
+ * @returns {Object} The same spec, updated in place
+ */
+export function transformCursorExamples(spec) {
+  const visit = (node, seen) => {
+    if (!node || typeof node !== 'object' || seen.has(node)) return;
+    seen.add(node);
+    const cursor = node.properties?.cursor;
+    if (
+      cursor &&
+      cursor.type === 'string' &&
+      cursor.example === undefined &&
+      !cursor.$ref
+    ) {
+      cursor.example = '';
+    }
+    for (const child of Object.values(node)) visit(child, seen);
+  };
+  visit(spec, new WeakSet());
+  return spec;
+}
+
+/**
  * Extracts the base path from a server URL
  * @param {string} url Server URL with variables
  * @returns {string} The base path
@@ -852,6 +969,12 @@ export function transform(content, filename, commitSha) {
   if (filename === 'admin_rest.yaml') {
     transformActAsBearerTokenToAPIToken(spec);
   }
+
+  // Repair examples that contradict their own schema, for all files
+  transformInvalidExamples(spec);
+
+  // Give pagination cursors an example the API accepts, for all files
+  transformCursorExamples(spec);
 
   // Inject open-api commit SHA if provided
   if (commitSha) {

--- a/src/validate-examples.js
+++ b/src/validate-examples.js
@@ -1,0 +1,257 @@
+/**
+ * Validates that every `example` in a spec agrees with the schema it is attached to.
+ *
+ * An example that contradicts its own schema is not a cosmetic problem. Renderers
+ * that build a request body from the spec copy example values verbatim, so a
+ * type-invalid example ships a request the API rejects — the developer site's
+ * interactive "try it" panel prefills exactly these values, and a wrong one turns
+ * the first click on a page into an error response. Speakeasy's SDK code samples
+ * hide the same defect, because they pass examples through typed models that
+ * silently coerce whatever does not fit, so a broken example can look fine in one
+ * tab and fail in another on the same page.
+ *
+ * Deliberately conservative: it reports only mismatches that are unambiguous, and
+ * stays silent wherever the intended shape is genuinely open to interpretation —
+ * `oneOf`/`anyOf`/`not`, and schemas that declare no type and carry no keyword to
+ * infer one from. A check that cries wolf on a valid spec gets switched off, which
+ * is worse than no check. `allOf` is checked rather than skipped, because it
+ * flattens deterministically (see mergeAllOf), and a missing type is inferred from
+ * `properties`/`additionalProperties`/`items`, since most schemas here describe an
+ * object without saying so.
+ */
+
+const SCALAR_CHECKS = {
+  string: (v) => typeof v === 'string',
+  number: (v) => typeof v === 'number',
+  integer: (v) => typeof v === 'number' && Number.isInteger(v),
+  boolean: (v) => typeof v === 'boolean',
+};
+
+/** Resolves local `#/components/...` refs. Returns null for anything external. */
+function resolveRef(spec, ref) {
+  if (typeof ref !== 'string' || !ref.startsWith('#/')) return null;
+  let node = spec;
+  for (const part of ref.slice(2).split('/')) {
+    node = node?.[part.replace(/~1/g, '/').replace(/~0/g, '~')];
+    if (node === undefined) return null;
+  }
+  return node ?? null;
+}
+
+/**
+ * Follows `$ref` chains to the schema that actually describes a value. Bounded
+ * because a self-referential chain in a malformed spec must not hang the build.
+ */
+function deref(spec, schema, depth = 0) {
+  if (!schema || typeof schema !== 'object' || depth > 20) return schema;
+  if (schema.$ref) {
+    const target = resolveRef(spec, schema.$ref);
+    return target ? deref(spec, target, depth + 1) : null;
+  }
+  return schema;
+}
+
+function typeName(value) {
+  if (Array.isArray(value)) return 'array';
+  if (value === null) return 'null';
+  return typeof value;
+}
+
+/**
+ * Flattens an `allOf` into a single object schema for the purpose of checking an
+ * example against it.
+ *
+ * `allOf` means the value satisfies every branch at once, so the union of the
+ * branches' properties is a faithful view — unlike `oneOf`/`anyOf`, where the
+ * intended branch is unknowable and checking would invent requirements. Returns
+ * null whenever a branch makes the result ambiguous, so the caller stays silent
+ * rather than guessing. Without this, a composed schema carrying an example (the
+ * usual shape for response schemas here) would never be checked at all.
+ */
+function mergeAllOf(spec, schema, depth) {
+  const merged = { type: 'object', properties: {} };
+  for (const branch of schema.allOf) {
+    const b = deref(spec, branch, depth);
+    if (!b || typeof b !== 'object') continue;
+    if (b.oneOf || b.anyOf || b.not) return null;
+    if (b.type && b.type !== 'object') return null;
+    if (b.allOf) {
+      const inner = mergeAllOf(spec, b, depth + 1);
+      if (!inner) return null;
+      Object.assign(merged.properties, inner.properties);
+      if (inner.additionalProperties)
+        merged.additionalProperties = inner.additionalProperties;
+      continue;
+    }
+    if (b.properties) Object.assign(merged.properties, b.properties);
+    if (b.additionalProperties && typeof b.additionalProperties === 'object') {
+      merged.additionalProperties = b.additionalProperties;
+    }
+  }
+  return merged;
+}
+
+/**
+ * Compares one example value against one schema, appending violations found.
+ *
+ * `path` is the spec location of the example being checked, so a failure names the
+ * schema a maintainer has to edit rather than just the shape that was wrong.
+ */
+function checkValue(spec, schema, value, path, out, depth = 0) {
+  if (depth > 12) return;
+  let s = deref(spec, schema);
+  if (!s || typeof s !== 'object') return;
+
+  // Composition and untyped schemas: the intended shape is ambiguous, so silence.
+  // `allOf` alone is the exception — it flattens deterministically.
+  if (s.allOf && !s.oneOf && !s.anyOf && !s.not) {
+    const flattened = mergeAllOf(spec, s, depth);
+    if (!flattened) return;
+    s = flattened;
+  } else if (s.oneOf || s.anyOf || s.allOf || s.not) {
+    return;
+  }
+  if (value === null) return; // nullable is spelled several ways across versions
+
+  if (s.enum && Array.isArray(s.enum) && !s.enum.includes(value)) {
+    out.push({
+      path,
+      problem: `value ${JSON.stringify(value)} is not one of the schema's enum values`,
+      expected: s.enum,
+      got: value,
+    });
+    return;
+  }
+
+  // Most schemas in these specs describe an object without saying `type: object`,
+  // which is legal and very common. Infer it from the keywords that only make
+  // sense for one type, or a wrong-shaped example against such a schema slips by.
+  const t =
+    s.type ??
+    (s.properties || s.additionalProperties
+      ? 'object'
+      : s.items
+        ? 'array'
+        : undefined);
+  if (!t) return;
+
+  if (t === 'array') {
+    if (!Array.isArray(value)) {
+      out.push({
+        path,
+        problem: `schema is type array but example is ${typeName(value)}`,
+        got: value,
+      });
+      return;
+    }
+    if (s.items) {
+      value.forEach((item, i) =>
+        checkValue(spec, s.items, item, `${path}[${i}]`, out, depth + 1),
+      );
+    }
+    return;
+  }
+
+  if (t === 'object') {
+    if (Array.isArray(value) || typeof value !== 'object') {
+      out.push({
+        path,
+        problem: `schema is type object but example is ${typeName(value)}`,
+        got: value,
+      });
+      return;
+    }
+    for (const [key, val] of Object.entries(value)) {
+      const propSchema = s.properties?.[key];
+      if (propSchema) {
+        checkValue(spec, propSchema, val, `${path}.${key}`, out, depth + 1);
+      } else if (
+        s.additionalProperties &&
+        typeof s.additionalProperties === 'object'
+      ) {
+        checkValue(
+          spec,
+          s.additionalProperties,
+          val,
+          `${path}.${key}`,
+          out,
+          depth + 1,
+        );
+      }
+    }
+    return;
+  }
+
+  const isScalarOk = SCALAR_CHECKS[t];
+  if (isScalarOk && !isScalarOk(value)) {
+    out.push({
+      path,
+      problem: `schema is type ${t} but example is ${typeName(value)}`,
+      got: value,
+    });
+  }
+}
+
+/**
+ * Walks a whole spec and returns every example that contradicts its schema.
+ *
+ * Both spellings are covered: a schema-level `example`, and OpenAPI 3.1's
+ * `examples` array on a schema. Media-type `examples` (keyed objects with a
+ * `value`) are checked against the sibling `schema` when one is present.
+ */
+export function findInvalidExamples(spec) {
+  const out = [];
+  const seen = new Set();
+
+  const walk = (node, path) => {
+    if (!node || typeof node !== 'object' || seen.has(node)) return;
+    seen.add(node);
+
+    if (
+      Object.prototype.hasOwnProperty.call(node, 'example') &&
+      (node.type || node.properties || node.items || node.$ref || node.allOf)
+    ) {
+      checkValue(spec, node, node.example, `${path}.example`, out);
+    }
+    if (
+      Array.isArray(node.examples) &&
+      (node.type || node.properties || node.items)
+    ) {
+      node.examples.forEach((ex, i) =>
+        checkValue(spec, node, ex, `${path}.examples[${i}]`, out),
+      );
+    }
+    // Media type object: { schema, examples: { name: { value } } }
+    if (node.schema && node.examples && !Array.isArray(node.examples)) {
+      for (const [name, ex] of Object.entries(node.examples)) {
+        if (ex && typeof ex === 'object' && 'value' in ex) {
+          checkValue(
+            spec,
+            node.schema,
+            ex.value,
+            `${path}.examples.${name}.value`,
+            out,
+          );
+        }
+      }
+    }
+
+    for (const [key, child] of Object.entries(node)) {
+      if (key === 'example' || key === 'examples') continue;
+      walk(child, `${path}.${key}`);
+    }
+  };
+
+  walk(spec, '$');
+  return out;
+}
+
+/** Formats violations for a test failure message or CI log. */
+export function formatViolations(violations) {
+  return violations
+    .map(
+      (v) =>
+        `  ${v.path}\n      ${v.problem}\n      got: ${JSON.stringify(v.got)?.slice(0, 160)}`,
+    )
+    .join('\n');
+}

--- a/tests/validate-examples.test.js
+++ b/tests/validate-examples.test.js
@@ -1,0 +1,365 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import yaml from 'js-yaml';
+import {
+  transform,
+  transformInvalidExamples,
+  transformCursorExamples,
+} from '../src/source-spec-transformer.js';
+import {
+  findInvalidExamples,
+  formatViolations,
+} from '../src/validate-examples.js';
+
+const SOURCE_DIR = 'source_specs';
+
+describe('example validity', () => {
+  const specFiles = fs
+    .readdirSync(SOURCE_DIR)
+    .filter((file) => file.endsWith('.yaml'));
+
+  it('finds the source spec files to check', () => {
+    expect(specFiles.length).toBeGreaterThan(0);
+  });
+
+  // Asserted on the transform's *output* rather than the committed source, because
+  // source_specs is overwritten by an automated sync many times a day: pinning the
+  // guarantee to the pipeline's result is what downstream consumers actually get.
+  it.each(specFiles)(
+    '%s produces no schema-contradicting examples after transform',
+    (file) => {
+      const content = fs.readFileSync(path.join(SOURCE_DIR, file), 'utf8');
+      const spec = yaml.load(transform(content, file));
+      const violations = findInvalidExamples(spec);
+
+      expect(
+        violations,
+        violations.length
+          ? `${file} has ${violations.length} example(s) that contradict their schema. ` +
+              `Anything that builds a request body from this spec will send an invalid value:\n${formatViolations(violations)}`
+          : undefined,
+      ).toEqual([]);
+    },
+  );
+});
+
+describe('findInvalidExamples', () => {
+  it('flags a scalar schema given an array example', () => {
+    const spec = {
+      components: { schemas: { S: { type: 'string', example: ['a'] } } },
+    };
+    expect(findInvalidExamples(spec)).toMatchObject([
+      { problem: 'schema is type string but example is array' },
+    ]);
+  });
+
+  it('flags an object-valued map given a bare string', () => {
+    const spec = {
+      components: {
+        schemas: {
+          Wrapper: {
+            type: 'object',
+            additionalProperties: { $ref: '#/components/schemas/Value' },
+            example: { field: 'oops' },
+          },
+          Value: { properties: { stringValue: { type: 'string' } } },
+        },
+      },
+    };
+    expect(findInvalidExamples(spec)).toMatchObject([
+      { problem: 'schema is type object but example is string' },
+    ]);
+  });
+
+  it('checks examples on allOf-composed schemas', () => {
+    const spec = {
+      components: {
+        schemas: {
+          Base: { type: 'object', properties: { count: { type: 'integer' } } },
+          Composed: {
+            allOf: [{ $ref: '#/components/schemas/Base' }],
+            example: { count: 'not-a-number' },
+          },
+        },
+      },
+    };
+    expect(findInvalidExamples(spec)).toMatchObject([
+      { problem: 'schema is type integer but example is string' },
+    ]);
+  });
+
+  it('stays silent on oneOf, where the intended branch is unknowable', () => {
+    const spec = {
+      components: {
+        schemas: {
+          S: {
+            oneOf: [{ type: 'string' }, { type: 'number' }],
+            example: ['neither'],
+          },
+        },
+      },
+    };
+    expect(findInvalidExamples(spec)).toEqual([]);
+  });
+
+  it('accepts a valid example', () => {
+    const spec = {
+      components: {
+        schemas: {
+          S: {
+            type: 'object',
+            properties: {
+              name: { type: 'string' },
+              tags: { type: 'array', items: { type: 'string' } },
+            },
+            example: { name: 'ok', tags: ['a', 'b'] },
+          },
+        },
+      },
+    };
+    expect(findInvalidExamples(spec)).toEqual([]);
+  });
+
+  it('flags a value outside an enum', () => {
+    const spec = {
+      components: {
+        schemas: {
+          S: { type: 'string', enum: ['A', 'B'], example: 'C' },
+        },
+      },
+    };
+    expect(findInvalidExamples(spec)).toMatchObject([
+      { problem: `value "C" is not one of the schema's enum values` },
+    ]);
+  });
+});
+
+describe('transformCursorExamples', () => {
+  it('gives a cursor property an empty-string example', () => {
+    const spec = {
+      components: {
+        schemas: {
+          Request: { properties: { cursor: { type: 'string' } } },
+        },
+      },
+    };
+    transformCursorExamples(spec);
+    expect(spec.components.schemas.Request.properties.cursor.example).toBe('');
+  });
+
+  it('reaches cursors nested below the top level', () => {
+    const spec = {
+      components: {
+        schemas: {
+          Outer: {
+            properties: {
+              inner: { properties: { cursor: { type: 'string' } } },
+            },
+          },
+        },
+      },
+    };
+    transformCursorExamples(spec);
+    expect(
+      spec.components.schemas.Outer.properties.inner.properties.cursor.example,
+    ).toBe('');
+  });
+
+  it('does not overwrite an example the spec already supplies', () => {
+    const spec = {
+      components: {
+        schemas: {
+          Request: {
+            properties: { cursor: { type: 'string', example: 'abc123' } },
+          },
+        },
+      },
+    };
+    transformCursorExamples(spec);
+    expect(spec.components.schemas.Request.properties.cursor.example).toBe(
+      'abc123',
+    );
+  });
+
+  it('leaves a non-string cursor alone', () => {
+    const spec = {
+      components: {
+        schemas: { Request: { properties: { cursor: { type: 'object' } } } },
+      },
+    };
+    transformCursorExamples(spec);
+    expect(
+      spec.components.schemas.Request.properties.cursor.example,
+    ).toBeUndefined();
+  });
+
+  it('gives every cursor in the real client spec an example', () => {
+    const content = fs.readFileSync(
+      path.join(SOURCE_DIR, 'client_rest.yaml'),
+      'utf8',
+    );
+    const spec = yaml.load(transform(content, 'client_rest.yaml'));
+    const missing = [];
+    const visit = (node, p, seen) => {
+      if (!node || typeof node !== 'object' || seen.has(node)) return;
+      seen.add(node);
+      const cursor = node.properties?.cursor;
+      if (cursor?.type === 'string' && cursor.example === undefined) {
+        missing.push(`${p}.properties.cursor`);
+      }
+      for (const [k, v] of Object.entries(node)) visit(v, `${p}.${k}`, seen);
+    };
+    visit(spec, '$', new WeakSet());
+    expect(missing).toEqual([]);
+  });
+});
+
+describe('transformInvalidExamples', () => {
+  it('wraps bare facet filter values as FacetFilterValue objects', () => {
+    const spec = {
+      components: {
+        schemas: {
+          Options: {
+            example: {
+              facetFilters: [{ fieldName: 'type', values: ['Spreadsheet'] }],
+            },
+          },
+        },
+      },
+    };
+    transformInvalidExamples(spec);
+    expect(
+      spec.components.schemas.Options.example.facetFilters[0].values,
+    ).toEqual([{ value: 'Spreadsheet', relationType: 'EQUALS' }]);
+  });
+
+  it('repairs rewrittenFacetFilters on response examples too', () => {
+    const spec = {
+      components: {
+        schemas: {
+          Response: {
+            example: {
+              rewrittenFacetFilters: [{ fieldName: 'type', values: ['Email'] }],
+            },
+          },
+        },
+      },
+    };
+    transformInvalidExamples(spec);
+    expect(
+      spec.components.schemas.Response.example.rewrittenFacetFilters[0].values,
+    ).toEqual([{ value: 'Email', relationType: 'EQUALS' }]);
+  });
+
+  it('collapses a listed status to the single string the schema declares', () => {
+    const spec = {
+      components: {
+        schemas: { DocumentMetadata: { example: { status: ['Done'] } } },
+      },
+    };
+    transformInvalidExamples(spec);
+    expect(spec.components.schemas.DocumentMetadata.example.status).toBe(
+      'Done',
+    );
+  });
+
+  it('wraps customData strings as CustomDataValue objects', () => {
+    const spec = {
+      components: {
+        schemas: {
+          DocumentMetadata: {
+            example: { customData: { someCustomField: 'someCustomValue' } },
+          },
+        },
+      },
+    };
+    transformInvalidExamples(spec);
+    expect(spec.components.schemas.DocumentMetadata.example.customData).toEqual(
+      {
+        someCustomField: { stringValue: 'someCustomValue' },
+      },
+    );
+  });
+
+  it('stringifies a numeric phone example', () => {
+    const spec = {
+      components: {
+        schemas: { PersonMetadata: { example: { phone: 6505551234 } } },
+      },
+    };
+    transformInvalidExamples(spec);
+    expect(spec.components.schemas.PersonMetadata.example.phone).toBe(
+      '6505551234',
+    );
+  });
+
+  it('reduces a list of candidate objectNames to one', () => {
+    const spec = {
+      components: {
+        schemas: {
+          objectName: { type: 'string', example: ['HR ticket', 'Email'] },
+        },
+      },
+    };
+    transformInvalidExamples(spec);
+    expect(spec.components.schemas.objectName.example).toBe('HR ticket');
+  });
+
+  it('wraps a bare suggestion array in its QuerySuggestionList', () => {
+    const spec = {
+      components: {
+        schemas: {
+          SearchResult: {
+            example: { mustIncludeSuggestions: [{ missingTerm: 'container' }] },
+          },
+        },
+      },
+    };
+    transformInvalidExamples(spec);
+    expect(
+      spec.components.schemas.SearchResult.example.mustIncludeSuggestions,
+    ).toEqual({ suggestions: [{ missingTerm: 'container' }] });
+  });
+
+  // The point of the guards: when the upstream spec is corrected at source, this
+  // pass must leave the now-valid examples alone rather than mangling them.
+  it('leaves already-valid examples untouched', () => {
+    const valid = {
+      components: {
+        schemas: {
+          DocumentMetadata: {
+            example: {
+              status: 'Done',
+              customData: {
+                someCustomField: { stringValue: 'someCustomValue' },
+              },
+            },
+          },
+          PersonMetadata: { example: { phone: '6505551234' } },
+          objectName: { type: 'string', example: 'HR ticket' },
+          Options: {
+            example: {
+              facetFilters: [
+                {
+                  fieldName: 'type',
+                  values: [{ value: 'Spreadsheet', relationType: 'EQUALS' }],
+                },
+              ],
+            },
+          },
+          SearchResult: {
+            example: {
+              mustIncludeSuggestions: {
+                suggestions: [{ missingTerm: 'container' }],
+              },
+            },
+          },
+        },
+      },
+    };
+    const before = JSON.parse(JSON.stringify(valid));
+    transformInvalidExamples(valid);
+    expect(valid).toEqual(before);
+  });
+});


### PR DESCRIPTION
## The problem

An `example` that disagrees with the schema it's attached to isn't cosmetic. Anything that builds a request body from these specs copies the value verbatim — the developer site's interactive "try it" panel prefills exactly these — so a type-invalid example ships a request the API rejects.

Concretely, on the Search page today, pasting a token and pressing Send **without editing anything** returns:

```
400 Error getting request body
```

Speakeasy's SDK samples hide this, because they pass examples through typed models that silently coerce whatever doesn't fit — the invalid string in `customData` becomes `models.CustomDataValue()`. So the same page can show a correct Python tab beside a request that fails.

## What was wrong

`client_rest.yaml` had **13 such examples in 7 places**. `admin_rest`, `indexing` and `platform` were already clean.

| Location | Count | Problem |
|---|---|---|
| `SearchRequestOptions.example.facetFilters[].values[]` | 4 | string, schema wants `FacetFilterValue` |
| `SearchResponse.example.rewrittenFacetFilters[].values[]` | 4 | same |
| `DocumentMetadata.example.status` | 1 | array, schema says `string` |
| `DocumentMetadata.example.customData.someCustomField` | 1 | string, schema wants `CustomDataValue` |
| `PersonMetadata.example.phone` | 1 | number, schema says `string` |
| `objectName.example` | 1 | array, schema says `string` |
| `SearchResult.example.mustIncludeSuggestions` | 1 | bare array, schema wants `QuerySuggestionList` |

Several of these contradict a *correct* example living right beside them — `FacetFilter` carries a valid `values: [{value, relationType}]` example while `SearchRequestOptions` overrides it with bare strings.

## The changes

**Repairs live in the transformer, not in `source_specs`** — that directory is replaced by the automated sync many times a day (8 times on the day I wrote this), so an edit there would be gone within hours. Every repair is guarded on the wrong shape, so once the spec is corrected at source each one becomes a no-op rather than clobbering a now-valid example. There's a test for exactly that.

**Pagination cursors get a separate pass.** They carry no example at all, so a renderer synthesizes the placeholder `"string"`, and the API answers **500** to a malformed cursor — turning a reader's first request into a server error. An empty cursor means "start from the beginning": the only value that's both type-correct and semantically valid, since any literal token we invented would be expired or forged.

> Worth fixing at the API too — a malformed cursor is a client error and should be 400, not 500 — but the docs would still be sending a failing request without this, so the example is needed either way.

**`validate-examples.js` is the general net.** It walks a spec and reports every example contradicting its schema; the test asserts the transform's *output* is clean, so any new mismatch fails CI. Two details mattered:

- it flattens `allOf` rather than skipping it — without that it missed 4 of the 13, since response schemas here are `allOf` + `example`
- it infers a missing `type` from `properties`/`items` — without that it missed 2 more, since `FacetFilterValue` and `CustomDataValue` declare `properties` but no `type: object`

It deliberately stays silent on `oneOf`/`anyOf`, where the intended shape is genuinely unknowable. A check that cries wolf on a valid spec gets switched off.

`pnpm run lint` and `pnpm test` already run in CI, so no workflow change is needed.

## Verification

**End to end against a real instance.** With both passes applied and the docs regenerated, the Search page's unmodified default body returns **200 with real results** where it previously returned 400:

```
2026 Glean Holiday/Week-off Calendar - US
Glean Employee Handbook (Updated 07-17-26)
Glean India - Leave Policy
```

**Negative control.** Disabling the repair pass fails the new test with all 13 violations named — the gate isn't vacuous.

90 tests pass across the four suites that run locally; prettier clean.

## One thing I couldn't run

`tests/check-client-releases.test.js` wouldn't execute locally because **this repo can't `pnpm install` behind Socket Firewall** — its own `js-yaml@4.3.0` and `vite@7.3.1` are blocked:

```
BLOCKED: js-yaml@4.3.0
  [HIGH] cve: Quadratic CPU consumption in !!omap resolution (3.x and 4.x)
         CVE-2026-59870 fix not backported (GHSA-5p4m-2wfm-xmqj)
BLOCKED: vite@7.3.1
```

I confirmed that file fails identically on a pristine `main`, so it's unrelated to this change — but it does mean the repo is currently un-installable for anyone behind the firewall. `js-yaml@4.3.1` and `5.2.3` are both allowed (note `5.2.1` is *not* — it has its own HIGH DoS advisory). Worth a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)